### PR TITLE
docs: adjudicate F14 — OTS appears to match Form 6251; taxcalc and our graph spec appear to diverge

### DIFF
--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -190,22 +190,16 @@ $43,813.50; taxcalc and the graph spec both compute $39,725.50 — agreeing
 to the penny — and the $4,088 gap is exactly 28% x $14,600, the standard
 deduction. Form 6251 line 2a instructs non-itemizers to add the standard
 deduction back into AMTI, which is what OTS does. If the form walkthrough
-<<<<<<< HEAD
-and a TAXSIM cross-check confirm that reading, this is the first *reference-implementation*
-defect found by the suite — shared by our own graph spec — and the excusing
-signature flips from OTS to graph, with an upstream report to PSL. The
-=======
 and a TAXSIM cross-check support that reading, this would be the first time
-the suite has turned up something in an *oracle* — apparently shared by our
-own graph spec — and the excusing signature flips from OTS to graph, with a
-note raised upstream to PSL. The
->>>>>>> 618afc8 (docs: soften the F14 write-up from verdict to question)
+the suite has turned up something in a *reference implementation* — apparently
+shared by our own graph spec — and the excusing signature flips from OTS to
+graph, with a note raised upstream to PSL. The
 suspects agreeing to the penny is itself evidence of a shared modeling
 choice rather than independent correctness.
 
 **ADJUDICATED — OTS appears to match Form 6251; taxcalc and our graph spec
 both appear to diverge from it.** As best we can tell this is the first time
-the suite has turned up something in an *oracle* rather than in us.
+the suite has turned up something in a *reference implementation* rather than in us.
 
 Four lines of evidence, which agree with each other:
 
@@ -266,7 +260,7 @@ to compute the law rather than to match an aggregate.
 Found while adjudicating F14. `scripts/taxcalc_audit.py` — the probe that
 found F14 — correctly carries the ISO spread to taxcalc as `cmbtp`. The
 adapter that shipped into the suite, `taxcalc_batch` in
-`tests/oracle/taxcalc_differential_test.py`, does not: it builds its record
+`tests/taxcalc/taxcalc_differential_test.py`, does not: it builds its record
 without `cmbtp`, so taxcalc is handed no AMT preference at all. Through the
 suite, the F14 case returns taxcalc AMT `$0.00` rather than `$39,725.50`,
 and feeding `iso=200_000` or `iso=0` produces identical output.

--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -30,7 +30,8 @@ delete the signature, and update this table in the same PR.
 | F11 | 2024 HoH 32% bracket starts \$191,150, not \$191,950 | upstream OpenTaxSolver | adjudicated vs IRS; upstream report pending | differential grid |
 | F12 | Itemized-deduction category changes AMT | API (input model v2) | open (design) | adversarial search |
 | F13 | 2025 MFS long-term-gain thresholds high | graph spec (suspect) | open | differential grid |
