### PR TITLE
fix: Form 8960 line 5a from 1040 L7 (loss-limited); activation reads indirect inputs

### DIFF
--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -27,7 +27,7 @@ delete the signature, and update this table in the same PR.
 | F8 | Cross-mode batch grid explosion | graph batch path | fix in PR #287 | benchmark |
 | F9 | Batch path bypasses TaxReturnInput | graph batch path | open | batch-conformance tests |
 | F10 | Short-term gains taxed at preferential rates | graph spec | open | differential grid |
-| F11 | 2024 HoH 32% bracket starts \$191,150, not \$191,950 | upstream OpenTaxSolver | adjudicated vs IRS; upstream report pending | differential grid |
+| F11 | 2024 HoH 32% bracket starts \$191,150, not \$191,950 | upstream OpenTaxSolver | adjudicated vs IRS; upstream report pending — not patched locally, we vendor OTS unmodified | differential grid |
 | F12 | Itemized-deduction category changes AMT | API (input model v2) | open (design) | adversarial search |
 | F13 | 2025 MFS long-term-gain thresholds high | graph spec (suspect) | open | differential grid |
 | F14 | AMT std-deduction add-back divergence (ISO cases) | taxcalc + graph (suspect) | open, adjudication pending | H_amt stratum |
@@ -181,6 +181,14 @@ an *upstream OpenTaxSolver* defect, to be reported upstream. First catch
 for the three-way adjudication method: taxcalc and the independent
 in-house engine outvoted the incumbent, and the revenue procedure confirmed
 the majority.
+
+**Not patched locally.** We vendor OpenTaxSolver unmodified — no edits to the
+release sources or to the generated amalgamation, and no correcting patch
+function in `ots/amalgamate.py`. The fix belongs in an OTS release. Until one
+carries it, the `_f11_ots_hoh_bracket` signature and its strict-xfail burn-in
+are the record; the xfail flips on its own once upstream corrects the table.
+(The same bad row is duplicated into Form 2210's copy of the 2024 rate table,
+which the upstream report should mention.)
 
 ### F12. NEW — itemized_deductions category ambiguity changes AMT
 

