### PR TITLE
fix: fill Schedule SE line 8a with the filer's own W-2 social security wages

### DIFF
--- a/src/tenforty/mappings.py
+++ b/src/tenforty/mappings.py
@@ -29,6 +29,13 @@ _SUBORDINATE_NODES: dict[str, list[str]] = {
     "w2_income": [
         "us_form_8959_L1_medicare_wages",
     ],
+    # The filer's OWN social security wages, which fill the wage base before
+    # self-employment earnings do. Derived from w2_income and the filing status rather
+    # than taken raw, because Schedule SE is a per-person form while w2_income is a
+    # household aggregate. See TaxReturnInput.schedule_se_ss_wages.
+    "schedule_se_ss_wages": [
+        "us_schedule_se_L5_w2_ss_wages",
+    ],
     "self_employment_income": [
         "us_schedule_se_L2_business_profit",
         "us_form_8995_L1_qbi_business_1",

--- a/src/tenforty/models.py
+++ b/src/tenforty/models.py
@@ -10,7 +10,7 @@ from collections.abc import Callable
 from enum import Enum
 from functools import partial
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, computed_field, model_validator
 
 from . import _ots_form_models
 
@@ -298,6 +298,31 @@ class TaxReturnInput(BaseModel):
     state_adjustment: float = 0.0
     incentive_stock_option_gains: float = 0.0
     dependent_exemptions: float = 0.0
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def schedule_se_ss_wages(self) -> float:
+        """The filer's own W-2 social security wages, for Schedule SE line 8a.
+
+        Line 8a feeds line 9 — what is LEFT of the social security wage base ($168,600
+        in 2024) once the filer's own wages are counted — and line 9 caps the 12.4% OASDI
+        charge on line 10. Leaving 8a empty charges that 12.4% on self-employment earnings
+        the filer's wages have already carried past the base.
+
+        `w2_income` is a HOUSEHOLD aggregate, but Schedule SE is a per-person form. For
+        Married/Joint we cannot tell whose wages are whose, so this stays zero and the full
+        OASDI charge stands — the conservative reading, and the behaviour that
+        `test_se_tax_mfj_w2_above_ss_base` locks in. Every other filing status has exactly
+        one person, so the aggregate simply IS that person's wages.
+
+        Zero when there is no self-employment income, so that this never causes Schedule SE
+        to be resolved or evaluated for a return that would not otherwise have filed one.
+        """
+        if not self.self_employment_income:
+            return 0.0
+        if self.filing_status == OTSFilingStatus.MARRIED_JOINT:
+            return 0.0
+        return float(self.w2_income)
 
     @model_validator(mode="after")
     def ensure_ordinary_includes_qualified(self) -> "TaxReturnInput":
@@ -1150,7 +1175,12 @@ _SUBORDINATE_FORM_CONFIG = [
         "year": 2024,
         "form_id": "US_1040_Sched_SE",
         "phase": 1,
-        "input_map": {"self_employment_income": "L2"},
+        "input_map": {
+            "self_employment_income": "L2",
+            # Line 8a: the filer's own social security wages, which fill the wage base
+            # before self-employment earnings do. See TaxReturnInput.schedule_se_ss_wages.
+            "schedule_se_ss_wages": "L8a",
+        },
         "export_map": {"L12": "S2_4", "L13": "S1_15"},
         "output_map": {"L12": "se_tax"},
     },
@@ -1194,7 +1224,12 @@ _SUBORDINATE_FORM_CONFIG = [
         "year": 2025,
         "form_id": "US_1040_Sched_SE",
         "phase": 1,
-        "input_map": {"self_employment_income": "L2"},
+        "input_map": {
+            "self_employment_income": "L2",
+            # Line 8a: the filer's own social security wages, which fill the wage base
+            # before self-employment earnings do. See TaxReturnInput.schedule_se_ss_wages.
+            "schedule_se_ss_wages": "L8a",
+        },
         "export_map": {"L12": "S2_4", "L13": "S1_15"},
         "output_map": {"L12": "se_tax"},
     },

--- a/tests/subordinate_forms_test.py
+++ b/tests/subordinate_forms_test.py
@@ -155,6 +155,134 @@ def test_se_tax_single_w2_and_se():
     )
 
 
+# === Schedule SE line 8a: the filer's own W-2 social security wages ===
+#
+# Line 8a carries the filer's social security wages; line 9 is what remains of the
+# $168,600 (2024) wage base after them; line 10 charges 12.4% on the LESSER of that
+# remainder and net SE earnings. Omitting line 8a charges the 12.4% OASDI rate on
+# self-employment earnings the wage base has already absorbed.
+#
+# For Single there is one person, so w2_income unambiguously IS that person's wages.
+# For Married/Joint, w2_income is a household aggregate and Schedule SE is a per-person
+# form, so line 8a stays at zero -- see test_se_tax_mfj_w2_above_ss_base above.
+
+SE_60K_NET = 60_000 * 0.9235  # Schedule SE line 6: net earnings = 55,410
+
+
+def test_se_tax_single_no_w2_taxes_all_se_earnings():
+    """With no wages the whole wage base is free, so all net SE earnings bear the 12.4%."""
+    r = evaluate_return(
+        year=2024, filing_status="Single", self_employment_income=60_000
+    )
+    # line 9 = 168,600 - 0 = 168,600 > 55,410, so line 10 = 55,410 * 0.124 = 6,870.84
+    # line 11 = 55,410 * 0.029 = 1,606.89
+    expected = SE_60K_NET * 0.124 + SE_60K_NET * 0.029
+    assert r.federal_se_tax == pytest.approx(expected, abs=0.01)
+
+
+def test_se_tax_single_w2_partially_consumes_ss_wage_base():
+    """Wages below the base leave a remainder; only that remainder bears the 12.4%."""
+    r = evaluate_return(
+        year=2024,
+        filing_status="Single",
+        w2_income=150_000,
+        self_employment_income=60_000,
+    )
+    # line 9 = 168,600 - 150,000 = 18,600, which is less than net earnings of 55,410,
+    # so line 10 = 18,600 * 0.124 = 2,306.40 (not 55,410 * 0.124 = 6,870.84)
+    expected = 18_600 * 0.124 + SE_60K_NET * 0.029
+    assert r.federal_se_tax == pytest.approx(expected, abs=0.01)
+
+
+def test_se_tax_single_w2_fully_consumes_ss_wage_base():
+    """Wages at the base leave nothing; only the 2.9% Medicare portion remains."""
+    r = evaluate_return(
+        year=2024,
+        filing_status="Single",
+        w2_income=168_600,
+        self_employment_income=60_000,
+    )
+    # line 9 = 168,600 - 168,600 = 0, so line 10 = 0.00 and only line 11 survives.
+    expected = SE_60K_NET * 0.029
+    assert r.federal_se_tax == pytest.approx(expected, abs=0.01)
+
+
+def test_se_tax_single_is_monotone_nonincreasing_in_w2():
+    """More of the filer's own wages can only shrink the OASDI slice, never grow it."""
+    taxes = [
+        evaluate_return(
+            year=2024,
+            filing_status="Single",
+            w2_income=w2,
+            self_employment_income=60_000,
+        ).federal_se_tax
+        for w2 in (0, 50_000, 120_000, 150_000, 168_600, 200_000)
+    ]
+    assert taxes == sorted(taxes, reverse=True)
+    assert taxes[0] > taxes[-1], "SE tax must fall once wages start filling the base"
+
+
+def test_se_tax_mfj_w2_aggregate_does_not_fill_one_spouses_wage_base():
+    """MFJ w2_income is a HOUSEHOLD aggregate and must not fill one spouse's line 8a.
+
+    Schedule SE is filed per person. Until the input model can attribute wages to a
+    spouse, Married/Joint leaves line 8a at zero. This guards the fix for the single-earner
+    statuses from being generalized into the regression that test_se_tax_mfj_w2_above_ss_base
+    documents.
+    """
+    r = evaluate_return(
+        year=2024,
+        filing_status="Married/Joint",
+        w2_income=181_408,
+        self_employment_income=53_272,
+    )
+    net = 53_272 * 0.9235
+    expected = net * 0.124 + net * 0.029  # full OASDI: the base is untouched
+    assert r.federal_se_tax == pytest.approx(expected, abs=0.01)
+
+
+@pytest.mark.xfail(
+    reason=(
+        "The graph batch path does not apply the line 8a derivation. evaluate_return() "
+        "builds a TaxReturnInput, so it picks up the computed schedule_se_ss_wages field; "
+        "GraphBackend.evaluate_batch() takes raw input columns instead, and in cross mode "
+        "the filing-status axis is expanded inside the Rust graph, so a status-dependent "
+        "column cannot be derived on the Python side. The fix belongs in the graph spec, "
+        "which should compute the filer's own SS wages itself."
+    ),
+    strict=True,
+)
+@skip_if_graph_unavailable
+def test_se_tax_graph_batch_matches_single():
+    """Batch and single evaluation must agree on SE tax."""
+    from tenforty import evaluate_returns
+
+    kwargs = dict(
+        year=2024,
+        filing_status="Single",
+        w2_income=168_600,
+        self_employment_income=60_000,
+    )
+    single = evaluate_return(backend="graph", **kwargs).federal_se_tax
+    batch = evaluate_returns(backend="graph", **{k: [v] for k, v in kwargs.items()})
+    assert batch["federal_se_tax"][0] == pytest.approx(single, abs=0.01)
+
+
+def test_se_tax_single_w2_consumes_wage_base_in_2025_too():
+    """The 2025 config carries the same line 8a mapping."""
+    high = evaluate_return(
+        year=2025,
+        filing_status="Single",
+        w2_income=200_000,
+        self_employment_income=60_000,
+    ).federal_se_tax
+    none = evaluate_return(
+        year=2025, filing_status="Single", self_employment_income=60_000
+    ).federal_se_tax
+    assert high < none, "2025 wages above the base must still zero the OASDI portion"
+    assert high == pytest.approx(SE_60K_NET * 0.029, abs=0.01)
+
+
 # === NIIT Tests ===
 
 


### PR DESCRIPTION
Fixes the Schedule SE half of #278.

Schedule SE line 8a carries the filer's own W-2 social security wages. It feeds line 9 — what is *left* of the $168,600 wage base after them — and line 9 caps the 12.4% OASDI charge on line 10. tenforty never filled 8a, so line 9 was always the full wage base and the 12.4% always applied in full. SE tax came out invariant to wages: a `Single` filer with $168,600 of wages and $60,000 of Schedule C profit was overcharged **$6,870.84**.

OTS itself is correct — its Schedule SE solver reads `L8a` and applies it exactly, and the graph form declares an `L5_w2_ss_wages` input node. Both engines have the field; neither wrapper filled it. PSL Tax-Calculator independently agrees with the corrected figures to the cent.

## Why it's derived rather than mapped

`test_se_tax_mfj_w2_above_ss_base` documents that a previous version *did* map `w2_income` straight to Schedule SE and it was reverted, because `w2_income` is a **household aggregate** while Schedule SE is a **per-person** form. That's right, and mapping it raw would just re-break MFJ.

But `Single`, `Head_of_House`, `Married/Sep` and `Widow(er)` have exactly one person — there's no ambiguity there, and the aggregate simply *is* that person's wages. So the value is derived on `TaxReturnInput` instead:

- **Married/Joint contributes nothing** — the conservative reading, and *exactly today's behaviour*. Your MFJ regression test is untouched and still passes.
- Every other status passes its wages through.
- **Zero whenever there's no self-employment income**, so it can never cause Schedule SE to be resolved or evaluated for a return that wouldn't otherwise have filed one. The set of forms that fire is provably unchanged.

Being a `computed_field`, it flows to **both** backends through the paths that already build a `TaxReturnInput` — so no changes to `core.py`, `graph.py`, or any evaluation machinery. The diff is one computed property plus two mapping entries.

## Tests

Six new tests in `subordinate_forms_test.py`: the band untouched, partially consumed, and fully consumed; monotonicity in wages; 2025; and a guard that MFJ still does *not* fill 8a, so this can't be "generalized" back into the regression you already fixed.

```
663 passed, 10 skipped, 17 xfailed     (657 passed, 16 xfailed before)
ruff check + format clean
```

## What this does not fix

Two things, both called out in #278 and neither hidden:

1. **The graph batch path.** `GraphBackend.evaluate_batch` takes raw input columns rather than a `TaxReturnInput`, and in cross mode the filing-status axis is expanded inside the Rust graph — so a status-dependent column can't be derived on the Python side. `evaluate_returns(backend="graph")` still returns the old figure while `evaluate_return(backend="graph")` returns the corrected one. That derivation probably belongs in the graph spec itself, and I didn't want to touch the DSL uninvited. **Added as a strict `xfail`** (`test_se_tax_graph_batch_matches_single`) so it's tracked rather than silent — it'll flip to a pass the moment the graph learns to compute it.

2. **§199A / 1040 line 13**, the second half of #278. Untouched here.

The complete fix for MFJ is a per-spouse wage split (as Tax-Calculator does with `e00200p`/`e00200s`), which is an API addition and therefore your call. Happy to follow up with it, and with either of the above, if you want them.

## Disclosure

I'm Claude (an AI assistant, Anthropic's Opus 4.8), working at the direction of my human operator, who reviewed and authorized this PR. The reasoning and the patch are mine; every figure was produced by running the code. Please review it as adversarially as you'd review any patch from a stranger — and more so, given where it came from.
