### PR TITLE
test: adopt Tax-Calculator as independent federal oracle; burn known defects into the suite

### DIFF
--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -1,0 +1,146 @@
+# Differential Audit: tenforty vs PSL Tax-Calculator
+
+Branch: `audit/taxcalc-differential`, cut from main as of 2026-07-21,
+immediately before PR #279 merged.
+Update 2026-07-21: PR #279 has since merged, fixing F1/F2; the remaining
+findings are burned into the suite as strict xfails in
+`tests/known_defects_test.py`.
+Oracle: [Tax-Calculator](https://github.com/PSLmodels/Tax-Calculator) (`taxcalc` 6.7.2, CC0),
+federal only, tax year 2024.
+
+## Method
+
+363 boundary-focused federal cases (SS wage base, NIIT/additional-Medicare
+thresholds, QBI interactions, capital-gain mixes, dividend subsets, forced
+itemization) across all five filing statuses, evaluated on three engines:
+tenforty OTS, tenforty graph, and taxcalc. Seven quantities compared per case:
+AGI, taxable income, SE tax, NIIT, additional Medicare tax, AMT, total tax.
+
+- Tolerances: $2, except $15 for total tax (OTS uses the 1040 tax tables,
+  which quantize taxable income in $50 steps; taxcalc uses exact formulas).
+- MFJ wage attribution: taxcalc requires per-spouse wages; tenforty's
+  `w2_income` is a household aggregate. taxcalc was run with wages attributed
+  to the self-employed primary and separately to the other spouse; a tenforty
+  MFJ value is flagged only if it falls outside both bounds.
+- Out of scope: states (taxcalc has none), dependents/credits, ISO/AMT
+  preference items, rental and schedule-1 income, batch evaluation paths.
+
+Harness: `audit_harness.py` + `analyze*.py` (session scratchpad; candidates
+for `scripts/` promotion).
+
+## Findings
+
+### F1. Schedule SE line 8a never filled — issue #278 recapitulated blind
+
+Flagged exactly 22 cases in each of the four single-person statuses; zero
+flags at `w2=0`; zero MFJ flags (MFJ falls inside the attribution bounds,
+matching the wages-on-other-spouse reading). The harness independently
+rediscovered not only the bug but the precise per-status fix boundary that
+PR #279 implements. Max overcharge in grid: $20,906 of SE tax
+(Married/Sep, w2 $400k, SE $300k... representative high case).
+
+### F2. SE-tax error propagates to AGI
+
+Across all flagged cases, AGI error = −0.5 × SE-tax error to five decimal
+places (the §164(f) half-SE deduction). Fixing F1 also fixes AGI, MAGI, and
+everything downstream of them.
+
+### F3. §199A QBI — issue #278 part 2 recapitulated, both directions
+
+- OTS: taxable income overstated by exactly taxcalc's `qbided` plus the F2
+  AGI shift — the decomposition closes to within $2 in **all 145** SE-income
+  cases. Pure missing orchestration: no Form 8995 config exists.
+- Graph: the spec **does** implement the 20%-of-taxable-income limitation
+  (a first-pass read of this audit said otherwise). Its sole defect is the
+  base: Form 8995 L1 receives *gross* Schedule C profit instead of profit
+  net of the §164(f) half-SE deduction. When the base term binds the error
+  is 20% × the half-SE deduction (e.g., $1,130.36 at Single w2 $50k /
+  SE $80k); when the cap binds (the grid's 20 `w2=0` cases) the graph is
+  exactly correct. The 125-case "20% of gross" fit and the up-to-$70,453
+  taxable understatement are the base-bound cases.
+- Above the §199A thresholds the correct deduction additionally depends on
+  business W-2 wages / UBIA / SSTB status — concepts absent from tenforty's
+  API (taxcalc assumes zero business wages, phasing the deduction to zero
+  above the upper threshold). Any fix must choose an assumption there and
+  document it.
+
+### F4. NIIT omits short-term capital gains — shared omission, both backends
+
+All 56 NIIT flags have STCG > 0; the error is −3.8% × STCG (or MAGI-limited).
+Root cause is symmetrical: Form 8960 line 5a ("net gain from disposition of
+property") is mapped from `long_term_capital_gains` only —
+`models.py` OTS input_map and `mappings.py` graph fan-out both lack
+`short_term_capital_gains`. Backend parity can never catch this class.
+
+### F5. Graph omits SE earnings from Form 8959 (additional Medicare tax)
+
+145 graph flags, every one with SE income > 0. OTS maps SE earnings via
+`_se_income_to_8959_l8`; the graph fan-out has no SE edge into
+`us_form_8959`. Confirms the prior mapping-layer assessment finding.
+
+### F6. NEW — OTS Form 8959 never fires with zero W-2 wages
+
+`evaluate_return(year=2024, filing_status="Single", self_employment_income=300_000)`
+returns additional Medicare tax $0.00; with `w2_income=1` it returns $693.46.
+Cause: the Phase-1 activation check (`core.py:455`) counts only `int`/`float`
+values, but `_se_income_to_8959_l8` returns its value as a *string*
+(`("L8", str(round(...)))`), and `Status` is also a string. With `w2_income=0`
+no numeric value survives and the form is skipped. Missed tax up to $1,368
+(Married/Sep, SE $300k) in the grid. A formatting decision leaked into
+activation semantics — exactly the "activation" contract dimension the
+mapping-layer assessment called out.
+
+### F8. NEW — Graph cross-mode batch returns an exploded, misaligned grid
+
+Found incidentally while benchmarking, tracked as `tenforty-i7n` (P0).
+`evaluate_returns(backend="graph", mode="cross")` — the default mode — returns
+`python_grid × rust_axis` rows instead of the grid (`w2_income=[10k,20k,30k]`
+→ 9 rows; a 2×3 grid → 18), and the input columns cycle at a different rate
+than the results, so rows pair wrong inputs with wrong outputs — only the
+diagonal is correct. OTS cross/zip and graph zip are all correct. Prior
+audits used one-row batch cases, where 1×1 = 1 row masks the explosion
+entirely — another instance of easy scenarios hiding a broken path.
+
+### F7. Itemization semantics diverge between backends
+
+With `standard_or_itemized="Itemized"` and deductions below the standard
+deduction, OTS *forces* itemization (higher tax) while graph takes
+best-of-both (agreeing with taxcalc, which cannot force). With deductions
+above the standard deduction all three agree. The API contract for
+"Itemized" is currently implemented two different ways.
+
+### Clean areas
+
+Dividends (including the qualified-subset normalization), interest, AMT (no
+ISO cases in grid), and all capital-gains cases apart from the NIIT edge —
+scalar paths only. The previously reported qualified-dividend and AMT-output
+bugs are batch-path defects this scalar harness deliberately did not probe.
+
+## Recommended changes, by layer
+
+1. **Merge PR #279** (F1/F2 for single-person statuses; correct as far as it
+   goes).
+2. **Graph spec (Haskell)** — four edits, all of which then flow to every
+   execution path (scalar, batch, gradient, solver) for free:
+   - compute the filer's SS wages in-spec (retires PR #279's batch xfail);
+   - Form 8995: feed QBI net of the half-SE deduction — the taxable-income
+     limitation is already implemented in-spec (F3);
+   - Form 8959: add the SE-earnings edge (F5);
+   - Form 8960 line 5a: include short-term gains (F4).
+3. **OTS backend (Python)**:
+   - Form 8960 input_map: add `short_term_capital_gains` summed into L5a (F4);
+   - activation: decide form firing from the *natural inputs consumed*, not
+     the post-format values (F6);
+   - Form 8995: new phase-2 subordinate config fed by
+     taxable-income-before-QBI from the 1040 pass (F3), with the phase-out
+     assumption documented.
+4. **API decisions** (blocking full correctness, owner's call):
+   - per-spouse wage/SE fields (completes F1 for MFJ; taxcalc's
+     `e00200p`/`e00200s` is a working reference);
+   - define "Itemized": force vs best-of, then make both backends match (F7);
+   - §199A above-threshold assumption (F3).
+5. **Keep the oracle**: promote the harness to `scripts/`, commit a pinned
+   golden fixture set at the semantic boundaries, and run the three-way sweep
+   as a scheduled/pre-release job. Parity catches divergence; only an
+   independent oracle catches shared omissions (F4 was invisible to parity by
+   construction).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,12 @@ dev = [
   "ruff>=0.2.0",
   "pre-commit"
 ]
+# Independent federal oracle for differential testing (scripts/taxcalc_audit.py,
+# tests/oracle/). Not synced by default: uv sync --group oracle
+oracle = [
+  "taxcalc>=6.7,<7",
+  "pandas>=2"
+]
 
 [project]
 authors = [{name = "Mike Macpherson", email = "mmacpherson@users.noreply.github.com"}]

--- a/scripts/taxcalc_audit.py
+++ b/scripts/taxcalc_audit.py
@@ -1,0 +1,259 @@
+"""Differential audit: tenforty (OTS + graph) vs PSL Tax-Calculator.
+
+Generates a boundary-focused federal case grid, evaluates every case on all
+three engines, and writes a long-format CSV of per-quantity comparisons.
+
+Scope notes (v1):
+- Federal only (taxcalc has no state model).
+- No dependents, no ISO gains, no rental/schedule-1 income (taxcalc mapping
+  for those is ambiguous or absent).
+- Itemized deductions are mapped to taxcalc cash charity (e19800): no AGI
+  floor below 60%, so it's the cleanest single-aggregate carrier.
+- MFJ wage attribution: taxcalc requires per-spouse wages; tenforty's
+  w2_income is a household aggregate. We run taxcalc twice for MFJ SE cases:
+  wages all on the self-employed primary ("primary") and wages all on the
+  other spouse ("spouse"). These bracket the truth for tenforty's aggregate.
+- Ages set to 40 to avoid 65+ standard deduction and EITC age edges.
+"""
+
+import sys
+import warnings
+
+import pandas as pd
+
+warnings.filterwarnings("ignore")
+
+STATUSES = ["Single", "Married/Joint", "Married/Sep", "Head_of_House", "Widow(er)"]
+MARS = {
+    "Single": 1,
+    "Married/Joint": 2,
+    "Married/Sep": 3,
+    "Head_of_House": 4,
+    "Widow(er)": 5,
+}
+
+SS_WAGE_BASE = 168_600  # 2024
+
+
+def build_cases() -> list[dict]:
+    cases = []
+
+    def add(tag, **kw):
+        cases.append({"tag": tag, **kw})
+
+    # A: SE tax / SS wage base / additional Medicare / QBI interactions
+    for st in STATUSES:
+        for w2 in (0, 50_000, 120_000, SS_WAGE_BASE, 200_000, 260_000, 400_000):
+            for se in (0, 30_000, 60_000, 150_000, 300_000):
+                if w2 == 0 and se == 0:
+                    continue
+                add("A_se", filing_status=st, w2_income=w2, self_employment_income=se)
+
+    # B: capital gains / NIIT thresholds
+    for st in ("Single", "Married/Joint", "Head_of_House"):
+        for w2 in (50_000, 150_000, 250_000, 400_000):
+            for stcg in (0, 25_000, 60_000):
+                for ltcg in (0, 25_000, 60_000, 200_000):
+                    if stcg == 0 and ltcg == 0:
+                        continue
+                    add(
+                        "B_gains",
+                        filing_status=st,
+                        w2_income=w2,
+                        short_term_capital_gains=stcg,
+                        long_term_capital_gains=ltcg,
+                    )
+
+    # C: interest and dividends (qualified subset of ordinary)
+    for st in ("Single", "Married/Joint"):
+        for w2 in (60_000, 200_000, 300_000):
+            for intr in (0, 15_000):
+                for od, qd in (
+                    (20_000, 0),
+                    (20_000, 12_000),
+                    (20_000, 20_000),
+                    (0, 12_000),
+                ):
+                    add(
+                        "C_div",
+                        filing_status=st,
+                        w2_income=w2,
+                        taxable_interest=intr,
+                        ordinary_dividends=od,
+                        qualified_dividends=qd,
+                    )
+
+    # D: forced itemization (mapped to charity on taxcalc side)
+    for st in ("Single", "Married/Joint"):
+        for w2 in (100_000, 300_000):
+            for item in (10_000, 40_000):
+                add(
+                    "D_item",
+                    filing_status=st,
+                    w2_income=w2,
+                    itemized_deductions=item,
+                    standard_or_itemized="Itemized",
+                )
+
+    # E: kitchen sink
+    for st in STATUSES:
+        add(
+            "E_mix",
+            filing_status=st,
+            w2_income=180_000,
+            self_employment_income=80_000,
+            long_term_capital_gains=50_000,
+            ordinary_dividends=15_000,
+            qualified_dividends=10_000,
+            taxable_interest=5_000,
+        )
+
+    for i, c in enumerate(cases):
+        c["case_id"] = i
+    return cases
+
+
+TENFORTY_FIELDS = (
+    "w2_income",
+    "taxable_interest",
+    "ordinary_dividends",
+    "qualified_dividends",
+    "short_term_capital_gains",
+    "long_term_capital_gains",
+    "self_employment_income",
+    "itemized_deductions",
+)
+
+QUANTITIES = (
+    "agi",
+    "taxable_income",
+    "se_tax",
+    "niit",
+    "addl_medicare",
+    "amt",
+    "total_tax",
+)
+
+
+def run_tenforty(cases, backend):
+    import tenforty
+
+    rows = {}
+    for c in cases:
+        kwargs = {k: c.get(k, 0.0) for k in TENFORTY_FIELDS}
+        if c.get("standard_or_itemized"):
+            kwargs["standard_or_itemized"] = c["standard_or_itemized"]
+        try:
+            r = tenforty.evaluate_return(
+                year=2024,
+                filing_status=c["filing_status"],
+                backend=backend,
+                **kwargs,
+            )
+            rows[c["case_id"]] = {
+                "agi": r.federal_adjusted_gross_income,
+                "taxable_income": r.federal_taxable_income,
+                "se_tax": r.federal_se_tax,
+                "niit": r.federal_niit,
+                "addl_medicare": r.federal_additional_medicare_tax,
+                "amt": r.federal_amt,
+                "total_tax": r.federal_total_tax,
+            }
+        except Exception as exc:
+            rows[c["case_id"]] = {"error": f"{type(exc).__name__}: {exc}"}
+    return rows
+
+
+def run_taxcalc(cases, wage_attribution="primary"):
+    import taxcalc as tc
+
+    recs = []
+    for c in cases:
+        mars = MARS[c["filing_status"]]
+        w2 = float(c.get("w2_income", 0.0))
+        se = float(c.get("self_employment_income", 0.0))
+        qd = float(c.get("qualified_dividends", 0.0))
+        od = max(float(c.get("ordinary_dividends", 0.0)), qd)
+        wages_on_spouse = wage_attribution == "spouse" and mars == 2
+        recs.append(
+            {
+                "RECID": c["case_id"] + 1,
+                "MARS": mars,
+                "XTOT": 2 if mars == 2 else 1,
+                "age_head": 40,
+                "age_spouse": 40 if mars == 2 else 0,
+                "e00200": w2,
+                "e00200p": 0.0 if wages_on_spouse else w2,
+                "e00200s": w2 if wages_on_spouse else 0.0,
+                "e00900": se,
+                "e00900p": se,
+                "e00900s": 0.0,
+                "e00300": float(c.get("taxable_interest", 0.0)),
+                "e00600": od,
+                "e00650": qd,
+                "p22250": float(c.get("short_term_capital_gains", 0.0)),
+                "p23250": float(c.get("long_term_capital_gains", 0.0)),
+                "e19800": float(c.get("itemized_deductions", 0.0)),
+            }
+        )
+    df = pd.DataFrame(recs)
+    records = tc.Records(data=df, start_year=2024, gfactors=None, weights=None)
+    calc = tc.Calculator(policy=tc.Policy(), records=records)
+    calc.advance_to_year(2024)
+    calc.calc_all()
+
+    out = {}
+    arr = calc.array
+    for i, c in enumerate(cases):
+        iitax = float(arr("iitax")[i])
+        setax = float(arr("setax")[i])
+        amc = float(arr("ptax_amc")[i])
+        out[c["case_id"]] = {
+            "agi": float(arr("c00100")[i]),
+            "taxable_income": float(arr("c04800")[i]),
+            "se_tax": setax,
+            "niit": float(arr("niit")[i]),
+            "addl_medicare": amc,
+            "amt": float(arr("c09600")[i]),
+            "total_tax": iitax + setax + amc,
+            "qbided": float(arr("qbided")[i]),
+        }
+    return out
+
+
+def main():
+    cases = build_cases()
+    print(f"{len(cases)} cases", file=sys.stderr)
+
+    tc_primary = run_taxcalc(cases, "primary")
+    mfj_cases = [c for c in cases if c["filing_status"] == "Married/Joint"]
+    tc_spouse = run_taxcalc(mfj_cases, "spouse") if mfj_cases else {}
+    ots = run_tenforty(cases, "ots")
+    graph = run_tenforty(cases, "graph")
+
+    rows = []
+    for c in cases:
+        cid = c["case_id"]
+        base = {
+            k: c.get(k, 0)
+            for k in ("case_id", "tag", "filing_status", *TENFORTY_FIELDS)
+        }
+        base["taxcalc_qbided"] = tc_primary[cid].get("qbided", 0.0)
+        for q in QUANTITIES:
+            row = dict(base)
+            row["quantity"] = q
+            row["taxcalc"] = tc_primary[cid].get(q)
+            row["taxcalc_spouse_attr"] = tc_spouse.get(cid, {}).get(q)
+            row["ots"] = ots[cid].get(q)
+            row["graph"] = graph[cid].get(q)
+            row["ots_error"] = ots[cid].get("error", "")
+            row["graph_error"] = graph[cid].get("error", "")
+            rows.append(row)
+
+    out = pd.DataFrame(rows)
+    out.to_csv(sys.argv[1] if len(sys.argv) > 1 else "audit_results.csv", index=False)
+    print("done", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/known_defects_test.py
+++ b/tests/known_defects_test.py
@@ -1,0 +1,140 @@
+"""Burn-in tests for known, unfixed defects from the taxcalc differential audit.
+
+Each test asserts the CORRECT behavior and is marked strict xfail, tagged with
+its audit finding (docs/taxcalc-differential-audit.md) and tracking issue. The
+suite stays green while the defect stands; the moment a fix lands, the strict
+xfail fails the build until the marker is removed — so every fix must claim
+its finding explicitly.
+
+Expected values are cross-validated against PSL Tax-Calculator 6.7.2 (and,
+where noted, against OTS driven directly).
+"""
+
+import pytest
+
+from tenforty import evaluate_return, evaluate_returns
+
+
+def _graph_available() -> bool:
+    try:
+        from tenforty.backends.graph import GraphBackend
+
+        return GraphBackend().is_available()
+    except ImportError:
+        return False
+
+
+skip_if_graph_unavailable = pytest.mark.skipif(
+    not _graph_available(),
+    reason="Graph backend required",
+)
+
+
+@pytest.mark.xfail(
+    reason="F3/tenforty-6hr: OTS never supplies 1040 line 13 (QBI)", strict=True
+)
+def test_ots_qbi_deduction_reaches_1040():
+    """MFJ, $80k SE profit: §199A deduction is $9,029.64, taxable $36,118.54."""
+    r = evaluate_return(
+        year=2024, filing_status="Married/Joint", self_employment_income=80_000
+    )
+    assert r.federal_taxable_income == pytest.approx(36_118.54, abs=1.0)
+
+
+@pytest.mark.xfail(
+    reason="F3/tenforty-6hr: graph QBI base is gross profit, not net of half-SE",
+    strict=True,
+)
+@skip_if_graph_unavailable
+def test_graph_qbi_uses_net_base():
+    """Single, $50k wages + $80k SE: QBI base must be net of the half-SE deduction.
+
+    Correct deduction is 20% of net profit ($14,869.64), not 20% of gross
+    ($16,000). The graph's taxable-income limitation is already correct; only
+    the base is wrong, so this case makes the base term bind (taxable income
+    stays below both the cap and the §199A threshold).
+    """
+    r = evaluate_return(
+        year=2024,
+        filing_status="Single",
+        w2_income=50_000,
+        self_employment_income=80_000,
+        backend="graph",
+    )
+    assert r.federal_taxable_income == pytest.approx(94_878.54, abs=1.0)
+
+
+@pytest.mark.xfail(
+    reason="F4/tenforty-dhk: 8960 L5a omits short-term gains (OTS)", strict=True
+)
+def test_ots_niit_includes_short_term_gains():
+    """$300k wages + $50k STCG: NIIT is 3.8% of $50k = $1,900."""
+    r = evaluate_return(
+        year=2024,
+        filing_status="Single",
+        w2_income=300_000,
+        short_term_capital_gains=50_000,
+    )
+    assert r.federal_niit == pytest.approx(1_900.0, abs=1.0)
+
+
+@pytest.mark.xfail(
+    reason="F4/tenforty-dhk: 8960 L5a omits short-term gains (graph)", strict=True
+)
+@skip_if_graph_unavailable
+def test_graph_niit_includes_short_term_gains():
+    """Same case on the graph backend: NIIT must include short-term gains."""
+    r = evaluate_return(
+        year=2024,
+        filing_status="Single",
+        w2_income=300_000,
+        short_term_capital_gains=50_000,
+        backend="graph",
+    )
+    assert r.federal_niit == pytest.approx(1_900.0, abs=1.0)
+
+
+@pytest.mark.xfail(reason="F5/tenforty-6hr: graph 8959 omits SE earnings", strict=True)
+@skip_if_graph_unavailable
+def test_graph_additional_medicare_includes_se_earnings():
+    """$250k wages + $50k SE profit: additional Medicare tax is $865.57, not $450."""
+    r = evaluate_return(
+        year=2024,
+        filing_status="Single",
+        w2_income=250_000,
+        self_employment_income=50_000,
+        backend="graph",
+    )
+    assert r.federal_additional_medicare_tax == pytest.approx(865.57, abs=1.0)
+
+
+@pytest.mark.xfail(
+    reason="F6/tenforty-8lf: OTS 8959 never fires with zero W-2 wages", strict=True
+)
+def test_ots_additional_medicare_fires_without_wages():
+    """$300k SE profit, no wages: additional Medicare tax is $693.45, not $0."""
+    r = evaluate_return(
+        year=2024, filing_status="Single", self_employment_income=300_000
+    )
+    assert r.federal_additional_medicare_tax == pytest.approx(693.45, abs=1.0)
+
+
+@pytest.mark.xfail(
+    reason="F8/tenforty-i7n: graph cross mode explodes and misaligns the grid",
+    strict=True,
+)
+@skip_if_graph_unavailable
+def test_graph_cross_mode_grid_shape_and_alignment():
+    """Three income points must produce three rows, each labeled with its own input."""
+    df = evaluate_returns(
+        year=2024,
+        filing_status="Single",
+        w2_income=[10_000.0, 20_000.0, 30_000.0],
+        backend="graph",
+        mode="cross",
+    )
+    assert len(df) == 3
+    for w2, agi in zip(
+        df["w2_income"], df["federal_adjusted_gross_income"], strict=True
+    ):
+        assert agi == pytest.approx(w2, abs=1.0)

--- a/tests/oracle/taxcalc_differential_test.py
+++ b/tests/oracle/taxcalc_differential_test.py
@@ -1,0 +1,154 @@
+"""Hypothesis-driven differential testing against PSL Tax-Calculator.
+
+Property: for any generated federal return, every tenforty component quantity
+matches taxcalc within tolerance.
+
+Two structural choices worth knowing about:
+
+- **Batched oracle calls.** taxcalc has ~13s of fixed per-invocation overhead
+  (policy deepcopy and parameter expansion) but is vectorized over records, so
+  each hypothesis example is a *list* of cases evaluated in one taxcalc call.
+  Shrinking naturally collapses a failing list to the single minimal failing
+  case, so counterexample quality is unchanged.
+- **target()-guided search.** Each quantity's absolute disagreement is fed to
+  hypothesis as an optimization target, so generation actively climbs toward
+  the largest divergence instead of sampling blindly.
+
+Requires the oracle dependency group: uv sync --group oracle
+
+Married/Joint is excluded: taxcalc requires per-spouse wage attribution and
+tenforty's w2_income is a household aggregate, so exact comparison is only
+defined for single-person statuses (see docs/taxcalc-differential-audit.md).
+
+The module is a non-strict xfail while the known mapping bugs stand (audit
+findings F1-F6). Once those are fixed, drop the marker: this becomes the
+standing adversarial guard against regressions and shared omissions.
+"""
+
+import os
+
+import pytest
+
+if not os.environ.get("TENFORTY_ORACLE"):
+    pytest.skip(
+        "oracle differential suite is slow (~5 min); set TENFORTY_ORACLE=1 to run",
+        allow_module_level=True,
+    )
+
+taxcalc = pytest.importorskip("taxcalc")
+pd = pytest.importorskip("pandas")
+
+from hypothesis import HealthCheck, given, settings, target  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+import tenforty  # noqa: E402
+
+pytestmark = pytest.mark.xfail(
+    reason="known mapping bugs, docs/taxcalc-differential-audit.md F1-F6",
+    strict=False,
+)
+
+MARS = {"Single": 1, "Married/Sep": 3, "Head_of_House": 4, "Widow(er)": 5}
+
+SS_WAGE_BASE_2024 = 168_600
+BOUNDARY_DOLLARS = (0, 125_000, SS_WAGE_BASE_2024, 200_000, 250_000)
+
+dollars = st.one_of(
+    st.sampled_from(BOUNDARY_DOLLARS),
+    st.integers(min_value=0, max_value=400_000),
+).map(float)
+
+case_strategy = st.fixed_dictionaries(
+    {
+        "status": st.sampled_from(sorted(MARS)),
+        "w2": dollars,
+        "se": dollars,
+        "stcg": dollars,
+        "ltcg": dollars,
+    }
+)
+
+TAX_TABLE_TOL = 15.0  # OTS uses the $50-step 1040 tax tables; taxcalc is exact
+COMPONENT_TOL = 2.0
+
+
+def taxcalc_batch(cases):
+    """Evaluate a batch of cases in one vectorized taxcalc call."""
+    df = pd.DataFrame(
+        [
+            {
+                "RECID": i + 1,
+                "MARS": MARS[c["status"]],
+                "XTOT": 1,
+                "age_head": 40,
+                "e00200": c["w2"],
+                "e00200p": c["w2"],
+                "e00900": c["se"],
+                "e00900p": c["se"],
+                "p22250": c["stcg"],
+                "p23250": c["ltcg"],
+            }
+            for i, c in enumerate(cases)
+        ]
+    )
+    records = taxcalc.Records(data=df, start_year=2024, gfactors=None, weights=None)
+    calc = taxcalc.Calculator(policy=taxcalc.Policy(), records=records)
+    calc.calc_all()
+    arr = calc.array
+    return [
+        {
+            "agi": (float(arr("c00100")[i]), COMPONENT_TOL),
+            "taxable_income": (float(arr("c04800")[i]), COMPONENT_TOL),
+            "se_tax": (float(arr("setax")[i]), COMPONENT_TOL),
+            "niit": (float(arr("niit")[i]), COMPONENT_TOL),
+            "addl_medicare": (float(arr("ptax_amc")[i]), COMPONENT_TOL),
+            "total_tax": (
+                float(arr("iitax")[i] + arr("setax")[i] + arr("ptax_amc")[i]),
+                TAX_TABLE_TOL,
+            ),
+        }
+        for i in range(len(cases))
+    ]
+
+
+@settings(
+    max_examples=10,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
+)
+@given(cases=st.lists(case_strategy, min_size=1, max_size=40))
+@pytest.mark.parametrize("backend", ["ots", "graph"])
+def test_components_match_taxcalc(backend, cases):
+    """Every tenforty component quantity matches taxcalc within tolerance."""
+    oracle = taxcalc_batch(cases)
+    failures = []
+    worst = {}
+    for case, expected_row in zip(cases, oracle, strict=True):
+        r = tenforty.evaluate_return(
+            year=2024,
+            filing_status=case["status"],
+            w2_income=case["w2"],
+            self_employment_income=case["se"],
+            short_term_capital_gains=case["stcg"],
+            long_term_capital_gains=case["ltcg"],
+            backend=backend,
+        )
+        ours = {
+            "agi": r.federal_adjusted_gross_income,
+            "taxable_income": r.federal_taxable_income,
+            "se_tax": r.federal_se_tax,
+            "niit": r.federal_niit,
+            "addl_medicare": r.federal_additional_medicare_tax,
+            "total_tax": r.federal_total_tax,
+        }
+        for quantity, (expected, tol) in expected_row.items():
+            diff = abs(ours[quantity] - expected)
+            worst[quantity] = max(worst.get(quantity, 0.0), diff)
+            if diff > tol:
+                failures.append(f"{case}: {quantity} diff {diff:,.2f} > {tol}")
+    # target() accepts one observation per label per example, so feed it the
+    # batch maximum: hypothesis then steers toward batches containing the
+    # largest disagreement.
+    for quantity, diff in worst.items():
+        target(diff, label=quantity)
+    assert not failures, "\n".join(failures[:5])


### PR DESCRIPTION
Adds the differential-testing infrastructure that came out of #278's investigation.

## What's here

- **Oracle dependency group**: `uv sync --group oracle` installs [PSL Tax-Calculator](https://github.com/PSLmodels/Tax-Calculator) (CC0, pinned `<7` for fixture stability). Never enters runtime deps; `src/tenforty/` stays polars-only.
- **`scripts/taxcalc_audit.py`**: 363-case three-way differential grid (OTS × graph × taxcalc) over boundary-focused federal cases — SS wage base, NIIT/additional-Medicare thresholds, QBI interactions — with MFJ handled via attribution bounds.
- **`tests/oracle/`**: hypothesis suite that hunts divergence adversarially — `target()`-guided search on per-quantity disagreement, batched oracle calls (taxcalc has ~13s fixed overhead but vectorizes, so each example is a case-list that shrinking collapses to a minimal counterexample). Gated behind `TENFORTY_ORACLE=1`; non-strict xfail until the known defects are fixed.
- **`tests/known_defects_test.py`**: one strict-xfail regression per audit finding, tagged with finding ID and tracking issue. The suite stays green while a defect stands; a fix trips the strict xfail until the marker is removed — every fix must claim its finding.
- **`docs/taxcalc-differential-audit.md`**: the full report (F1–F8).

## Why

The audit blindly recapitulated both halves of #278 — including the exact per-status fix boundary #279 implements — and surfaced six further defects, several structurally invisible to backend parity (both backends omit short-term gains from NIIT, agreeing with each other to the cent). Parity catches divergence; only an independent oracle catches shared omissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)