### PR TITLE
chore(pre-commit): pin typos rev to v1.9.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     args: [--fix, --exit-non-zero-on-fix]
   - id: ruff-format
 - repo: https://github.com/crate-ci/typos
-  rev: v1
+  rev: v1.9.0
   hooks:
   - id: typos
     # Only *check* spelling in prose; avoid rewriting identifiers in code.


### PR DESCRIPTION
## Summary
- Replace the mutable `rev: v1` moving tag with a concrete `v1.9.0` pin
- The self-hosted `update-pre-commit-hooks.yaml` workflow already passes `--skip https://github.com/crate-ci/typos` to `pre-commit autoupdate`, so this pin won't be clobbered on the weekly run — bumps will be manual
- Eliminates the persistent "Mutable references are never updated after first install" warning on every pre-commit invocation

## Context
Prior attempts to pin typos were overwritten by pre-commit.ci's autoupdate (despite `autoupdate_exclude`). Now that pre-commit.ci is uninstalled from the repo/account, the pin will stick.

## Test plan
- [x] pre-commit still runs cleanly locally
- [ ] Verify next weekly `update-pre-commit-hooks` workflow run leaves typos rev alone