### PR TITLE
release: v2025.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [2025.10] - 2026-05-03
+### Changed
+- Accelerated `parse_ots_return` for faster bulk estimate calculation
+  (thanks @zacswider, #257)
+
+### Fixed
+- Pre-commit update workflow: replaced removed `--skip` flag, bumped typos
+  to v1.46.0, dropped redundant `--force-exclude` arg (#258, #259, #260, #261)
+
 ## [2025.9] - 2026-03-23
 ### Changed
 - Updated OTS 2025 tax year release from 23.05 to 23.06

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ license = {file = "LICENSE.txt", content-type = "text/plain"}
 name = "tenforty"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">= 3.10"
-version = "2025.9"
+version = "2025.10"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary
- Bump version to 2025.10
- Changelog: accelerated bulk estimate calculation (@zacswider, #257), CI/pre-commit fixes (#258–#261)

🤖 Generated with [Claude Code](https://claude.com/claude-code)