-| F14 | AMT std-deduction add-back divergence (ISO cases) | taxcalc + graph (suspect) | open, adjudication pending | H_amt stratum |
+| F14 | AMT std-deduction add-back divergence (ISO cases) | **taxcalc + graph (confirmed)** | adjudicated: OTS correct; fix graph, report taxcalc | H_amt stratum |
+| F16 | Suite adapter drops `iso`, so taxcalc sees no AMT preference | taxcalc harness | fixed (#295) | F14 adjudication |
 | F17 | Graph charges SE tax below the \$400 de-minimis floor | graph spec | open (tenforty-dw0) | differential sweep |
 
 ## Method
@@ -194,6 +195,63 @@ defect found by the suite — shared by our own graph spec — and the excusing
 signature flips from OTS to graph, with an upstream report to PSL. The
 suspects agreeing to the penny is itself evidence of a shared modeling
 choice rather than independent correctness.
+
+**ADJUDICATED — OTS is right; taxcalc and the graph spec are both wrong.**
+This is the first confirmed defect in an oracle, found by the suite.
+
+Four independent lines of evidence, all agreeing:
+
+1. **Form 6251 walkthrough.** AGI $150,000; standard deduction $14,600;
+   regular taxable income $135,400. Line 2a adds the standard deduction back,
+   so AMTI = $135,400 + $14,600 + $200,000 = **$350,000** — equivalently
+   AGI + preference, which is the point of the add-back. Exemption $85,700
+   (no phase-out below $609,350), base $264,300, TMT = 26% x $232,600 +
+   28% x $31,700 = $69,352. Regular tax $25,538.50. AMT = **$43,813.50** —
+   exactly OTS.
+2. **IRS instructions for line 2a**, verbatim: *"If you aren't filing
+   Schedule A (Form 1040), then enter the standard deduction amount that you
+   reported on Form 1040 or 1040-SR, line 12e."* It is an addition in Part I.
+   (Line references shift by form year; the rule is long-standing.)
+3. **taxcalc source.** `calcfunctions.py` computes, for non-itemizers,
+   `c62100 = c00100 - e00700 - qbided - standard` — AGI less the standard
+   deduction, with no add-back. Reproduced directly: feeding `cmbtp=200000`
+   with the standard deduction yields AMTI $335,400 where $350,000 is
+   correct, short by exactly the $14,600 standard deduction, and AMT
+   $39,725.50.
+4. **Internal inconsistency in taxcalc itself.** Its *itemizer* branch
+   subtracts deductions and then adds back the AMT-disallowed ones (SALT,
+   misc, excess medical) — correct. Its non-itemizer branch subtracts the
+   standard deduction and adds back nothing, treating a 100%-disallowed
+   deduction as though it were allowed. Holding AGI and the preference fixed
+   and varying only the deduction makes the asymmetry plain: $30,000 of pure
+   charity (allowed for AMT) gives the correct AMTI $320,000, while the
+   $14,600 standard deduction gives $335,400 instead of $350,000.
+
+The correct fix upstream is to drop the `- standard` term, since the
+standard deduction is entirely disallowed for AMT:
+`c62100 = c00100 - e00700 - qbided`.
+
+Consequences: the excusing signature flips from `ots` to `graph`; the graph
+spec needs the add-back; goldens regenerate; and an upstream report goes to
+PSLmodels/Tax-Calculator (drafted in `docs/upstream-taxcalc-reports.md`).
+The two suspects agreeing to the penny was the tell, and it held up.
+
+### F16. NEW — the suite's taxcalc adapter drops `iso`, so taxcalc sees no AMT preference
+
+Found while adjudicating F14. `scripts/taxcalc_audit.py` — the probe that
+found F14 — correctly carries the ISO spread to taxcalc as `cmbtp`. The
+adapter that shipped into the suite, `taxcalc_batch` in
+`tests/oracle/taxcalc_differential_test.py`, does not: it builds its record
+without `cmbtp`, so taxcalc is handed no AMT preference at all. Through the
+suite, the F14 case returns taxcalc AMT `$0.00` rather than `$39,725.50`,
+and feeding `iso=200_000` or `iso=0` produces identical output.
+
+Currently **latent**: `_case_strategy()` does not generate `iso`, so no
+running test compares an AMT-preference case. That is exactly why it is
+dangerous — the moment AMT coverage is added (which `tenforty-y90` plans),
+every such case would compare tenforty *with* the preference against taxcalc
+*without* it, manufacturing large bogus divergences on both backends and
+burying any real one. Fix the adapter before adding the coverage.
 
 ### F7. Itemization semantics diverge between backends
 

--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -30,7 +30,7 @@ delete the signature, and update this table in the same PR.
 | F11 | 2024 HoH 32% bracket starts \$191,150, not \$191,950 | upstream OpenTaxSolver | adjudicated vs IRS; upstream report pending | differential grid |
 | F12 | Itemized-deduction category changes AMT | API (input model v2) | open (design) | adversarial search |
 | F13 | 2025 MFS long-term-gain thresholds high | graph spec (suspect) | open | differential grid |
-| F14 | AMT std-deduction add-back divergence (ISO cases) | **taxcalc + graph (confirmed)** | adjudicated: OTS correct; fix graph, report taxcalc | H_amt stratum |
+| F14 | AMT std-deduction add-back divergence (ISO cases) | taxcalc + graph (both, apparently) | adjudicated: OTS matches the form; fix graph, ask taxcalc | H_amt stratum |
 | F16 | Suite adapter drops `iso`, so taxcalc sees no AMT preference | taxcalc harness | fixed (#295) | F14 adjudication |
 | F17 | Graph charges SE tax below the \$400 de-minimis floor | graph spec | open (tenforty-dw0) | differential sweep |
 
@@ -190,16 +190,24 @@ $43,813.50; taxcalc and the graph spec both compute $39,725.50 — agreeing
 to the penny — and the $4,088 gap is exactly 28% x $14,600, the standard
 deduction. Form 6251 line 2a instructs non-itemizers to add the standard
 deduction back into AMTI, which is what OTS does. If the form walkthrough
+<<<<<<< HEAD
 and a TAXSIM cross-check confirm that reading, this is the first *reference-implementation*
 defect found by the suite — shared by our own graph spec — and the excusing
 signature flips from OTS to graph, with an upstream report to PSL. The
+=======
+and a TAXSIM cross-check support that reading, this would be the first time
+the suite has turned up something in an *oracle* — apparently shared by our
+own graph spec — and the excusing signature flips from OTS to graph, with a
+note raised upstream to PSL. The
+>>>>>>> 618afc8 (docs: soften the F14 write-up from verdict to question)
 suspects agreeing to the penny is itself evidence of a shared modeling
 choice rather than independent correctness.
 
-**ADJUDICATED — OTS is right; taxcalc and the graph spec are both wrong.**
-This is the first confirmed defect in an oracle, found by the suite.
+**ADJUDICATED — OTS appears to match Form 6251; taxcalc and our graph spec
+both appear to diverge from it.** As best we can tell this is the first time
+the suite has turned up something in an *oracle* rather than in us.
 
-Four independent lines of evidence, all agreeing:
+Four lines of evidence, which agree with each other:
 
 1. **Form 6251 walkthrough.** AGI $150,000; standard deduction $14,600;
    regular taxable income $135,400. Line 2a adds the standard deduction back,
@@ -212,29 +220,46 @@ Four independent lines of evidence, all agreeing:
    Schedule A (Form 1040), then enter the standard deduction amount that you
    reported on Form 1040 or 1040-SR, line 12e."* It is an addition in Part I.
    (Line references shift by form year; the rule is long-standing.)
-3. **taxcalc source.** `calcfunctions.py` computes, for non-itemizers,
+3. **taxcalc source.** For non-itemizers `calcfunctions.py` computes
    `c62100 = c00100 - e00700 - qbided - standard` — AGI less the standard
-   deduction, with no add-back. Reproduced directly: feeding `cmbtp=200000`
-   with the standard deduction yields AMTI $335,400 where $350,000 is
-   correct, short by exactly the $14,600 standard deduction, and AMT
-   $39,725.50.
-4. **Internal inconsistency in taxcalc itself.** Its *itemizer* branch
-   subtracts deductions and then adds back the AMT-disallowed ones (SALT,
-   misc, excess medical) — correct. Its non-itemizer branch subtracts the
-   standard deduction and adds back nothing, treating a 100%-disallowed
-   deduction as though it were allowed. Holding AGI and the preference fixed
-   and varying only the deduction makes the asymmetry plain: $30,000 of pure
-   charity (allowed for AMT) gives the correct AMTI $320,000, while the
-   $14,600 standard deduction gives $335,400 instead of $350,000.
+   deduction, with no add-back that we could find. Reproduced directly:
+   feeding `cmbtp=200000` with the standard deduction yields AMTI $335,400
+   against the $350,000 we expected, short by exactly the $14,600 standard
+   deduction, and AMT $39,725.50.
+4. **The two taxcalc branches seem inconsistent with each other.** The
+   *itemizer* branch subtracts deductions and then adds back the
+   AMT-disallowed ones (SALT, misc, excess medical), which matches our
+   reading of the form. The non-itemizer branch subtracts the standard
+   deduction and adds back nothing. Holding AGI and the preference fixed and
+   varying only the deduction shows the asymmetry: $30,000 of pure charity
+   (allowed for AMT) gives $320,000, matching expectation, while the $14,600
+   standard deduction gives $335,400 where we expected $350,000.
 
-The correct fix upstream is to drop the `- standard` term, since the
-standard deduction is entirely disallowed for AMT:
-`c62100 = c00100 - e00700 - qbided`.
+If our reading is right, the upstream change would be to drop the
+`- standard` term: `c62100 = c00100 - e00700 - qbided`.
 
-Consequences: the excusing signature flips from `ots` to `graph`; the graph
-spec needs the add-back; goldens regenerate; and an upstream report goes to
-PSLmodels/Tax-Calculator (drafted in `docs/upstream-taxcalc-reports.md`).
-The two suspects agreeing to the penny was the tell, and it held up.
+**What we have not established.** Whether any of this is unintended. The
+formula was translated from an older SAS implementation, and taxcalc issue
+#37 shows someone passing over this same line in 2014 and closing it as a
+false alarm — so it may be long-standing inherited behaviour rather than an
+oversight. More importantly, `cmbtp` is built in `taxdata` from PUF records;
+if it is derived from reported AMTI it may already absorb this, in which case
+the model and its data could be consistent in aggregate and a change to
+`calcfunctions.py` alone might make published results worse. We have no
+visibility into that. The upstream note is therefore framed as a question,
+not a bug report (`docs/upstream-taxcalc-reports.md`).
+
+**A correction to our own reasoning.** The original F14 entry treated taxcalc
+and our graph spec agreeing to the penny as the tell — two engines against
+one. On reflection that agreement is weak evidence: both appear to take the
+same shortcut (start from taxable income, add preferences, skip line 2a), so
+it looks like common-mode error rather than independent corroboration. The
+statute and the form instructions are what carry the argument, not the vote.
+
+Consequences for us: the excusing signature flips from `ots` to `graph`; the
+graph spec needs the add-back; goldens regenerate. We are changing our own
+engine regardless of how the upstream question lands, since we are claiming
+to compute the law rather than to match an aggregate.
 
 ### F16. NEW — the suite's taxcalc adapter drops `iso`, so taxcalc sees no AMT preference
 

--- a/docs/upstream-taxcalc-reports.md
+++ b/docs/upstream-taxcalc-reports.md
@@ -1,0 +1,112 @@
+# Upstream Tax-Calculator reports
+
+Reports staged for [PSLmodels/Tax-Calculator](https://github.com/PSLmodels/Tax-Calculator).
+Same convention as `docs/upstream-ots-reports.md`: what we found, how we
+verified it, and the text to file.
+
+**Status: drafted, not sent.** Filing is Mike's, in his own time.
+
+---
+
+## 1. AMTI omits the Form 6251 line 2a standard-deduction add-back
+
+**Where:** `taxcalc/calcfunctions.py`, in the function that builds `c62100`
+(Form 6251 line 4).
+
+```python
+if standard > 0.0:
+    c62100 = c00100 - e00700 - qbided - standard
+```
+
+For a filer taking the standard deduction, AMTI is computed as AGI **less the
+standard deduction**. The standard deduction is not allowed against the
+alternative minimum tax, so it should not reduce AMTI.
+
+Form 6251 Part I starts from regular taxable income and adds back the items
+the AMT disallows. Line 2a, per the IRS instructions:
+
+> If you aren't filing Schedule A (Form 1040), then enter the standard
+> deduction amount that you reported on Form 1040 or 1040-SR, line 12e.
+
+It is an addition in Part I. (The exact line reference moves between form
+years; the rule itself is long-standing.)
+
+**Suggested fix** — drop the `- standard` term, since the deduction is
+entirely disallowed:
+
+```python
+if standard > 0.0:
+    c62100 = c00100 - e00700 - qbided
+```
+
+### The itemizer branch already gets this right
+
+The asymmetry is visible within the function itself. For itemizers:
+
+```python
+c62100 = (
+    c00100 - e00700 - qbided - c04470 +
+    c18300 +    # SALT add-back
+    c20800 -    # Sch A misc add-back
+    c21040 +
+    max(0., min(c17000, AMT_Medical_frt * c00100))
+)
+```
+
+That subtracts itemized deductions and then adds back the AMT-disallowed
+components, leaving the allowed ones (charity, mortgage interest) subtracted —
+correct. The non-itemizer branch subtracts its deduction and adds back
+nothing, which treats a 100%-disallowed deduction as though it were fully
+allowed.
+
+### Reproduction
+
+Single filer, 2024, $150,000 wages, $200,000 of AMT preference via `cmbtp`
+(an ISO exercise spread), taking the standard deduction:
+
+```python
+rec = {"RECID": 1, "MARS": 1, "XTOT": 1, "age_head": 40, "age_spouse": 0,
+       "e00200": 150000.0, "e00200p": 150000.0, "e00200s": 0.0,
+       "cmbtp": 200000.0}
+```
+
+| quantity | Tax-Calculator | correct |
+|---|---|---|
+| AGI (`c00100`) | 150,000.00 | 150,000.00 |
+| regular taxable income | 135,400.00 | 135,400.00 |
+| **AMTI (`c62100`)** | **335,400.00** | **350,000.00** |
+| **AMT (`c09600`)** | **39,725.50** | **43,813.50** |
+
+AMTI is short by exactly $14,600 — the 2024 single standard deduction — and
+the tax difference is $4,088 = 28% × $14,600.
+
+Hand-check: taxable income $135,400 + standard deduction $14,600 + preference
+$200,000 = AMTI $350,000. Less the $85,700 exemption (no phase-out below
+$609,350) = $264,300. TMT = 26% × $232,600 + 28% × $31,700 = $69,352. Regular
+tax $25,538.50. AMT = $43,813.50.
+
+### Holding everything else fixed, only the deduction type
+
+Same AGI, same preference; vary only the deduction:
+
+| deduction | amount | `c62100` | correct |
+|---|---|---|---|
+| standard (disallowed for AMT) | 14,600 | 335,400 | **350,000** |
+| itemized, pure charity (allowed for AMT) | 30,000 | 320,000 | 320,000 |
+
+The itemized case is right. The standard case understates AMTI by the full
+standard deduction. A filer taking the standard deduction should have *higher*
+AMTI than an otherwise-identical filer with allowed itemized deductions; here
+the standard-deduction filer is treated more favorably than the law permits.
+
+### How this was found
+
+Three-way differential testing. [tenforty](https://github.com/mmacpherson/tenforty)
+runs OpenTaxSolver and its own independent graph engine against
+Tax-Calculator as an oracle. On AMT-preference cases OTS produced $43,813.50
+while Tax-Calculator and our graph engine both produced $39,725.50 — agreeing
+to the penny. Two engines agreeing exactly, against a third, turned out to
+indicate a shared modeling choice rather than independent confirmation. The
+Form 6251 walkthrough and the IRS instructions favor the outlier.
+
+We are fixing the same defect in our own engine.

--- a/docs/upstream-taxcalc-reports.md
+++ b/docs/upstream-taxcalc-reports.md
@@ -1,68 +1,72 @@
 # Upstream Tax-Calculator reports
 
-Reports staged for [PSLmodels/Tax-Calculator](https://github.com/PSLmodels/Tax-Calculator).
-Same convention as `docs/upstream-ots-reports.md`: what we found, how we
-verified it, and the text to file.
+Questions and observations staged for
+[PSLmodels/Tax-Calculator](https://github.com/PSLmodels/Tax-Calculator). Same
+convention as `docs/upstream-ots-reports.md`: what we saw, how we checked it,
+and the text to file.
 
 **Status: drafted, not sent.** Filing is Mike's, in his own time.
 
 ---
 
-## 1. AMTI omits the Form 6251 line 2a standard-deduction add-back
+## 1. Question: is the standard deduction intentionally left in AMTI for non-itemizers?
 
-**Where:** `taxcalc/calcfunctions.py`, in the function that builds `c62100`
-(Form 6251 line 4).
+**Where:** `taxcalc/calcfunctions.py`, where `c62100` (Form 6251 line 4) is
+built.
+
+We have been using Tax-Calculator as an oracle while testing our own tax
+engines, and we ran into a difference we can't account for. We may well be
+misreading something — this is a question rather than a bug report.
+
+For a filer taking the standard deduction:
 
 ```python
 if standard > 0.0:
     c62100 = c00100 - e00700 - qbided - standard
 ```
 
-For a filer taking the standard deduction, AMTI is computed as AGI **less the
-standard deduction**. The standard deduction is not allowed against the
-alternative minimum tax, so it should not reduce AMTI.
+If we follow this correctly, AMTI comes out as AGI less the standard
+deduction. Our reading of Form 6251 is that the standard deduction should not
+reduce AMTI, so we expected the `- standard` term not to be there.
 
-Form 6251 Part I starts from regular taxable income and adds back the items
-the AMT disallows. Line 2a, per the IRS instructions:
+What we based that on:
 
-> If you aren't filing Schedule A (Form 1040), then enter the standard
-> deduction amount that you reported on Form 1040 or 1040-SR, line 12e.
+- **IRC §56(b)(1)(E)** — *"The standard deduction under section 63(c), the
+  deduction for personal exemptions under section 151, and the deduction under
+  section 642(b) shall not be allowed."*
+- **Form 6251 line 2a instructions** — *"If you aren't filing Schedule A (Form
+  1040), then enter the standard deduction amount that you reported on Form
+  1040 or 1040-SR, line 12e."* Line 1 starts from regular taxable income, which
+  already has the deduction subtracted, and 2a appears to add it back. (Line
+  references move between form years.)
 
-It is an addition in Part I. (The exact line reference moves between form
-years; the rule itself is long-standing.)
+So our expectation was `c62100 = c00100 - e00700 - qbided` for non-itemizers.
 
-**Suggested fix** — drop the `- standard` term, since the deduction is
-entirely disallowed:
+### What made us think it might be unintentional rather than a modeling choice
 
-```python
-if standard > 0.0:
-    c62100 = c00100 - e00700 - qbided
-```
-
-### The itemizer branch already gets this right
-
-The asymmetry is visible within the function itself. For itemizers:
+The itemizer branch just above handles the analogous situation the other way:
 
 ```python
 c62100 = (
     c00100 - e00700 - qbided - c04470 +
     c18300 +    # SALT add-back
-    c20800 -    # Sch A misc add-back
-    c21040 +
-    max(0., min(c17000, AMT_Medical_frt * c00100))
+    c20800 +    # Sch A misc add-back
+    ...
 )
 ```
 
 That subtracts itemized deductions and then adds back the AMT-disallowed
 components, leaving the allowed ones (charity, mortgage interest) subtracted —
-correct. The non-itemizer branch subtracts its deduction and adds back
-nothing, which treats a 100%-disallowed deduction as though it were fully
-allowed.
+which matches our reading of the form. The non-itemizer branch subtracts its
+deduction without a corresponding add-back, and the two branches seem
+inconsistent with each other. That asymmetry is really what prompted this
+question; if the non-itemizer treatment is deliberate, we couldn't find the
+reasoning and would be glad to understand it.
 
-### Reproduction
+### What we observed
 
-Single filer, 2024, $150,000 wages, $200,000 of AMT preference via `cmbtp`
-(an ISO exercise spread), taking the standard deduction:
+Single filer, 2024, $150,000 wages, $200,000 of AMT preference via `cmbtp` (an
+ISO exercise spread), taking the standard deduction:
 
 ```python
 rec = {"RECID": 1, "MARS": 1, "XTOT": 1, "age_head": 40, "age_spouse": 0,
@@ -70,43 +74,52 @@ rec = {"RECID": 1, "MARS": 1, "XTOT": 1, "age_head": 40, "age_spouse": 0,
        "cmbtp": 200000.0}
 ```
 
-| quantity | Tax-Calculator | correct |
+| quantity | Tax-Calculator | our reading of Form 6251 |
 |---|---|---|
 | AGI (`c00100`) | 150,000.00 | 150,000.00 |
 | regular taxable income | 135,400.00 | 135,400.00 |
-| **AMTI (`c62100`)** | **335,400.00** | **350,000.00** |
-| **AMT (`c09600`)** | **39,725.50** | **43,813.50** |
+| AMTI (`c62100`) | 335,400.00 | 350,000.00 |
+| AMT (`c09600`) | 39,725.50 | 43,813.50 |
 
-AMTI is short by exactly $14,600 — the 2024 single standard deduction — and
-the tax difference is $4,088 = 28% × $14,600.
+The AMTI difference is $14,600, the 2024 single standard deduction, and the tax
+difference is $4,088 = 28% × $14,600.
 
-Hand-check: taxable income $135,400 + standard deduction $14,600 + preference
-$200,000 = AMTI $350,000. Less the $85,700 exemption (no phase-out below
+Our hand-check: taxable income $135,400 + standard deduction $14,600 +
+preference $200,000 = $350,000. Less the $85,700 exemption (no phase-out below
 $609,350) = $264,300. TMT = 26% × $232,600 + 28% × $31,700 = $69,352. Regular
-tax $25,538.50. AMT = $43,813.50.
+tax $25,538.50, so AMT = $43,813.50.
 
-### Holding everything else fixed, only the deduction type
+### Varying only the deduction type
 
-Same AGI, same preference; vary only the deduction:
+Same AGI, same preference:
 
-| deduction | amount | `c62100` | correct |
+| deduction | amount | `c62100` | our expectation |
 |---|---|---|---|
-| standard (disallowed for AMT) | 14,600 | 335,400 | **350,000** |
-| itemized, pure charity (allowed for AMT) | 30,000 | 320,000 | 320,000 |
+| standard | 14,600 | 335,400 | 350,000 |
+| itemized, pure charity | 30,000 | 320,000 | 320,000 |
 
-The itemized case is right. The standard case understates AMTI by the full
-standard deduction. A filer taking the standard deduction should have *higher*
-AMTI than an otherwise-identical filer with allowed itemized deductions; here
-the standard-deduction filer is treated more favorably than the law permits.
+The itemized case matches what we expected. In the standard case, we would have
+expected the filer to end up with *higher* AMTI than the filer with $30,000 of
+allowed itemized deductions, since our reading is that the standard deduction
+doesn't carry over to AMT at all.
 
-### How this was found
+### One thing we could not check
 
-Three-way differential testing. [tenforty](https://github.com/mmacpherson/tenforty)
-runs OpenTaxSolver and its own independent graph engine against
-Tax-Calculator as an oracle. On AMT-preference cases OTS produced $43,813.50
-while Tax-Calculator and our graph engine both produced $39,725.50 — agreeing
-to the penny. Two engines agreeing exactly, against a third, turned out to
-indicate a shared modeling choice rather than independent confirmation. The
-Form 6251 walkthrough and the IRS instructions favor the outlier.
+`cmbtp` is an input built in `taxdata` rather than here. If it is derived from
+reported AMTI on PUF records, it may already absorb this, in which case the
+model and its data could be consistent in aggregate even though the formula
+read on its own doesn't match our expectation — and changing
+`calcfunctions.py` alone might make published results worse. We have no
+visibility into that, and it seems like the most likely explanation if this
+turns out to be deliberate.
 
-We are fixing the same defect in our own engine.
+### How this came up
+
+We run OpenTaxSolver and our own graph-based engine against Tax-Calculator as
+an oracle. On AMT-preference cases, OpenTaxSolver produced $43,813.50 while
+Tax-Calculator and our own engine both produced $39,725.50. We initially read
+the agreement as confirmation, but on looking at Form 6251 we think our engine
+and Tax-Calculator may simply be making the same shortcut — starting from
+taxable income and adding preferences without the line 2a step. We're changing
+our engine accordingly, and wanted to raise the question here in case it's
+relevant, or in case we've misunderstood the treatment.

--- a/docs/upstream-taxcalc-reports.md
+++ b/docs/upstream-taxcalc-reports.md
@@ -14,7 +14,7 @@ and the text to file.
 **Where:** `taxcalc/calcfunctions.py`, where `c62100` (Form 6251 line 4) is
 built.
 
-We have been using Tax-Calculator as an oracle while testing our own tax
+We have been using Tax-Calculator as a reference while testing our own tax
 engines, and we ran into a difference we can't account for. We may well be
 misreading something — this is a question rather than a bug report.
 
@@ -116,7 +116,7 @@ turns out to be deliberate.
 ### How this came up
 
 We run OpenTaxSolver and our own graph-based engine against Tax-Calculator as
-an oracle. On AMT-preference cases, OpenTaxSolver produced $43,813.50 while
+a reference. On AMT-preference cases, OpenTaxSolver produced $43,813.50 while
 Tax-Calculator and our own engine both produced $39,725.50. We initially read
 the agreement as confirmation, but on looking at Form 6251 we think our engine
 and Tax-Calculator may simply be making the same shortcut — starting from


### PR DESCRIPTION
Closes the adjudication half of `tenforty-ztx`. Documentation only — the fix is `tenforty-8ik`.

## What we found

Single 2024, $150k wages, $200k ISO spread. OTS gives AMT **$43,813.50**; Tax-Calculator and our graph spec both give **$39,725.50**. On working through Form 6251, OTS appears to be the one matching the form.

Four lines of evidence, which agree with each other:

1. **Form 6251 walkthrough.** AMTI = taxable income $135,400 + standard deduction $14,600 + preference $200,000 = $350,000 (equivalently AGI + preference). Less the $85,700 exemption = $264,300. TMT = 26%×$232,600 + 28%×$31,700 = $69,352. Regular tax $25,538.50 → **AMT $43,813.50**, matching OTS.

2. **IRC §56(b)(1)(E)** — *"The standard deduction under section 63(c) … shall not be allowed."*

3. **Form 6251 line 2a instructions** — *"If you aren't filing Schedule A (Form 1040), then enter the standard deduction amount…"* Line 1 starts from taxable income, so 2a appears to add the deduction back.

4. **taxcalc's two branches seem inconsistent with each other.** The itemizer branch subtracts deductions then adds back the AMT-disallowed ones; the non-itemizer branch subtracts and adds back nothing. Holding AGI and preference fixed:

   | deduction | amount | `c62100` | expected |
   |---|---|---|---|
   | standard | 14,600 | 335,400 | 350,000 |
   | itemized, pure charity | 30,000 | 320,000 | 320,000 |

## What we have *not* established

**Whether any of it is unintended.** The formula appears translated from an older SAS implementation, and taxcalc issue #37 shows someone passing over this same line in 2014 and closing it as a false alarm — so it may be long-standing inherited behaviour.

More importantly, **`cmbtp` is built in `taxdata` from PUF records**. If it is derived from reported AMTI it may already absorb this, in which case the model and its data could be consistent in aggregate while the formula read alone does not match our expectation — and changing `calcfunctions.py` alone might make published results worse. We have no visibility into that repo.

The upstream note is therefore written as **a question, not a bug report**.

## A correction to our own reasoning

The original F14 entry treated taxcalc and our graph spec agreeing to the penny as the tell — two engines against one. On reflection that agreement is weak evidence: both appear to take the same shortcut (start from taxable income, add preferences, skip line 2a), which looks like common-mode error rather than independent corroboration. The statute and the form instructions carry the argument; the vote does not.

## Also: F16, found while adjudicating

`scripts/taxcalc_audit.py:281` (the probe that found F14) carries the ISO spread to taxcalc as `cmbtp`. **The adapter that shipped into the suite, `taxcalc_batch`, does not.** Through the suite the F14 case returns taxcalc AMT `$0.00`, and `iso=200_000` vs `iso=0` produce identical output.

Latent today, since `_case_strategy()` generates no `iso` — which is the hazard: `tenforty-y90` plans AMT coverage, and adding it first would compare tenforty *with* the preference against taxcalc *without* it, manufacturing large bogus divergences on both backends and burying anything real. The suite also cannot currently reproduce F14 at all.

Filed as **`tenforty-g7c`**, made a blocker of `y90` and `8ik`.

## Follow-ups

- **`tenforty-8ik`** — graph spec add-back, flip the F14 signature `ots` → `graph`, regenerate goldens. We intend to change our engine regardless of how the upstream question lands, since we claim to compute the law rather than match an aggregate.
- **`tenforty-g7c`** — the adapter, before any AMT coverage.
- Upstream note drafted in `docs/upstream-taxcalc-reports.md`. **Drafted, not sent.**

## Not done

No TAXSIM-35 cross-check — it needs the NBER service. Cheap extra confirmation before raising anything upstream, if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)