### PR TITLE
fix: AZ Widow(er) standard deduction out-of-bounds read

### DIFF
--- a/src/tenforty/otslib/ots_amalgamation.cpp
+++ b/src/tenforty/otslib/ots_amalgamation.cpp
@@ -69916,7 +69916,7 @@ double getAZStdDedAmt()
 			{ 27700.0 },  /* Married, filing jointly. */
 			{ 13850.0 },  /* Married, filing separate. */
 			{ 20800.0 },  /* Head of Household. */
-			{ 27700.0 }   /* Widow(er) - same as MFJ. */
+			{ 20800.0 }   /* Widow(er) - AZ maps QW to HoH. */
 			     };
 	return azStdDedAmt[status][0];
 }
@@ -77099,7 +77099,7 @@ double getAZStdDedAmt()
 			{ 29200.0 },  /* Married, filing jointly. */
 			{ 14600.0 },  /* Married, filing separate. */
 			{ 21900.0 },  /* Head of Household. */
-			{ 29200.0 }   /* Widow(er) - same as MFJ. */
+			{ 21900.0 }   /* Widow(er) - AZ maps QW to HoH. */
 			     };
 	return azStdDedAmt[status][0];
 }
@@ -101993,7 +101993,7 @@ double getAZStdDedAmt()
 			{ 31500.0 },  /* Married, filing jointly. */
 			{ 15750.0 },  /* Married, filing separate. */
 			{ 23625.0 },  /* Head of Household. */
-			{ 31500.0 }   /* Widow(er) - same as MFJ. */
+			{ 23625.0 }   /* Widow(er) - AZ maps QW to HoH. */
 			     };
 	return azStdDedAmt[status][0];
 }

--- a/src/tenforty/otslib/ots_amalgamation.cpp
+++ b/src/tenforty/otslib/ots_amalgamation.cpp
@@ -69910,12 +69910,13 @@ float thisversion = 2.01;
 
 double getAZStdDedAmt()
 {
-	double azStdDedAmt[5][1]={				/* Updated for 2023. */
+	double azStdDedAmt[6][1]={				/* Updated for 2023. */
 			{0.0},
 			{ 13850.0 },  /* Single */
 			{ 27700.0 },  /* Married, filing jointly. */
 			{ 13850.0 },  /* Married, filing separate. */
-			{ 20800.0 }   /* Head of Household. */
+			{ 20800.0 },  /* Head of Household. */
+			{ 27700.0 }   /* Widow(er) - same as MFJ. */
 			     };
 	return azStdDedAmt[status][0];
 }
@@ -77092,12 +77093,13 @@ float thisversion = 3.01;
 
 double getAZStdDedAmt()
 {
-	double azStdDedAmt[5][1]={				/* Updated for 2024. */
+	double azStdDedAmt[6][1]={				/* Updated for 2024. */
 			{0.0},
 			{ 14600.0 },  /* Single */
 			{ 29200.0 },  /* Married, filing jointly. */
 			{ 14600.0 },  /* Married, filing separate. */
-			{ 21900.0 }   /* Head of Household. */
+			{ 21900.0 },  /* Head of Household. */
+			{ 29200.0 }   /* Widow(er) - same as MFJ. */
 			     };
 	return azStdDedAmt[status][0];
 }
@@ -101985,12 +101987,13 @@ float thisversion = 4.00;
 
 double getAZStdDedAmt()
 {
-	double azStdDedAmt[5][1]={				/* Updated for 2025. */
+	double azStdDedAmt[6][1]={				/* Updated for 2025. */
 			{0.0},
 			{ 15750.0 },  /* Single */
 			{ 31500.0 },  /* Married, filing jointly. */
 			{ 15750.0 },  /* Married, filing separate. */
-			{ 23625.0 }   /* Head of Household. */
+			{ 23625.0 },  /* Head of Household. */
+			{ 31500.0 }   /* Widow(er) - same as MFJ. */
 			     };
 	return azStdDedAmt[status][0];
 }

--- a/tests/hypothesis_test.py
+++ b/tests/hypothesis_test.py
@@ -332,21 +332,26 @@ def test_evaluate_return_properties(
 
 
 def test_az_widow_standard_deduction():
-    """Regression: AZ Widow(er) used out-of-bounds array for standard deduction."""
+    """Regression: AZ Widow(er) used out-of-bounds array for standard deduction.
+
+    AZ Form 140 has no Widow(er) box; qualifying widow(er) files as
+    Head of Household and gets the HoH standard deduction.
+    """
     result = tenforty.evaluate_return(
         year=2024,
         state="AZ",
         filing_status="Widow(er)",
         w2_income=50000.0,
     )
-    mfj_result = tenforty.evaluate_return(
+    hoh_result = tenforty.evaluate_return(
         year=2024,
         state="AZ",
-        filing_status="Married/Joint",
+        filing_status="Head_of_House",
         w2_income=50000.0,
+        num_dependents=1,
     )
-    assert result.state_taxable_income == mfj_result.state_taxable_income
-    assert result.state_total_tax == mfj_result.state_total_tax
+    assert result.state_taxable_income == hoh_result.state_taxable_income
+    assert result.state_total_tax == hoh_result.state_total_tax
     assert result.state_taxable_income > 0
 
 

--- a/tests/hypothesis_test.py
+++ b/tests/hypothesis_test.py
@@ -331,6 +331,25 @@ def test_evaluate_return_properties(
     #     ), "Federal total tax should not exceed taxable income"
 
 
+def test_az_widow_standard_deduction():
+    """Regression: AZ Widow(er) used out-of-bounds array for standard deduction."""
+    result = tenforty.evaluate_return(
+        year=2024,
+        state="AZ",
+        filing_status="Widow(er)",
+        w2_income=50000.0,
+    )
+    mfj_result = tenforty.evaluate_return(
+        year=2024,
+        state="AZ",
+        filing_status="Married/Joint",
+        w2_income=50000.0,
+    )
+    assert result.state_taxable_income == mfj_result.state_taxable_income
+    assert result.state_total_tax == mfj_result.state_total_tax
+    assert result.state_taxable_income > 0
+
+
 @example(year=2024, state="CA", filing_status="Single", qualified_dividends=50000.0)
 @example(
     year=2024, state=None, filing_status="Married/Joint", qualified_dividends=100000.0


### PR DESCRIPTION
## Summary
- Fix out-of-bounds array access in `getAZStdDedAmt()` for Arizona state tax — `WIDOW=5` indexed past the 5-element (0–4) standard deduction array, reading uninitialized memory
- Add Widow(er) entry using the **Head of Household** standard deduction amount, since AZ Form 140 has no Widow(er) box — qualifying widow(er) files as HoH per AZ DOR instructions
- Fixed for all three tax years (2023, 2024, 2025)
- Add regression test confirming AZ Widow(er) matches HoH standard deduction

## Context
Surfaced as a hypothesis test failure in CI on PR #267 (Python 3.14 happened to generate the AZ/Widow(er) counterexample). The bug exists on all Python versions — the out-of-bounds read returns whatever happens to be in memory, which was garbage (`4.85e+130`) on the CI runner.

This is an **upstream OTS bug** in `taxsolve_AZ_140_20{23,24,25}.c` — the amalgamation copies it faithfully. The fix patches it in `ots_amalgamation.cpp` directly.

## Test plan
- [x] New `test_az_widow_standard_deduction` regression test passes (verifies Widow(er) matches HoH)
- [x] Full hypothesis suite passes (657 passed, 0 failed)
- [x] Verified AZ standard deduction amounts against AZ DOR published values

🤖 Generated with [Claude Code](https://claude.com/claude-code)