### PR TITLE
chore(pre-commit): skip cargo-fmt on pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+ci:
+  skip: [cargo-fmt]
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0


### PR DESCRIPTION
## Summary
- pre-commit.ci's sandbox has no Rust toolchain, so the local `cargo-fmt` hook fails with `Executable cargo not found` on every PR
- Add `ci.skip: [cargo-fmt]` so pre-commit.ci bypasses that hook; `cargo-fmt` still runs locally via `pre-commit install`
- `cargo-clippy` is already `stages: [manual]` so it was never running on CI

## Test plan
- [x] Local `pre-commit run --all-files` still exercises the standard hooks
- [ ] After merge, pre-commit.ci runs on the next tenforty PR should show `cargo-fmt` skipped and the overall check green