--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -20,9 +20,9 @@ delete the signature, and update this table in the same PR.
 | F1 | Schedule SE L8a never filled | mapping, both backends | fixed (#279, v2025.11) | @bg002h, #278 |
 | F2 | SE-tax error propagates to AGI | consequence of F1 | fixed with F1 | @bg002h, #278 |
 | F3 | QBI: missing (OTS) / gross base (graph) | OTS orchestration + graph spec | open | @bg002h, #278 |
-| F4 | Form 8960 L5a omits short-term gains | mapping, both backends | open | mapping assessment + differential sweep |
+| F4 | Form 8960 L5a omits short-term gains | mapping, both backends | fixed on OTS; open on graph | mapping assessment + differential sweep |
 | F5 | Graph Form 8959 omits SE earnings | graph mapping | open | mapping assessment + differential sweep |
-| F6 | OTS 8959 never fires with zero wages | OTS activation semantics | open | differential sweep |
+| F6 | OTS 8959 never fires with zero wages | OTS activation semantics | fixed | differential sweep |
 | F7 | "Itemized" force vs best-of divergence | API contract | open (owner decision) | differential sweep |
 | F8 | Cross-mode batch grid explosion | graph batch path | fix in PR #287 | benchmark |
 | F9 | Batch path bypasses TaxReturnInput | graph batch path | open | batch-conformance tests |
@@ -97,6 +97,20 @@ property") is mapped from `long_term_capital_gains` only —
 `models.py` OTS input_map and `mappings.py` graph fan-out both lack
 `short_term_capital_gains`. Backend parity can never catch this class.
 
+**Fixed on OTS, at a different layer than first proposed.** Line 5a is not
+reconstructed from the gain naturals; it is imported from Form 1040 line 7 via
+`fed_import_map`, which is what Form 8960 instructs. Line 7 is the Schedule D
+result, so both holding periods are already netted and the section 1211(b)
+$3,000 loss limitation is already applied — an earlier attempt that summed the
+two gain naturals onto line 5a fixed the gains but silently dropped that
+limitation, understating NIIT by up to $1,786 on a net-loss case.
+
+Line 5a intentionally carries all of line 7. Gain from property held in an
+active trade or business leaves net investment income on line 5b, not by
+filtering 5a; we map no 5b because no input can produce business-property
+gain, pinned by a strict xfail. The graph half is still open, so the
+`_f4_niit_stcg` signature is narrowed to `backend == "graph"`.
+
 ### F5. Graph omits SE earnings from Form 8959 (additional Medicare tax)
 
 145 graph flags, every one with SE income > 0. OTS maps SE earnings via
@@ -114,6 +128,14 @@ no numeric value survives and the form is skipped. Missed tax up to $1,368
 (Married/Sep, SE $300k) in the grid. A formatting decision leaked into
 activation semantics — exactly the "activation" contract dimension the
 mapping-layer assessment called out.
+
+**Fixed.** Activation is decided by `subordinate_form_applies`, which tests
+the *natural* inputs a form consumes rather than the post-format OTS values, so
+a formatting decision can no longer decide whether a form runs. Naturals that
+reach a form indirectly through `fed_import_map` are declared in
+`activation_naturals` and counted too — without that, moving Form 8960 line 5a
+to the 1040 import would have stopped the form firing for a filer whose only
+investment income is capital gains.
 
 ### F8. NEW — Graph cross-mode batch returns an exploded, misaligned grid
 

--- a/src/tenforty/core.py
+++ b/src/tenforty/core.py
@@ -25,6 +25,7 @@ from .models import (
     OTSYear,
     OutputFieldSpec,
     StrEnum,
+    SubordinateFormConfig,
     TaxReturnInput,
 )
 
@@ -386,6 +387,31 @@ def _evaluate_subordinate(
 
 ## LEVEL 1: Map from natural description, eg "w2_income", to OTS line-level
 ##          description, eg "L1a", and back.
+def subordinate_form_applies(
+    sub_cfg: SubordinateFormConfig, natural_input: dict[str, Any]
+) -> bool:
+    """Decide whether a subordinate form has any input worth evaluating.
+
+    Judged on the natural inputs the form consumes, not on the formatted OTS
+    values. A mapping expressed as a callable returns a preformatted string
+    that no numeric test can see: Form 8959 takes self-employment income that
+    way, so a filer with SE earnings and no W-2 wages used to look entirely
+    empty and the form never ran. Formatting must not decide whether a form
+    runs.
+
+    A form can also consume a natural indirectly, receiving it from the
+    federal return through `fed_import_map` — Form 8960 takes its net gain
+    from Form 1040 line 7 that way. Those naturals never appear in
+    `input_map`, so the form declares them in `activation_naturals`.
+    """
+    consumed = set(sub_cfg.input_map) | set(sub_cfg.activation_naturals)
+    return any(
+        isinstance(value, (int, float)) and value != 0
+        for key, value in natural_input.items()
+        if key in consumed
+    )
+
+
 def map_natural_to_ots_input(
     natural_input: dict[str, Any], natural_mapping: dict[str, str]
 ):
@@ -449,13 +475,11 @@ def evaluate_natural_input_form(
             continue
         if (year.value, sub_cfg.form_id) not in OTS_FORM_CONFIG:
             continue
+        if not subordinate_form_applies(sub_cfg, natural_form_values):
+            continue
         sub_form_values = sub_cfg.defaults | map_natural_to_ots_input(
             natural_form_values, sub_cfg.input_map
         )
-        if not any(
-            isinstance(v, (int, float)) and v != 0 for v in sub_form_values.values()
-        ):
-            continue
         try:
             sub_result = _evaluate_subordinate(
                 year.value, sub_cfg.form_id, sub_form_values, on_error=on_error
@@ -512,13 +536,11 @@ def evaluate_natural_input_form(
             continue
         if (year.value, sub_cfg.form_id) not in OTS_FORM_CONFIG:
             continue
+        if not subordinate_form_applies(sub_cfg, natural_form_values):
+            continue
         sub_form_values = sub_cfg.defaults | map_natural_to_ots_input(
             natural_form_values, sub_cfg.input_map
         )
-        if not any(
-            isinstance(v, (int, float)) and v != 0 for v in sub_form_values.values()
-        ):
-            continue
         federal_return = ots_output["federal"]
         for fed_key, sub_key in sub_cfg.fed_import_map.items():
             if fed_key in federal_return:

--- a/src/tenforty/models.py
+++ b/src/tenforty/models.py
@@ -271,6 +271,12 @@ class SubordinateFormConfig(BaseModel):
     output_map: dict[str, str] = {}
     total_tax_key: str | None = None
     defaults: dict[str, str] = {}
+    # Naturals this form consumes through `fed_import_map` rather than directly.
+    # Activation is decided on the inputs a form consumes, and a value arriving
+    # from the federal return is invisible to `input_map` — so without this a
+    # filer whose only investment income is capital gains would never trigger
+    # Form 8960 at all.
+    activation_naturals: list[str] = []
 
 
 OTS_FORM_CONFIG = dict(
@@ -1206,10 +1212,24 @@ _SUBORDINATE_FORM_CONFIG = [
             "taxable_interest": "L1",
             "ordinary_dividends": "L2",
             "rental_income": "L4a",
-            "long_term_capital_gains": "L5a",
             "filing_status": "Status",
         },
-        "fed_import_map": {"L11": "L13"},
+        # L5a is "net gain from disposition of property" — Form 8960 takes it
+        # from Form 1040 line 7, which is the Schedule D result with the
+        # section 1211(b) $3,000 loss limitation already applied and both
+        # holding periods already netted. Importing it is what the form
+        # instructs; reconstructing it from the gain naturals would drop the
+        # limitation and have to re-net the two terms by hand.
+        #
+        # Line 5a intentionally carries ALL of line 7. Gain from property held
+        # in an active trade or business is excluded from net investment income
+        # on line 5b, not by filtering 5a. We map no 5b because no input can
+        # produce business-property gain; add both together if one ever does.
+        "fed_import_map": {"L11": "L13", "L7": "L5a"},
+        "activation_naturals": [
+            "short_term_capital_gains",
+            "long_term_capital_gains",
+        ],
         "output_map": {"L17": "niit"},
         "total_tax_key": "L17",
         "defaults": {
@@ -1255,10 +1275,17 @@ _SUBORDINATE_FORM_CONFIG = [
             "taxable_interest": "L1",
             "ordinary_dividends": "L2",
             "rental_income": "L4a",
-            "long_term_capital_gains": "L5a",
             "filing_status": "Status",
         },
-        "fed_import_map": {"L11b": "L13"},
+        # See the 2024 Form 8960 entry for why line 5a is imported from the
+        # 1040 rather than mapped from the gain naturals. The 2025 1040 splits
+        # the capital-gain line, so the gain is on L7a here, not L7 — the same
+        # year shift as L11 -> L11b for AGI.
+        "fed_import_map": {"L11b": "L13", "L7a": "L5a"},
+        "activation_naturals": [
+            "short_term_capital_gains",
+            "long_term_capital_gains",
+        ],
         "output_map": {"L17": "niit"},
         "total_tax_key": "L17",
         "defaults": {

--- a/tests/known_defects_test.py
+++ b/tests/known_defects_test.py
@@ -13,6 +13,7 @@ where noted, against OTS driven directly).
 import pytest
 
 from tenforty import evaluate_return, evaluate_returns
+from tenforty.models import SUBORDINATE_FORM_CONFIG
 
 
 def _graph_available() -> bool:
@@ -62,7 +63,6 @@ def test_graph_qbi_uses_net_base():
     assert r.federal_taxable_income == pytest.approx(94_878.54, abs=1.0)
 
 
-@pytest.mark.xfail(reason="F4: 8960 L5a omits short-term gains (OTS)", strict=True)
 def test_ots_niit_includes_short_term_gains():
     """$300k wages + $50k STCG: NIIT is 3.8% of $50k = $1,900."""
     r = evaluate_return(
@@ -88,6 +88,61 @@ def test_graph_niit_includes_short_term_gains():
     assert r.federal_niit == pytest.approx(1_900.0, abs=1.0)
 
 
+def test_ots_niit_honors_the_capital_loss_limitation():
+    """A net capital loss offsets net investment income by at most $3,000.
+
+    Form 8960 line 5a is the amount from Form 1040 line 7, which Schedule D
+    has already capped under section 1211(b). $100k of interest against a $50k
+    short-term loss leaves $97,000 of NII, so NIIT is 3.8% x $97,000.
+    """
+    for kind in ("short_term_capital_gains", "long_term_capital_gains"):
+        r = evaluate_return(
+            year=2024,
+            filing_status="Single",
+            w2_income=300_000,
+            taxable_interest=100_000,
+            **{kind: -50_000},
+        )
+        assert r.federal_niit == pytest.approx(3_686.0, abs=1.0), kind
+
+
+def test_ots_niit_fires_when_gains_are_the_only_investment_income():
+    """Form 8960 must run when capital gains are the sole investment income.
+
+    Line 5a arrives from the federal return rather than from `input_map`, so
+    the gain naturals are invisible to a purely direct activation test. They
+    are declared in `activation_naturals` for exactly this case.
+    """
+    r = evaluate_return(
+        year=2024,
+        filing_status="Single",
+        w2_income=300_000,
+        long_term_capital_gains=50_000,
+    )
+    assert r.federal_niit == pytest.approx(1_900.0, abs=1.0)
+
+
+@pytest.mark.xfail(
+    reason="No input can express gain from property held in an active trade or "
+    "business, so Form 8960 line 5b is unmapped and all of Form 1040 line 7 "
+    "lands in net investment income",
+    strict=True,
+)
+def test_business_property_gain_can_be_excluded_from_nii():
+    """Line 5b is where non-NIIT gain leaves net investment income.
+
+    Line 5a intentionally carries all of Form 1040 line 7; gain from property
+    held in an active trade or business is then subtracted on line 5b, and OTS
+    computes L5d = L5a + L5b + L5c. We map no 5b because no natural input can
+    produce business-property gain — Form 4797 is not modelled. That makes the
+    omission harmless today and wrong the moment such an input is added, so
+    this pins the two changes together.
+    """
+    cfg = next(c for c in SUBORDINATE_FORM_CONFIG[2024] if c.form_id == "Form_8960")
+    wired = set(cfg.input_map.values()) | set(cfg.fed_import_map.values())
+    assert "L5b" in wired
+
+
 @pytest.mark.xfail(reason="F5: graph 8959 omits SE earnings", strict=True)
 @skip_if_graph_unavailable
 def test_graph_additional_medicare_includes_se_earnings():
@@ -102,7 +157,6 @@ def test_graph_additional_medicare_includes_se_earnings():
     assert r.federal_additional_medicare_tax == pytest.approx(865.57, abs=1.0)
 
 
-@pytest.mark.xfail(reason="F6: OTS 8959 never fires with zero W-2 wages", strict=True)
 def test_ots_additional_medicare_fires_without_wages():
     """$300k SE profit, no wages: additional Medicare tax is $693.45, not $0."""
     r = evaluate_return(

--- a/tests/mapping_completeness_test.py
+++ b/tests/mapping_completeness_test.py
@@ -45,7 +45,7 @@ INVENTORY = {
     ("form_8960", "ordinary_dividends"): {"ots": "mapped", "graph": "mapped"},
     ("form_8960", "long_term_capital_gains"): {"ots": "mapped", "graph": "mapped"},
     ("form_8960", "short_term_capital_gains"): {
-        "ots": "missing:F4",
+        "ots": "mapped",
         "graph": "missing:F4",
     },
     ("form_8995", "self_employment_income"): {
@@ -60,7 +60,12 @@ def _ots_mapped(form_key: str, natural: str, year: int = 2024) -> bool:
     for cfg in SUBORDINATE_FORM_CONFIG.get(year, []):
         if cfg.form_id != form_id:
             continue
-        for input_key in cfg.input_map:
+        # A form consumes a natural either directly through `input_map` or
+        # indirectly through `fed_import_map`, in which case it declares the
+        # natural in `activation_naturals`. Both are real consumer edges; only
+        # counting the direct one would report Form 8960 as having lost its
+        # capital-gain edge when it was moved to the 1040 line 7 import.
+        for input_key in (*cfg.input_map, *cfg.activation_naturals):
             if input_key == natural or DERIVED_FROM.get(input_key) == natural:
                 return True
     return False

--- a/tests/taxcalc/taxcalc_policy.py
+++ b/tests/taxcalc/taxcalc_policy.py
@@ -35,8 +35,14 @@ def _f3_qbi(backend: str, case: dict) -> set[str]:
 
 
 def _f4_niit_stcg(backend: str, case: dict) -> set[str]:
-    """F4: Form 8960 L5a omits short-term gains, both backends."""
-    if case.get("stcg", 0):
+    """F4: Form 8960 L5a omits short-term gains.
+
+    Fixed on OTS, which now imports line 5a from Form 1040 line 7 rather than
+    reconstructing it from the gain naturals. The graph spec still carries the
+    defect, so the signature is narrowed rather than deleted. Delete it with
+    the graph fix.
+    """
+    if backend == "graph" and case.get("stcg", 0):
         return {"niit", "total_tax"}
     return set()
 
@@ -44,13 +50,6 @@ def _f4_niit_stcg(backend: str, case: dict) -> set[str]:
 def _f5_graph_8959(backend: str, case: dict) -> set[str]:
     """F5: graph Form 8959 omits SE earnings."""
     if backend == "graph" and case.get("se", 0):
-        return {"addl_medicare", "total_tax"}
-    return set()
-
-
-def _f6_ots_8959_activation(backend: str, case: dict) -> set[str]:
-    """F6: OTS Form 8959 never fires with zero W-2 wages."""
-    if backend == "ots" and not case.get("w2", 0) and case.get("se", 0):
         return {"addl_medicare", "total_tax"}
     return set()
 
@@ -176,7 +175,6 @@ SIGNATURES: list[Callable[[str, dict], set[str]]] = [
     _f3_qbi,
     _f4_niit_stcg,
     _f5_graph_8959,
-    _f6_ots_8959_activation,
     _f7_itemized_semantics,
     _f10_graph_stcg_preferential,
     _f11_ots_hoh_bracket,

--- a/tests/taxcalc/taxcalc_policy.py
+++ b/tests/taxcalc/taxcalc_policy.py
@@ -67,6 +67,11 @@ def _f11_ots_hoh_bracket(backend: str, case: dict) -> set[str]:
     The IRS figure (Rev. Proc. 2023-34) is $191,950; taxcalc and graph agree.
     Flat $64 overcharge above the boundary, 2024 only — the 2025 table is
     correct, so the signature is deliberately year-restricted.
+
+    This one is upstream, not ours. We vendor OpenTaxSolver unmodified, so the
+    fix belongs in an OTS release, not in a local patch to the vendored source.
+    This signature and its strict-xfail burn-in are the record until a release
+    carries the correction.
     """
     if (
         backend != "ots"


### PR DESCRIPTION
Supersedes #289. Same two defects (F4, F6), F4 fixed at the layer Form 8960 actually names — with no capital-loss regression, because the fix inherits the limitation for free.

## F4 — Form 8960 line 5a omitted short-term gains

Line 5a is *net gain from disposition of property*; holding period is irrelevant to NIIT, but it was mapped from `long_term_capital_gains` alone, so NIIT ran 3.8% short on any short-term gain.

Form 8960 takes line 5a from **Form 1040 line 7** — the Schedule D result, with both holding periods netted and the section 1211(b) $3,000 loss limitation already applied. So line 5a is now imported via `fed_import_map` rather than reconstructed from the gain naturals.

Why this route over #289's (sum the two gain naturals onto 5a via a callable):

- **It inherits the loss limitation.** #289 summed raw naturals, which fixed gains but dropped the $3,000 cap — a $50k net loss against $100k of interest yielded NIIT on the raw $100,000, understating by up to $1,786. The L7 import yields NIIT on $97,000, correctly.
- **It fixes the long-term path too**, which #289 left carrying the same defect on the LTCG side.
- **It deletes code** rather than adding a callable, and derives 5a from the line the form names.

The 2025 1040 splits the capital-gain line, so the gain lands on `L7a`, not `L7` — the same year shift as `L11`→`L11b` for AGI. **The golden differential suite caught the 2025 miss**; without it the regression ships.

## F6 — subordinate forms never fired when input arrived as a callable

Activation counted `int`/`float` values in the *formatted* OTS input, but a callable mapping returns a preformatted string. Form 8959 takes SE income that way, so a filer with SE earnings and no W-2 wages looked empty and the form never ran. `subordinate_form_applies` now tests the *natural* inputs a form consumes.

It also honors a new `activation_naturals` list: a natural that reaches a form through `fed_import_map` (line 5a from the 1040) is invisible to `input_map`, so without this the F4 import above would stop Form 8960 firing when capital gains are the only investment income. That's the same class of bug as F6, and the two fixes share the function.

## Recorded, not fixed — pinned by strict xfail

Line 5a intentionally carries **all** of 1040 line 7. Gain from property held in an active trade or business leaves net investment income on line 5b, not by filtering 5a (OTS computes `L5d = L5a + L5b + L5c`). We map no 5b because no input can express business-property gain — Form 4797 is unmodelled. Harmless today, wrong the moment such an input is added; `test_business_property_gain_can_be_excluded_from_nii` fails until 5b is wired and flips on its own when it is.

## Verification

- **699 passed, 12 skipped, 32 xfailed.**
- Flips `test_ots_niit_includes_short_term_gains` and `test_ots_additional_medicare_fires_without_wages`; narrows `_f4_niit_stcg` to `graph`; retires `_f6_ots_8959_activation`.
- New coverage: loss-limitation on both gain paths, gains-only activation, the 5b xfail. Teeth confirmed — stripping `activation_naturals` regresses the gains-only case; the 2025 golden failure proved the `L7a` fix load-bearing.
- Inventory row `(form_8960, short_term_capital_gains)` → `mapped` for OTS.
- Ports #289's F11 note (upstream defect, not patched locally).

## Not in scope

F11 stays a documented upstream OTS defect (`tenforty-909` for the report). The graph-side F4 remains open (`_f4_niit_stcg` narrowed to `graph`, `tenforty-lpe`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)