### PR TITLE
40 qualified dividends ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2024.4] - 2025-03-08
+### Added
+- Fix and add test coverage for qualified dividends bug. Thanks @nanoticity for the report.
+
 ## [2024.3] - 2025-03-08
 ### Added
 - Updated OTS 2024 tax-year release from 22.01 to 22.05

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ license = {file = "LICENSE.txt", content-type = "text/plain"}
 name = "tenforty"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">= 3.10"
-version = "2024.3"
+version = "2024.4"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
Address bug report, where large positive qualified dividends apparently result in no tax.

The issue is that, in a scenario where someone had say 300k in qualified dividends, and zero other non-qualified dividends, it would get reported on the 1099-DIV as 300k qualified dividends and and 300K "total ordinary dividends". Qualified dividends are a subset of ordinary dividends.

One wouldn't see this if they were copying over numbers from a prepared 1040, because the preparer/software would have brought over the numbers from the 1099-DIV correctly. But in the case where you're just using tenforty to see how tax varies as a function of qualified dividends, this wouldn't happen. So the fix is to ensure that ordinary dividends is at least as much as qualified dividends.

Adds a new test, that fails before the fix, and passes with it in.

Thanks @nanoticity for the report.