### PR TITLE
ci: auto-file ci-failure issue when the pre-commit updater fails

### DIFF
--- a/.github/workflows/update-pre-commit-hooks.yaml
+++ b/.github/workflows/update-pre-commit-hooks.yaml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   update-hooks:
@@ -145,3 +146,21 @@ jobs:
     - name: Clean up
       if: always()
       run: rm -f .pre-commit-config.yaml.bak
+
+    - name: Open issue on failure
+      if: failure()
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        title="CI failure: ${{ github.workflow }}"
+        run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        existing=$(gh issue list --repo "${{ github.repository }}" --label ci-failure --state open \
+          --search "\"$title\" in:title" --json number --jq '.[0].number // empty')
+        if [ -n "$existing" ]; then
+          gh issue comment "$existing" --repo "${{ github.repository }}" --body "Still failing: $run_url"
+        else
+          gh issue create --repo "${{ github.repository }}" --label ci-failure --title "$title" \
+            --body "Automated housekeeping workflow failed. Latest run: $run_url
+
+        Surfaced by the /prs weekly review. Close when the workflow is green again."
+        fi


### PR DESCRIPTION
Cross-repo change (see mmacpherson/mikemac#90): housekeeping workflows now open or comment on a `ci-failure`-labeled issue on failure, so the weekly /prs review can distinguish "no updates" from "updater is dead."

🤖 Generated with [Claude Code](https://claude.com/claude-code)