### PR TITLE
fix(pre-commit): bump typos from v1.9.0 to v1.46.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     args: [--fix, --exit-non-zero-on-fix]
   - id: ruff-format
 - repo: https://github.com/crate-ci/typos
-  rev: v1.9.0
+  rev: v1.46.0
   hooks:
   - id: typos
     # Only *check* spelling in prose; avoid rewriting identifiers in code.


### PR DESCRIPTION
## Summary
- The typos pin from #254 chose v1.9.0 (June 2022), which predates the `--force-exclude` flag used in our hook config
- This caused the pre-commit update workflow's validation step to fail with exit code 64 every week
- Bump to v1.46.0 (current) — tested locally, passes clean on `--all-files`

## Test plan
- [x] `pre-commit run typos --all-files` passes locally
- [ ] Re-trigger update workflow after merge to confirm end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)