### PR TITLE
fix: Form 8960 line 5a includes short-term gains; form activation reads naturals

### DIFF
--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -20,17 +20,18 @@ delete the signature, and update this table in the same PR.
 | F1 | Schedule SE L8a never filled | mapping, both backends | fixed (#279, v2025.11) | @bg002h, #278 |
 | F2 | SE-tax error propagates to AGI | consequence of F1 | fixed with F1 | @bg002h, #278 |
 | F3 | QBI: missing (OTS) / gross base (graph) | OTS orchestration + graph spec | open | @bg002h, #278 |
-| F4 | Form 8960 L5a omits short-term gains | mapping, both backends | open | mapping assessment + oracle sweep |
+| F4 | Form 8960 L5a omits short-term gains | mapping, both backends | fixed on OTS; open on graph | mapping assessment + oracle sweep |
 | F5 | Graph Form 8959 omits SE earnings | graph mapping | open | mapping assessment + oracle sweep |
-| F6 | OTS 8959 never fires with zero wages | OTS activation semantics | open | oracle sweep |
+| F6 | OTS 8959 never fires with zero wages | OTS activation semantics | fixed | oracle sweep |
 | F7 | "Itemized" force vs best-of divergence | API contract | open (owner decision) | oracle sweep |
 | F8 | Cross-mode batch grid explosion | graph batch path | fix in PR #287 | benchmark |
 | F9 | Batch path bypasses TaxReturnInput | graph batch path | open | batch-conformance tests |
 | F10 | Short-term gains taxed at preferential rates | graph spec | open | oracle grid |
-| F11 | 2024 HoH 32% bracket starts \$191,150, not \$191,950 | upstream OpenTaxSolver | adjudicated vs IRS; upstream report pending | oracle grid |
+| F11 | 2024 HoH 32% bracket starts \$191,150, not \$191,950 | upstream OpenTaxSolver | adjudicated vs IRS; upstream report pending — not patched locally, we vendor OTS unmodified | oracle grid |
 | F12 | Itemized-deduction category changes AMT | API (input model v2) | open (design) | adversarial search |
 | F13 | 2025 MFS long-term-gain thresholds high | graph spec (suspect) | open | oracle grid |
 | F14 | AMT std-deduction add-back divergence (ISO cases) | taxcalc + graph (suspect) | open, adjudication pending | H_amt stratum |
+| F15 | OTS itemizes despite `standard_or_itemized="Standard"`; taxable_income unexcused | OTS orchestration + API contract | open (tenforty-z31) | oracle sweep |
 
 ## Method
 
@@ -96,6 +97,12 @@ property") is mapped from `long_term_capital_gains` only —
 `models.py` OTS input_map and `mappings.py` graph fan-out both lack
 `short_term_capital_gains`. Backend parity can never catch this class.
 
+**Fixed on OTS.** Both gain naturals now map through
+`_capital_gain_to_8960_l5a`, so the mapper appends them onto the same
+semicolon-terminated line and OTS's `GetLineF` reads line 5a as their sum.
+The graph half is still open, so the `_f4_niit_stcg` signature is narrowed to
+`backend == "graph"` rather than deleted.
+
 ### F5. Graph omits SE earnings from Form 8959 (additional Medicare tax)
 
 145 graph flags, every one with SE income > 0. OTS maps SE earnings via
@@ -113,6 +120,11 @@ no numeric value survives and the form is skipped. Missed tax up to $1,368
 (Married/Sep, SE $300k) in the grid. A formatting decision leaked into
 activation semantics — exactly the "activation" contract dimension the
 mapping-layer assessment called out.
+
+**Fixed.** Activation is now decided by `subordinate_form_applies`, which
+tests the *natural* inputs a form consumes against the form's `input_map`
+instead of the post-format OTS values. Formatting can no longer decide
+whether a form runs.
 
 ### F8. NEW — Graph cross-mode batch returns an exploded, misaligned grid
 
@@ -158,6 +170,14 @@ an *upstream OpenTaxSolver* defect, to be reported upstream. First catch
 for the three-way adjudication method: the oracle and the independent
 in-house engine outvoted the incumbent, and the revenue procedure confirmed
 the majority.
+
+**Not patched locally.** We vendor OpenTaxSolver unmodified — no edits to the
+release sources or to the generated amalgamation, and no correcting patch
+function in `ots/amalgamate.py`. The fix belongs in an OTS release. Until one
+carries it, the `_f11_ots_hoh_bracket` signature and its strict-xfail burn-in
+are the record; the xfail flips on its own once upstream corrects the table.
+(The same bad row is duplicated into Form 2210's copy of the 2024 rate table,
+which the upstream report should mention.)
 
 ### F12. NEW — itemized_deductions category ambiguity changes AMT
 

--- a/src/tenforty/core.py
+++ b/src/tenforty/core.py
@@ -25,6 +25,7 @@ from .models import (
     OTSYear,
     OutputFieldSpec,
     StrEnum,
+    SubordinateFormConfig,
     TaxReturnInput,
 )
 
@@ -386,6 +387,25 @@ def _evaluate_subordinate(
 
 ## LEVEL 1: Map from natural description, eg "w2_income", to OTS line-level
 ##          description, eg "L1a", and back.
+def subordinate_form_applies(
+    sub_cfg: SubordinateFormConfig, natural_input: dict[str, Any]
+) -> bool:
+    """Decide whether a subordinate form has any input worth evaluating.
+
+    Judged on the natural inputs the form consumes rather than on the
+    formatted OTS values, because a mapping expressed as a callable returns a
+    preformatted string that no numeric test can see. Form 8959 takes
+    self-employment income through such a callable, so a filer with SE
+    earnings and no W-2 wages used to look entirely empty and the form never
+    ran.
+    """
+    return any(
+        isinstance(value, (int, float)) and value != 0
+        for key, value in natural_input.items()
+        if key in sub_cfg.input_map
+    )
+
+
 def map_natural_to_ots_input(
     natural_input: dict[str, Any], natural_mapping: dict[str, str]
 ):
@@ -449,13 +469,11 @@ def evaluate_natural_input_form(
             continue
         if (year.value, sub_cfg.form_id) not in OTS_FORM_CONFIG:
             continue
+        if not subordinate_form_applies(sub_cfg, natural_form_values):
+            continue
         sub_form_values = sub_cfg.defaults | map_natural_to_ots_input(
             natural_form_values, sub_cfg.input_map
         )
-        if not any(
-            isinstance(v, (int, float)) and v != 0 for v in sub_form_values.values()
-        ):
-            continue
         try:
             sub_result = _evaluate_subordinate(
                 year.value, sub_cfg.form_id, sub_form_values, on_error=on_error
@@ -512,13 +530,11 @@ def evaluate_natural_input_form(
             continue
         if (year.value, sub_cfg.form_id) not in OTS_FORM_CONFIG:
             continue
+        if not subordinate_form_applies(sub_cfg, natural_form_values):
+            continue
         sub_form_values = sub_cfg.defaults | map_natural_to_ots_input(
             natural_form_values, sub_cfg.input_map
         )
-        if not any(
-            isinstance(v, (int, float)) and v != 0 for v in sub_form_values.values()
-        ):
-            continue
         federal_return = ots_output["federal"]
         for fed_key, sub_key in sub_cfg.fed_import_map.items():
             if fed_key in federal_return:

--- a/src/tenforty/models.py
+++ b/src/tenforty/models.py
@@ -1169,6 +1169,18 @@ def _se_income_to_8959_l8(se_income):
     return ("L8", str(round(se_income * 0.9235)))
 
 
+def _capital_gain_to_8960_l5a(gain):
+    """Contribute one capital-gain natural to Form 8960 line 5a.
+
+    Line 5a is net gain from property dispositions — holding period is
+    irrelevant to the net investment income tax, so short- and long-term
+    gains both belong there. Both naturals map through this callable so the
+    mapper appends them onto the same semicolon-terminated line, which OTS
+    reads as a sum.
+    """
+    return ("L5a", str(gain))
+
+
 _SUBORDINATE_FORM_CONFIG = [
     # 2024 Schedule SE — Phase 1 (no federal dependency)
     {
@@ -1206,7 +1218,8 @@ _SUBORDINATE_FORM_CONFIG = [
             "taxable_interest": "L1",
             "ordinary_dividends": "L2",
             "rental_income": "L4a",
-            "long_term_capital_gains": "L5a",
+            "long_term_capital_gains": _capital_gain_to_8960_l5a,
+            "short_term_capital_gains": _capital_gain_to_8960_l5a,
             "filing_status": "Status",
         },
         "fed_import_map": {"L11": "L13"},
@@ -1255,7 +1268,8 @@ _SUBORDINATE_FORM_CONFIG = [
             "taxable_interest": "L1",
             "ordinary_dividends": "L2",
             "rental_income": "L4a",
-            "long_term_capital_gains": "L5a",
+            "long_term_capital_gains": _capital_gain_to_8960_l5a,
+            "short_term_capital_gains": _capital_gain_to_8960_l5a,
             "filing_status": "Status",
         },
         "fed_import_map": {"L11b": "L13"},

--- a/tests/known_defects_test.py
+++ b/tests/known_defects_test.py
@@ -62,7 +62,6 @@ def test_graph_qbi_uses_net_base():
     assert r.federal_taxable_income == pytest.approx(94_878.54, abs=1.0)
 
 
-@pytest.mark.xfail(reason="F4: 8960 L5a omits short-term gains (OTS)", strict=True)
 def test_ots_niit_includes_short_term_gains():
     """$300k wages + $50k STCG: NIIT is 3.8% of $50k = $1,900."""
     r = evaluate_return(
@@ -102,7 +101,6 @@ def test_graph_additional_medicare_includes_se_earnings():
     assert r.federal_additional_medicare_tax == pytest.approx(865.57, abs=1.0)
 
 
-@pytest.mark.xfail(reason="F6: OTS 8959 never fires with zero W-2 wages", strict=True)
 def test_ots_additional_medicare_fires_without_wages():
     """$300k SE profit, no wages: additional Medicare tax is $693.45, not $0."""
     r = evaluate_return(

--- a/tests/mapping_completeness_test.py
+++ b/tests/mapping_completeness_test.py
@@ -45,7 +45,7 @@ INVENTORY = {
     ("form_8960", "ordinary_dividends"): {"ots": "mapped", "graph": "mapped"},
     ("form_8960", "long_term_capital_gains"): {"ots": "mapped", "graph": "mapped"},
     ("form_8960", "short_term_capital_gains"): {
-        "ots": "missing:F4",
+        "ots": "mapped",
         "graph": "missing:F4",
     },
     ("form_8995", "self_employment_income"): {

--- a/tests/oracle/oracle_policy.py
+++ b/tests/oracle/oracle_policy.py
@@ -35,8 +35,13 @@ def _f3_qbi(backend: str, case: dict) -> set[str]:
 
 
 def _f4_niit_stcg(backend: str, case: dict) -> set[str]:
-    """F4: Form 8960 L5a omits short-term gains, both backends."""
-    if case.get("stcg", 0):
+    """F4: Form 8960 L5a omits short-term gains.
+
+    Fixed on the OTS side, which now maps both gain naturals onto line 5a;
+    the graph spec still carries the defect, so the signature is narrowed
+    rather than deleted. Delete it with the graph fix.
+    """
+    if backend == "graph" and case.get("stcg", 0):
         return {"niit", "total_tax"}
     return set()
 
@@ -44,13 +49,6 @@ def _f4_niit_stcg(backend: str, case: dict) -> set[str]:
 def _f5_graph_8959(backend: str, case: dict) -> set[str]:
     """F5: graph Form 8959 omits SE earnings."""
     if backend == "graph" and case.get("se", 0):
-        return {"addl_medicare", "total_tax"}
-    return set()
-
-
-def _f6_ots_8959_activation(backend: str, case: dict) -> set[str]:
-    """F6: OTS Form 8959 never fires with zero W-2 wages."""
-    if backend == "ots" and not case.get("w2", 0) and case.get("se", 0):
         return {"addl_medicare", "total_tax"}
     return set()
 
@@ -68,6 +66,11 @@ def _f11_ots_hoh_bracket(backend: str, case: dict) -> set[str]:
     The IRS figure (Rev. Proc. 2023-34) is $191,950; taxcalc and graph agree.
     Flat $64 overcharge above the boundary, 2024 only — the 2025 table is
     correct, so the signature is deliberately year-restricted.
+
+    This one is upstream, not ours. We vendor OpenTaxSolver unmodified, so
+    the fix belongs in an OTS release, not in a local patch to the vendored
+    source. This signature and its strict-xfail burn-in are the record of the
+    defect until an OTS release carries the correction.
     """
     if (
         backend != "ots"
@@ -143,7 +146,6 @@ SIGNATURES: list[Callable[[str, dict], set[str]]] = [
     _f3_qbi,
     _f4_niit_stcg,
     _f5_graph_8959,
-    _f6_ots_8959_activation,
     _f7_itemized_semantics,
     _f10_graph_stcg_preferential,
     _f11_ots_hoh_bracket,


### PR DESCRIPTION
Closes the OTS half of the mapping-layer bundle (`tenforty-mjv`). Two defects surfaced by the Tax-Calculator differential oracle, both ours — in the OTS orchestration layer. **The vendored OpenTaxSolver sources are untouched.**

## F4 — Form 8960 line 5a omitted short-term gains

Line 5a is *net gain from disposition of property*. Holding period is irrelevant to the net investment income tax, but line 5a was mapped from `long_term_capital_gains` alone, so NIIT came up short by 3.8% of any short-term gain.

Both gain naturals now map through a shared callable, `_capital_gain_to_8960_l5a`. The mapper appends callable results onto the same key, and line 5a is semicolon-terminated, so OTS's `GetLineF` reads the two values as a sum.

The graph backend still carries this defect, so `_f4_niit_stcg` is **narrowed** to `backend == "graph"` rather than deleted — the graph spec bundle deletes it.

## F6 — subordinate forms never fired when their input arrived as a callable

Activation counted only `int`/`float` values in the *formatted* OTS input. A mapping expressed as a callable returns a preformatted string. Form 8959 takes self-employment income that way, so a filer with SE earnings and no W-2 wages looked entirely empty and the form never ran — up to $1,368 of additional Medicare tax silently dropped.

`subordinate_form_applies` now tests the natural inputs a form consumes against its `input_map`, so a formatting decision can no longer decide whether a form runs.

## Not in scope: F11

The upstream 2024 Head-of-Household 32% bracket typo (`191150` should be `191950`) is **deliberately not fixed here**. We vendor OpenTaxSolver unmodified — no edits to release sources or the generated amalgamation, and no correcting patch function in `ots/amalgamate.py`. It goes upstream as a bug report (`tenforty-909`) and stays recorded as the `_f11_ots_hoh_bracket` signature plus its strict xfail, which flips on its own once an OTS release carries the correction.

## Verification

- `678 passed, 11 skipped, 30 xfailed` — full suite, pre-commit hooks clean.
- Flips three strict-xfail burn-ins: `test_ots_niit_includes_short_term_gains`, `test_ots_additional_medicare_fires_without_wages`, and the graph-side F4 case stays xfailed.
- `form_8960` / `short_term_capital_gains` inventory row flipped to `mapped` for OTS.
- Ledger updated for F4, F6, F11.

## Filed while working this

- `tenforty-z31` (F15) — the opt-in `TENFORTY_ORACLE=1` differential suite has a **pre-existing** unexcused `taxable_income` divergence on `main` (verified independently of this branch). CI never sets `TENFORTY_ORACLE`, so it has never run there.
- `tenforty-sbb` — PR #268 hand-edited the generated `ots_amalgamation.cpp` without a patch function, so any regeneration silently reverts it. Being addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)