### PR TITLE
fix(ci): replace removed --skip flag in pre-commit autoupdate

### DIFF
--- a/.github/workflows/update-pre-commit-hooks.yaml
+++ b/.github/workflows/update-pre-commit-hooks.yaml
@@ -34,9 +34,14 @@ jobs:
         # Store original config for comparison
         cp .pre-commit-config.yaml .pre-commit-config.yaml.bak
 
-        # Update hooks (skip typos — uses moving v1 tag that reverts semver pin)
+        # Save typos rev before update (pinned — moving v1 tag reverts semver pin)
+        TYPOS_REV=$(awk '/crate-ci\/typos/{getline; print $2}' .pre-commit-config.yaml)
+
         uv sync
-        uv run pre-commit autoupdate --skip https://github.com/crate-ci/typos
+        uv run pre-commit autoupdate
+
+        # Restore pinned typos rev
+        sed -i "/crate-ci\/typos/{n;s/rev: .*/rev: $TYPOS_REV/}" .pre-commit-config.yaml
 
         # Check if there are any changes
         if ! diff -q .pre-commit-config.yaml .pre-commit-config.yaml.bak > /dev/null; then


### PR DESCRIPTION
## Summary
- `pre-commit autoupdate --skip` was removed in a recent pre-commit release, breaking the weekly hook update workflow since Apr 19 (3 consecutive failures)
- Replace with save/restore of the typos rev via awk + sed

## Test plan
- [ ] Trigger workflow manually: `gh workflow run "Update Pre-commit Hooks" --repo mmacpherson/tenforty`
- [ ] Verify PR is created with updated hooks (typos rev preserved at v1.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)