### PR TITLE
build: reproduce the AZ Widow(er) bounds fix in the generator, not by hand

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,2 +1,7 @@
 [default.extend-words]
+# "Ded" abbreviates "Deduction" in upstream OpenTaxSolver identifiers such as
+# getAZStdDedAmt. typos splits identifiers into words, reads "Ded" as a
+# misspelling of "Dead", and rewrites the symbol — silently corrupting quoted
+# upstream source.
+Ded = "Ded"
 ND = "ND"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,43 @@ pick up the same content. It follows the [AGENTS.md](https://agents.md) conventi
 - **Never force-push** `main` or any branch with an open PR.
 - Run the relevant quality gates before requesting review.
 
+## Vendored OpenTaxSolver is not ours to edit
+
+We **vendor** OpenTaxSolver, we do not fork it. Never change what OTS computes —
+not the release tarballs, not the generated `ots_amalgamation.cpp`, and not
+through a patch function in `ots/amalgamate.py`. This holds even when the defect
+is proven and the fix is one character.
+
+When you find a defect in OTS's tax logic:
+
+1. Report it upstream. Stage the report in `docs/upstream-ots-defects.md`.
+2. Record it locally as a **strict-xfail** test plus a known-defect signature in
+   `tests/oracle/oracle_policy.py`. The xfail is the durable record and flips on
+   its own once a release carries the correction.
+
+Patching the vendored source instead would fork it invisibly: our tree would
+silently diverge from the upstream we claim to wrap, with nothing in the OTS
+release to show for it.
+
+**The narrow exception is portability and memory safety** — making the source
+compile and not read out of bounds, without changing any computed figure. The
+existing patch functions are of this kind: C99→C++ shims, and
+`patch_az_widow_std_deduction` for an out-of-bounds array read. Anything in this
+category still gets reported upstream, and the patch function carries a docstring
+saying why it qualifies.
+
+Before deciding a finding is upstream's, check whether it is actually **ours**:
+the mapping layer (`models.py` input maps, `core.py` activation and
+orchestration) is our code and gets fixed here.
+
+Two traps worth knowing:
+
+- `ots_amalgamation.cpp` is the only `.cpp` the generator emits and the only one
+  compiled — every `.pxd` points at it. The 114 per-year `ots_YYYY_*.cpp` files
+  are stale and carry unpatched sources; don't read them as live.
+- Editing a generated file without a matching patch function means the next
+  regeneration silently reverts you. Change `ots/amalgamate.py`, then regenerate.
+
 ## Overview
 
 Python library for US federal and state tax computation. Two backends:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ is proven and the fix is one character.
 
 When you find a defect in OTS's tax logic:
 
-1. Report it upstream. Stage the report in `docs/upstream-ots-defects.md`.
+1. Report it upstream. Stage the report in `docs/upstream-ots-reports.md`.
 2. Record it locally as a **strict-xfail** test plus a known-defect signature in
    `tests/oracle/oracle_policy.py`. The xfail is the durable record and flips on
    its own once a release carries the correction.

--- a/docs/upstream-ots-defects.md
+++ b/docs/upstream-ots-defects.md
@@ -1,0 +1,119 @@
+# Upstream OpenTaxSolver defect reports
+
+tenforty vendors OpenTaxSolver unmodified. When we find a defect in OTS itself
+we report it upstream rather than patching our copy — see `AGENTS.md`. This
+file is the staging area for those reports: what we found, how we verified it,
+and the text to send.
+
+**Status: drafted, not sent.** Sending is Mike's, in his own time.
+
+Maintainer: Aston Roberts (OpenTaxSolver).
+
+---
+
+## 1. 2024 Head-of-Household 32% bracket floor is $191,150; should be $191,950
+
+**Release:** OpenTaxSolver2024_22.06
+**Files:**
+- `src/taxsolve_US_1040_2024.c:84`
+- `src/taxsolve_f2210_2024.c:55` (second copy of the same table)
+- `src/archive/taxsolve_US_1040_2024_01_07_2025.c:84`
+
+The Head-of-Household row of `brkpt` begins the 32% bracket at `191150.0`:
+
+```c
+{ 0.0,  11600.0,  47150.0, 100525.0, 191950.0, 243725.0, 609350.0, 9e19 },  /* Single */
+{ 0.0,  23200.0,  94300.0, 201050.0, 383900.0, 487450.0, 731201.0, 9e19 },  /* Married, filing jointly. */
+{ 0.0,  11600.0,  47150.0, 100525.0, 191950.0, 243725.0, 365600.0, 9e19 },  /* Married, filing separate. */
+{ 0.0,  16550.0,  63100.0, 100500.0, 191150.0, 243700.0, 609350.0, 9e19 },  /* Head of Household. */
+```
+
+IRS Rev. Proc. 2023-34 puts the 2024 Head-of-Household 32% bracket at
+**$191,950** — the same figure Single and Married-filing-separately already
+carry correctly in the rows above. It looks like a digit transposition
+(191,150 vs 191,950) confined to the one row.
+
+Two details that support this reading:
+
+- The **same file's AMT worksheet** already uses `191950.0` for Head of
+  Household, so the release contradicts itself internally.
+- The **2025 table is correct**, so this is isolated to 2024.
+
+**Effect:** a flat **$64.00** overcharge (32% − 24% = 8%, applied to the $800
+of income misclassified into the higher bracket) on every 2024
+Head-of-Household return with taxable income at or above the true boundary.
+
+**How we found it:** differential testing against two independent engines. Both
+the PSL Tax-Calculator and our own independent implementation produce the IRS
+figure; OTS was the odd one out, and the revenue procedure confirmed the
+majority. Bisecting OTS's marginal rate locates the boundary at exactly
+$191,150.
+
+Note the fix is needed in **two** places — `taxsolve_f2210_2024.c` carries its
+own copy of the 2024 rate table with the same bad row.
+
+---
+
+## 2. `getAZStdDedAmt()` reads out of bounds for Widow(er) filers
+
+**Releases:** OpenTaxSolver2023_21.06, OpenTaxSolver2024_22.06, OpenTaxSolver2025_23.06
+**Files:**
+- `src/taxsolve_AZ_140_2023.c:32`
+- `src/taxsolve_AZ_140_2024.c:50`
+- `src/taxsolve_AZ_140_2025.c:50`
+
+```c
+double getAZStdDedAmt()
+{
+	double azStdDedAmt[5][1]={				/* Updated for 2024. */
+			{0.0},
+			{ 14600.0 },  /* Single */
+			{ 29200.0 },  /* Married, filing jointly. */
+			{ 14600.0 },  /* Married, filing separate. */
+			{ 21900.0 }   /* Head of Household. */
+			     };
+	return azStdDedAmt[status][0];
+}
+```
+
+The table has five rows (valid indices 0–4) and is indexed by `status`. But
+`WIDOW` is **5** (`taxsolve_get_fed_return_data.c:41`), and
+`taxsolve_get_fed_return_data.c:541` assigns `status = WIDOW` whenever the
+federal return says `Widow`. So an Arizona return for a qualifying widow(er)
+reads one element past the end of the array.
+
+This is undefined behaviour, and it behaves like it. Building the identical
+source on two platforms, the read returned:
+
+| platform | value returned | resulting AZ state taxable income, 2024, $50k W-2 |
+|---|---|---|
+| Linux (x86-64) | `0.0` | `$50,000.00` — the standard deduction silently vanishes |
+| macOS | garbage | `1.583028576620421e+85` |
+
+Correct result for that return is `$28,100.00` of state taxable income
+(`$702.50` tax), using the Head-of-Household deduction.
+
+**Suggested fix:** add a sixth row carrying the Head-of-Household amount.
+Arizona Form 140 has no Widow(er) checkbox — AZ DOR instructions have a
+qualifying widow(er) file as Head of Household, and the form's own checkbox
+logic in the same file (`taxsolve_AZ_140_2024.c:193`) handles only MFJ, HoH,
+MFS and Single, with no Widow(er) branch. So Head of Household is both the
+in-bounds fix and the substantively correct figure:
+
+```c
+	double azStdDedAmt[6][1]={				/* Updated for 2024. */
+			{0.0},
+			{ 14600.0 },  /* Single */
+			{ 29200.0 },  /* Married, filing jointly. */
+			{ 14600.0 },  /* Married, filing separate. */
+			{ 21900.0 },  /* Head of Household. */
+			{ 21900.0 }   /* Widow(er) - AZ maps QW to HoH. */
+			     };
+```
+
+The same shape applies to 2023 (`20800.0`) and 2025 (`23625.0`).
+
+**Note on our copy:** because this one is a memory-safety defect rather than a
+tax-logic disagreement, we do apply it locally, as a narrow and documented
+exception, via `patch_az_widow_std_deduction` in `ots/amalgamate.py`. We would
+much rather drop that patch and track the release.

--- a/docs/upstream-ots-reports.md
+++ b/docs/upstream-ots-reports.md
@@ -1,6 +1,6 @@
-# Upstream OpenTaxSolver defect reports
+# Upstream OpenTaxSolver reports
 
-tenforty vendors OpenTaxSolver unmodified. When we find a defect in OTS itself
+tenforty vendors OpenTaxSolver unmodified. When we find an issue in OTS itself
 we report it upstream rather than patching our copy — see `AGENTS.md`. This
 file is the staging area for those reports: what we found, how we verified it,
 and the text to send.

--- a/ots/amalgamate.py
+++ b/ots/amalgamate.py
@@ -533,6 +533,47 @@ def patch_sched1a_line29_label(lines: list[str]) -> list[str]:
     return lines
 
 
+def patch_az_widow_std_deduction(lines: list[str]) -> list[str]:
+    """Extend ``getAZStdDedAmt``'s table so Widow(er) is in bounds.
+
+    ``azStdDedAmt`` is declared ``[5][1]`` and indexed by filing status, but
+    ``WIDOW`` is 5 — one past the end — so an AZ Widow(er) return reads
+    whatever follows the array. The result is undefined and platform-
+    dependent: 0.0 on one build (the standard deduction silently vanishes),
+    1.58e85 on another. Add a sixth row carrying the Head-of-Household
+    amount, which is the correct figure anyway: AZ Form 140 has no Widow(er)
+    box, and AZ DOR instructions have a qualifying widow(er) file as Head of
+    Household.
+
+    This is a memory-safety fix, not a tax-logic change — the same category
+    as the C99/C++ compatibility shims above, which also exist to make the
+    vendored source usable rather than to alter what it computes. It is a
+    deliberate, narrow exception to the rule that vendored OpenTaxSolver
+    source is never modified, and it is reported upstream (see
+    docs/upstream-ots-defects.md).
+
+    Applied by hand to the generated amalgamation in PR #268; reproduced here
+    so that regenerating the bindings does not silently revert it.
+    """
+    hoh_row = re.compile(r"^(\s*)\{ ([\d.]+) \}\s*(/\* Head of Household\. \*/)$")
+    out = []
+    in_short_table = False
+    for line in lines:
+        if "azStdDedAmt[5][1]" in line:
+            in_short_table = True
+            out.append(line.replace("azStdDedAmt[5][1]", "azStdDedAmt[6][1]"))
+            continue
+        match = hoh_row.match(line) if in_short_table else None
+        if match is None:
+            out.append(line)
+            continue
+        indent, amount, comment = match.groups()
+        out.append(f"{indent}{{ {amount} }},  {comment}")
+        out.append(f"{indent}{{ {amount} }}   /* Widow(er) - AZ maps QW to HoH. */")
+        in_short_table = False
+    return out
+
+
 def patch_restrict_keyword(lines: list[str]) -> list[str]:
     """Translate C99 ``restrict`` to the GCC/Clang ``__restrict__`` extension.
 
@@ -656,6 +697,8 @@ def postprocess_source_groups(
             case _:
                 group["source"] = patch_exit_to_return(group["source"])
                 group["source"] = patch_reset_globals(group["source"])
+                if "AZ_140" in inner_key:
+                    group["source"] = patch_az_widow_std_deduction(group["source"])
                 if "OR_40" in inner_key:
                     group["source"] = patch_show_fname_init_or_40(group["source"])
                 if "US_1040" in inner_key:

--- a/ots/amalgamate.py
+++ b/ots/amalgamate.py
@@ -550,7 +550,7 @@ def patch_az_widow_std_deduction(lines: list[str]) -> list[str]:
     vendored source usable rather than to alter what it computes. It is a
     deliberate, narrow exception to the rule that vendored OpenTaxSolver
     source is never modified, and it is reported upstream (see
-    docs/upstream-ots-defects.md).
+    docs/upstream-ots-reports.md).
 
     Applied by hand to the generated amalgamation in PR #268; reproduced here
     so that regenerating the bindings does not silently revert it.


### PR DESCRIPTION
Addresses `tenforty-sbb`. Supersedes #290, which took the other branch of the decision.

## The trap

PR #268 fixed an out-of-bounds read in OpenTaxSolver's `getAZStdDedAmt()` by editing the **generated** `ots_amalgamation.cpp` directly, with no corresponding patch function in `ots/amalgamate.py`.

That made the fix invisible to the generator. Running

```
python ots/amalgamate.py ots/ots-releases/*.tgz && make -C ots install
```

silently reverted it and restored the defect, with nothing to signal that anything had been lost. This was found by regenerating during unrelated work and diffing the result.

## The defect

`getAZStdDedAmt()` declares `azStdDedAmt[5][1]` and indexes it by filing status, but `WIDOW` is `5` — one past the end. `taxsolve_get_fed_return_data.c:541` assigns `status = WIDOW` whenever the federal return says `Widow`, so every AZ Widow(er) return reads past the array.

The read is undefined and behaves like it:

| platform | value | 2024 AZ Widow(er), $50k W-2 → state taxable income |
|---|---|---|
| Linux | `0.0` | `$50,000.00` — deduction silently vanishes |
| macOS | garbage | `1.583028576620421e+85` |

Correct is `$28,100.00`. That platform split is not hypothetical — it is why #290's revert went red on `validate (macos-latest, 3.12)` while nine other jobs passed.

`patch_az_widow_std_deduction` now adds the sixth row during amalgamation, carrying the Head-of-Household amount. That is the correct figure regardless: AZ Form 140 has no Widow(er) checkbox, AZ DOR instructions have a qualifying widow(er) file as Head of Household, and the form's own checkbox logic (`taxsolve_AZ_140_2024.c:193`) has no Widow(er) branch.

## Why a patch function is allowed here

This is a **memory-safety** fix, not a tax-logic change — the same category as the existing C99→C++ compatibility shims, which also exist to make the vendored source usable rather than to alter what it computes. It stays a narrow, documented exception, and it still gets reported upstream.

## Verification

**No generated file changes in this PR.** That is the point: `amalgamate.py` over the release tarballs now emits `ots_amalgamation.cpp` byte-for-byte as checked in. Regeneration is reproducible again, and #268's regression test keeps passing.

`676 passed, 11 skipped, 32 xfailed` — identical to `main`'s baseline. Hooks clean.

## Also here

- **`AGENTS.md` gains the vendoring policy**, which was previously unwritten — what we never touch, the narrow portability/memory-safety exception, how to tell an upstream defect from one in our own mapping layer, and two traps: the 114 stale per-year `.cpp` files that are neither generated nor compiled, and the "edit a generated file and the next regeneration reverts you" failure mode this PR is about.
- **`docs/upstream-ots-reports.md`** stages the upstream reports — this defect and the 2024 Head-of-Household bracket typo (F11) — with exact files, line numbers, verification, and suggested patches. **Drafted, not sent; sending is Mike's** (`tenforty-909`).
- **`.typos.toml` pins `Ded`** — typos splits identifiers into words, read it as a misspelling of "Dead", and rewrote `getAZStdDedAmt` inside quoted upstream source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)