### PR TITLE
72 dividend arguments for evaluate returns are singular

### DIFF
--- a/src/tenforty/core.py
+++ b/src/tenforty/core.py
@@ -390,8 +390,8 @@ def evaluate_returns(
     standard_or_itemized: list[str] | str = "Standard",
     w2_income: list[float] | float = 0.0,
     taxable_interest: list[float] | float = 0.0,
-    qualified_dividend: list[float] | float = 0.0,
-    ordinary_dividend: list[float] | float = 0.0,
+    qualified_dividends: list[float] | float = 0.0,
+    ordinary_dividends: list[float] | float = 0.0,
     short_term_capital_gains: list[float] | float = 0.0,
     long_term_capital_gains: list[float] | float = 0.0,
     schedule_1_income: list[float] | float = 0.0,
@@ -423,8 +423,8 @@ def evaluate_returns(
     standard_or_itemized = ensure_list(standard_or_itemized)
     w2_incomes = ensure_list(w2_income)
     taxable_interests = ensure_list(taxable_interest)
-    qualified_dividends = ensure_list(qualified_dividend)
-    ordinary_dividends = ensure_list(ordinary_dividend)
+    qualified_dividends = ensure_list(qualified_dividends)
+    ordinary_dividends = ensure_list(ordinary_dividends)
     short_term_capital_gains = ensure_list(short_term_capital_gains)
     long_term_capital_gains = ensure_list(long_term_capital_gains)
     schedule_1_incomes = ensure_list(schedule_1_income)

--- a/tests/hypothesis_test.py
+++ b/tests/hypothesis_test.py
@@ -226,7 +226,7 @@ def test_qualified_dividends_properly_taxed(
     ), "Setting ordinary_dividends explicitly should not change the tax result"
 
     # For very high income, we should definitely see some tax
-    if qualified_dividends > 100000:
+    if qualified_dividends > 200000:
         assert result.federal_total_tax > 0, (
             f"Qualified dividends of {qualified_dividends} should generate tax"
         )


### PR DESCRIPTION
There was a typo in the `evaluate_returns()` function:

- "qualified_dividend" should have been "qualified_dividends"
- "ordinary_dividend" should have been "ordinary_dividends"


(Also patched a sometimes-failing hypothesis test.)