### PR TITLE
docs: correct the corroborating citation in the F11 upstream report

### DIFF
--- a/docs/upstream-ots-reports.md
+++ b/docs/upstream-ots-reports.md
@@ -35,9 +35,18 @@ carry correctly in the rows above. It looks like a digit transposition
 
 Two details that support this reading:
 
-- The **same file's AMT worksheet** already uses `191950.0` for Head of
-  Household, so the release contradicts itself internally.
-- The **2025 table is correct**, so this is isolated to 2024.
+- **The same file already uses $191,950 for Head of Household elsewhere.** In
+  `sched_D_tax_worksheet()`, the step that caps income at the start of the 32%
+  bracket reads:
+
+  ```c
+  case HEAD_OF_HOUSEHOLD:                     ws[19] = smallerof( ws[1], 191950.0 );  break;
+  ```
+
+  (`taxsolve_US_1040_2024.c:1473`). So the release carries both figures for the
+  same boundary — the correct one in the worksheet, the transposed one in the
+  bracket table.
+- **The 2025 table is correct**, so this is isolated to 2024.
 
 **Effect:** a flat **$64.00** overcharge (32% − 24% = 8%, applied to the $800
 of income misclassified into the higher bracket) on every 2024
@@ -96,7 +105,7 @@ Correct result for that return is `$28,100.00` of state taxable income
 **Suggested fix:** add a sixth row carrying the Head-of-Household amount.
 Arizona Form 140 has no Widow(er) checkbox — AZ DOR instructions have a
 qualifying widow(er) file as Head of Household, and the form's own checkbox
-logic in the same file (`taxsolve_AZ_140_2024.c:193`) handles only MFJ, HoH,
+logic in the same file (`taxsolve_AZ_140_2024.c:194`) handles only MFJ, HoH,
 MFS and Single, with no Widow(er) branch. So Head of Household is both the
 in-bounds fix and the substantively correct figure:
 


### PR DESCRIPTION
Found while reviewing #291 after it merged. Small but worth fixing before the report goes out (`tenforty-909`).

## The error

The report claimed the same file's **AMT worksheet** already uses `191950.0` for Head of Household. That was a misidentification — the code is `sched_D_tax_worksheet()`, the **Schedule D Tax Worksheet**, and has nothing to do with the alternative minimum tax.

2024's AMT figures are nowhere near $191,950 (exemption $85,700; phase-in begins $609,350). A maintainer checking that sentence would have found it wrong — in a report whose whole purpose is to be checked.

## The correction is stronger than the original

`taxsolve_US_1040_2024.c:1473`:

```c
case HEAD_OF_HOUSEHOLD:                     ws[19] = smallerof( ws[1], 191950.0 );  break;
```

That caps Head-of-Household income at the **start of the 32% bracket** — the same boundary the `brkpt` table gets wrong at line 84. So the release carries both figures for one quantity: correct in the worksheet, transposed in the table. That is better evidence of a typo than a coincidental match in an unrelated computation would have been.

## Everything else re-verified

Re-checked against the release tarballs rather than from memory:

| claim | status |
|---|---|
| `taxsolve_US_1040_2024.c:84` — bad HoH row | ✅ |
| `taxsolve_f2210_2024.c:55` — second copy | ✅ |
| `archive/taxsolve_US_1040_2024_01_07_2025.c:84` | ✅ |
| 2025 table clean (no `191150`) | ✅ |
| AZ decl lines: 2023 `:32`, 2024 `:50`, 2025 `:50` | ✅ |
| AZ HoH amounts: `20800.0` / `21900.0` / `23625.0` | ✅ |
| `WIDOW` = 5 (`taxsolve_get_fed_return_data.c:41`) | ✅ |
| `status = WIDOW` (`…get_fed_return_data.c:541`) | ✅ |
| $64 = 8% × ($191,950 − $191,150) | ✅ |
| AZ filing-status branches at `:193` | ⚠️ tightened to `:194` — `:193` is the comment above them |

Docs only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)