### PR TITLE
fix: graph spec bundle — short-term gains, MFS ceiling, 8959 SE, 8960 5a, SE de-minimis

### DIFF
--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -20,16 +20,16 @@ delete the signature, and update this table in the same PR.
 | F1 | Schedule SE L8a never filled | mapping, both backends | fixed (#279, v2025.11) | @bg002h, #278 |
 | F2 | SE-tax error propagates to AGI | consequence of F1 | fixed with F1 | @bg002h, #278 |
 | F3 | QBI: missing (OTS) / gross base (graph) | OTS orchestration + graph spec | open | @bg002h, #278 |
-| F4 | Form 8960 L5a omits short-term gains | mapping, both backends | fixed on OTS; open on graph | mapping assessment + differential sweep |
-| F5 | Graph Form 8959 omits SE earnings | graph mapping | open | mapping assessment + differential sweep |
+| F4 | Form 8960 L5a omits short-term gains | mapping, both backends | fixed (OTS #296, graph: L5a imports Schedule D L16) | mapping assessment + differential sweep |
+| F5 | Graph Form 8959 Part II drops SE earnings (line 12 used min, not subtract) | graph spec | fixed | mapping assessment + differential sweep |
 | F6 | OTS 8959 never fires with zero wages | OTS activation semantics | fixed | differential sweep |
 | F7 | "Itemized" force vs best-of divergence | API contract | open (owner decision) | differential sweep |
 | F8 | Cross-mode batch grid explosion | graph batch path | fix in PR #287 | benchmark |
 | F9 | Batch path bypasses TaxReturnInput | graph batch path | open | batch-conformance tests |
-| F10 | Short-term gains taxed at preferential rates | graph spec | open | differential grid |
+| F10 | Short-term gains taxed at preferential rates (QCGWS line 3) | graph spec | fixed | differential grid |
 | F11 | 2024 HoH 32% bracket starts \$191,150, not \$191,950 | upstream OpenTaxSolver | adjudicated vs IRS; upstream report pending — not patched locally, we vendor OTS unmodified | differential grid |
 | F12 | Itemized-deduction category changes AMT | API (input model v2) | open (design) | adversarial search |
-| F13 | 2025 MFS long-term-gain thresholds high | graph spec (suspect) | open | differential grid |
+| F13 | 2025 MFS 15%-rate ceiling wrong (266,700 vs 300,000), inline in 1040 not Tables | graph spec | fixed | differential grid |
 | F14 | AMT std-deduction add-back divergence (ISO cases) | taxcalc + graph (both, apparently) | adjudicated: OTS matches the form; fix graph, ask taxcalc | H_amt stratum |
 | F16 | Suite adapter drops `iso`, so taxcalc sees no AMT preference | taxcalc harness | fixed (#295) | F14 adjudication |
 | F17 | Graph charges SE tax below the \$400 de-minimis floor | graph spec | open (tenforty-dw0) | differential sweep |
@@ -369,3 +369,53 @@ Above the floor the two agree exactly, so the divergence is isolated to the
 de-minimis rule. Two engines against one, with the form instruction agreeing
 with the majority. The half-SE-tax adjustment reaches AGI, so `agi` diverged
 by exactly half the SE tax as well.
+
+
+### Graph spec bundle — corrected mechanisms (F5, F10, F13, F4-graph, F17)
+
+Five graph-side findings fixed together in the Haskell spec. Two of the
+mechanisms differed from what the tracking notes predicted; recording the
+real ones.
+
+**F5 was arithmetic, not a missing import.** Form 8959 line 8 already imported
+self-employment income from Schedule SE. Line 12 computed
+`smallerOf line8 line11` where the form subtracts (`line8 - line11`, not below
+zero). With wages above the threshold, line 11 is zero, so `min(SE, 0)` was
+zero and the whole SE Additional-Medicare charge vanished. Changed to
+`subtractNotBelowZero`. Single, $250k wages + $50k SE: $450 → $865.57.
+
+**F10 is the Qualified Dividends and Capital Gain Tax Worksheet, line 3.** It
+read `ifPos L15 (min L15 L16) L16` — when there was no long-term gain it fell
+through to L16 (the net total, including short-term), routing short-term gains
+to preferential rates. Replaced with `max0 (min L15 L16)`, the worksheet's
+"smaller of Schedule D line 15 or 16, else zero." Single, $50k wages + $25k
+STCG: income tax $6,022 → $8,341.
+
+**F13 was a single wrong constant, and not where expected.** The preferential
+breakpoints are inlined in `US1040_2025.hs`, not read from `Tables2025.hs`
+(whose `qualifiedDividendBrackets2025` is dead code). The 2025 MFS 15%-rate
+ceiling read $266,700; Rev. Proc. 2024-40 puts it at $300,000. The wrong value
+taxed $33,300 of gain at 20% instead of 15% — a flat $1,665 overcharge. 2024's
+MFS breakpoints were already correct.
+
+**F4-graph** now imports Form 8960 line 5a from Schedule D line 16 (both
+holding periods netted), mirroring #296's OTS fix and dropping the
+`long_term_capital_gains → L5a` mapping. Short-term gains reach NIIT; the
+long-term path is unchanged. Single, $300k wages + $50k STCG: NIIT $0 →
+$1,900.
+
+**F17** adds the Schedule SE $400 de-minimis floor (IRC 1402(b)(2)): line 10
+returns zero when line 4c is under $400. See the F17 entry above.
+
+The five known-defect signatures (`_f4_niit_stcg`, `_f5_graph_8959`,
+`_f10_graph_stcg_preferential`, `_f13_graph_2025_mfs_ltcg`,
+`_f17_graph_se_deminimis`) and their strict-xfail burn-ins are deleted; the
+differential sweep passes on the graph backend with none of them.
+
+Two things found and deliberately left for follow-up: `Tables2025.hs`'s
+`qualifiedDividendBrackets2025` (and the 2024 twin) is dead — the live
+breakpoints are inline in the 1040, so the two should be reconciled or the
+dead table removed. And graph Schedule D line 16 sums the net gain without the
+section 1211(b) $3,000 capital-loss limitation; harmless for the gain cases
+here but wrong for a net-loss return, on both the main tax and the imported
+8960 line 5a.

--- a/src/tenforty/forms/us_1040_2024.json
+++ b/src/tenforty/forms/us_1040_2024.json
@@ -126,41 +126,48 @@
         },
         "100": {
             "id": 100,
-            "name": "qcgws_21",
             "op": {
-                "left": 98,
-                "right": 99,
-                "type": "mul"
+                "type": "literal",
+                "value": 0.2
             }
         },
         "101": {
             "id": 101,
-            "name": "qcgws_22",
+            "name": "qcgws_21",
             "op": {
-                "income": 71,
-                "table": "federal_brackets_2024",
-                "type": "bracket_tax"
+                "left": 99,
+                "right": 100,
+                "type": "mul"
             }
         },
         "102": {
             "id": 102,
+            "name": "qcgws_22",
             "op": {
-                "left": 96,
-                "right": 100,
-                "type": "add"
+                "income": 72,
+                "table": "federal_brackets_2024",
+                "type": "bracket_tax"
             }
         },
         "103": {
             "id": 103,
-            "name": "qcgws_23",
             "op": {
-                "left": 102,
+                "left": 97,
                 "right": 101,
                 "type": "add"
             }
         },
         "104": {
             "id": 104,
+            "name": "qcgws_23",
+            "op": {
+                "left": 103,
+                "right": 102,
+                "type": "add"
+            }
+        },
+        "105": {
+            "id": 105,
             "name": "qcgws_24",
             "op": {
                 "income": 64,
@@ -168,27 +175,27 @@
                 "type": "bracket_tax"
             }
         },
-        "105": {
-            "id": 105,
-            "name": "qcgws_25",
-            "op": {
-                "left": 103,
-                "right": 104,
-                "type": "min"
-            }
-        },
         "106": {
             "id": 106,
-            "name": "L16_tax",
+            "name": "qcgws_25",
             "op": {
-                "cond": 68,
-                "otherwise": 104,
-                "then": 105,
-                "type": "if_positive"
+                "left": 104,
+                "right": 105,
+                "type": "min"
             }
         },
         "107": {
             "id": 107,
+            "name": "L16_tax",
+            "op": {
+                "cond": 69,
+                "otherwise": 105,
+                "then": 106,
+                "type": "if_positive"
+            }
+        },
+        "108": {
+            "id": 108,
             "name": "L17_schedule_2_tax",
             "op": {
                 "form": "us_schedule_2",
@@ -197,23 +204,13 @@
                 "year": 2024
             }
         },
-        "108": {
-            "id": 108,
-            "name": "L18_total_tax_before_credits",
-            "op": {
-                "left": 106,
-                "right": 107,
-                "type": "add"
-            }
-        },
         "109": {
             "id": 109,
-            "name": "L19_child_tax_credit",
+            "name": "L18_total_tax_before_credits",
             "op": {
-                "form": "us_form_8812",
-                "line": "L14",
-                "type": "import",
-                "year": 2024
+                "left": 107,
+                "right": 108,
+                "type": "add"
             }
         },
         "11": {
@@ -225,6 +222,16 @@
         },
         "110": {
             "id": 110,
+            "name": "L19_child_tax_credit",
+            "op": {
+                "form": "us_form_8812",
+                "line": "L14",
+                "type": "import",
+                "year": 2024
+            }
+        },
+        "111": {
+            "id": 111,
             "name": "L20_schedule_3_credits",
             "op": {
                 "form": "us_schedule_3",
@@ -233,41 +240,41 @@
                 "year": 2024
             }
         },
-        "111": {
-            "id": 111,
-            "name": "L21_total_credits",
-            "op": {
-                "left": 109,
-                "right": 110,
-                "type": "add"
-            }
-        },
         "112": {
             "id": 112,
+            "name": "L21_total_credits",
             "op": {
-                "type": "literal",
-                "value": 0
+                "left": 110,
+                "right": 111,
+                "type": "add"
             }
         },
         "113": {
             "id": 113,
             "op": {
-                "left": 108,
-                "right": 111,
-                "type": "sub"
+                "type": "literal",
+                "value": 0
             }
         },
         "114": {
             "id": 114,
-            "name": "L22_tax_after_credits",
             "op": {
-                "left": 112,
-                "right": 113,
-                "type": "max"
+                "left": 109,
+                "right": 112,
+                "type": "sub"
             }
         },
         "115": {
             "id": 115,
+            "name": "L22_tax_after_credits",
+            "op": {
+                "left": 113,
+                "right": 114,
+                "type": "max"
+            }
+        },
+        "116": {
+            "id": 116,
             "name": "L23_other_taxes",
             "op": {
                 "form": "us_schedule_2",
@@ -276,40 +283,30 @@
                 "year": 2024
             }
         },
-        "116": {
-            "id": 116,
+        "117": {
+            "id": 117,
             "name": "L24_total_tax",
             "op": {
-                "left": 114,
-                "right": 115,
+                "left": 115,
+                "right": 116,
                 "type": "add"
             }
         },
-        "117": {
-            "id": 117,
+        "118": {
+            "id": 118,
             "op": {
                 "left": 20,
                 "right": 21,
                 "type": "add"
             }
         },
-        "118": {
-            "id": 118,
-            "name": "L25d_total_withholding",
-            "op": {
-                "left": 117,
-                "right": 22,
-                "type": "add"
-            }
-        },
         "119": {
             "id": 119,
-            "name": "L28_additional_ctc",
+            "name": "L25d_total_withholding",
             "op": {
-                "form": "us_form_8812",
-                "line": "L27",
-                "type": "import",
-                "year": 2024
+                "left": 118,
+                "right": 22,
+                "type": "add"
             }
         },
         "12": {
@@ -321,6 +318,16 @@
         },
         "120": {
             "id": 120,
+            "name": "L28_additional_ctc",
+            "op": {
+                "form": "us_form_8812",
+                "line": "L27",
+                "type": "import",
+                "year": 2024
+            }
+        },
+        "121": {
+            "id": 121,
             "name": "L29_aotc",
             "op": {
                 "form": "us_form_8863",
@@ -329,8 +336,8 @@
                 "year": 2024
             }
         },
-        "121": {
-            "id": 121,
+        "122": {
+            "id": 122,
             "name": "L31_schedule_3_payments",
             "op": {
                 "form": "us_schedule_3",
@@ -339,19 +346,11 @@
                 "year": 2024
             }
         },
-        "122": {
-            "id": 122,
-            "op": {
-                "left": 118,
-                "right": 23,
-                "type": "add"
-            }
-        },
         "123": {
             "id": 123,
             "op": {
-                "left": 122,
-                "right": 24,
+                "left": 119,
+                "right": 23,
                 "type": "add"
             }
         },
@@ -359,7 +358,7 @@
             "id": 124,
             "op": {
                 "left": 123,
-                "right": 119,
+                "right": 24,
                 "type": "add"
             }
         },
@@ -375,7 +374,7 @@
             "id": 126,
             "op": {
                 "left": 125,
-                "right": 25,
+                "right": 121,
                 "type": "add"
             }
         },
@@ -383,25 +382,25 @@
             "id": 127,
             "op": {
                 "left": 126,
-                "right": 121,
+                "right": 25,
                 "type": "add"
             }
         },
         "128": {
             "id": 128,
-            "name": "L33_total_payments",
             "op": {
                 "left": 127,
-                "right": 26,
+                "right": 122,
                 "type": "add"
             }
         },
         "129": {
             "id": 129,
+            "name": "L33_total_payments",
             "op": {
                 "left": 128,
-                "right": 116,
-                "type": "sub"
+                "right": 26,
+                "type": "add"
             }
         },
         "13": {
@@ -414,49 +413,57 @@
         "130": {
             "id": 130,
             "op": {
-                "left": 128,
-                "right": 116,
+                "left": 129,
+                "right": 117,
                 "type": "sub"
             }
         },
         "131": {
             "id": 131,
             "op": {
-                "type": "literal",
-                "value": 0
+                "left": 129,
+                "right": 117,
+                "type": "sub"
             }
         },
         "132": {
             "id": 132,
-            "name": "L34_overpayment",
             "op": {
-                "cond": 129,
-                "otherwise": 131,
-                "then": 130,
-                "type": "if_positive"
+                "type": "literal",
+                "value": 0
             }
         },
         "133": {
             "id": 133,
+            "name": "L34_overpayment",
             "op": {
-                "type": "literal",
-                "value": 0
+                "cond": 130,
+                "otherwise": 132,
+                "then": 131,
+                "type": "if_positive"
             }
         },
         "134": {
             "id": 134,
             "op": {
-                "left": 116,
-                "right": 128,
-                "type": "sub"
+                "type": "literal",
+                "value": 0
             }
         },
         "135": {
             "id": 135,
+            "op": {
+                "left": 117,
+                "right": 129,
+                "type": "sub"
+            }
+        },
+        "136": {
+            "id": 136,
             "name": "L37_amount_owed",
             "op": {
-                "left": 133,
-                "right": 134,
+                "left": 134,
+                "right": 135,
                 "type": "max"
             }
         },
@@ -918,35 +925,34 @@
         "66": {
             "id": 66,
             "op": {
+                "type": "literal",
+                "value": 0
+            }
+        },
+        "67": {
+            "id": 67,
+            "op": {
                 "left": 65,
                 "right": 37,
                 "type": "min"
             }
         },
-        "67": {
-            "id": 67,
-            "name": "qcgws_3",
-            "op": {
-                "cond": 65,
-                "otherwise": 37,
-                "then": 66,
-                "type": "if_positive"
-            }
-        },
         "68": {
             "id": 68,
-            "name": "qcgws_4",
+            "name": "qcgws_3",
             "op": {
-                "left": 11,
+                "left": 66,
                 "right": 67,
-                "type": "add"
+                "type": "max"
             }
         },
         "69": {
             "id": 69,
+            "name": "qcgws_4",
             "op": {
-                "type": "literal",
-                "value": 0
+                "left": 11,
+                "right": 68,
+                "type": "add"
             }
         },
         "7": {
@@ -959,83 +965,81 @@
         "70": {
             "id": 70,
             "op": {
-                "left": 64,
-                "right": 68,
-                "type": "sub"
+                "type": "literal",
+                "value": 0
             }
         },
         "71": {
             "id": 71,
-            "name": "qcgws_5",
             "op": {
-                "left": 69,
-                "right": 70,
-                "type": "max"
+                "left": 64,
+                "right": 69,
+                "type": "sub"
             }
         },
         "72": {
             "id": 72,
+            "name": "qcgws_5",
             "op": {
-                "type": "literal",
-                "value": 47025
+                "left": 70,
+                "right": 71,
+                "type": "max"
             }
         },
         "73": {
             "id": 73,
             "op": {
                 "type": "literal",
-                "value": 94050
+                "value": 47025
             }
         },
         "74": {
             "id": 74,
             "op": {
                 "type": "literal",
-                "value": 47025
+                "value": 94050
             }
         },
         "75": {
             "id": 75,
             "op": {
                 "type": "literal",
-                "value": 63000
+                "value": 47025
             }
         },
         "76": {
             "id": 76,
             "op": {
                 "type": "literal",
-                "value": 94050
+                "value": 63000
             }
         },
         "77": {
             "id": 77,
-            "name": "qcgws_6",
             "op": {
-                "type": "by_status",
-                "values": {
-                    "head_of_household": 75,
-                    "married_joint": 73,
-                    "married_separate": 74,
-                    "qualifying_widow": 76,
-                    "single": 72
-                }
+                "type": "literal",
+                "value": 94050
             }
         },
         "78": {
             "id": 78,
-            "name": "qcgws_7",
+            "name": "qcgws_6",
             "op": {
-                "left": 64,
-                "right": 77,
-                "type": "min"
+                "type": "by_status",
+                "values": {
+                    "head_of_household": 76,
+                    "married_joint": 74,
+                    "married_separate": 75,
+                    "qualifying_widow": 77,
+                    "single": 73
+                }
             }
         },
         "79": {
             "id": 79,
-            "name": "qcgws_8",
+            "name": "qcgws_7",
             "op": {
-                "left": 71,
+                "left": 64,
                 "right": 78,
                 "type": "min"
             }
@@ -1049,87 +1053,87 @@
         },
         "80": {
             "id": 80,
-            "name": "qcgws_9",
+            "name": "qcgws_8",
             "op": {
-                "left": 78,
+                "left": 72,
                 "right": 79,
-                "type": "sub"
+                "type": "min"
             }
         },
         "81": {
             "id": 81,
-            "name": "qcgws_10",
+            "name": "qcgws_9",
             "op": {
-                "left": 64,
-                "right": 68,
-                "type": "min"
-            }
-        },
-        "82": {
-            "id": 82,
-            "name": "qcgws_12",
-            "op": {
-                "left": 81,
+                "left": 79,
                 "right": 80,
                 "type": "sub"
             }
         },
+        "82": {
+            "id": 82,
+            "name": "qcgws_10",
+            "op": {
+                "left": 64,
+                "right": 69,
+                "type": "min"
+            }
+        },
         "83": {
             "id": 83,
+            "name": "qcgws_12",
             "op": {
-                "type": "literal",
-                "value": 518900
+                "left": 82,
+                "right": 81,
+                "type": "sub"
             }
         },
         "84": {
             "id": 84,
             "op": {
                 "type": "literal",
-                "value": 583750
+                "value": 518900
             }
         },
         "85": {
             "id": 85,
             "op": {
                 "type": "literal",
-                "value": 291850
+                "value": 583750
             }
         },
         "86": {
             "id": 86,
             "op": {
                 "type": "literal",
-                "value": 551350
+                "value": 291850
             }
         },
         "87": {
             "id": 87,
             "op": {
                 "type": "literal",
-                "value": 583750
+                "value": 551350
             }
         },
         "88": {
             "id": 88,
-            "name": "qcgws_13",
             "op": {
-                "type": "by_status",
-                "values": {
-                    "head_of_household": 86,
-                    "married_joint": 84,
-                    "married_separate": 85,
-                    "qualifying_widow": 87,
-                    "single": 83
-                }
+                "type": "literal",
+                "value": 583750
             }
         },
         "89": {
             "id": 89,
-            "name": "qcgws_14",
+            "name": "qcgws_13",
             "op": {
-                "left": 64,
-                "right": 88,
-                "type": "min"
+                "type": "by_status",
+                "values": {
+                    "head_of_household": 87,
+                    "married_joint": 85,
+                    "married_separate": 86,
+                    "qualifying_widow": 88,
+                    "single": 84
+                }
             }
         },
         "9": {
@@ -1141,85 +1145,87 @@
         },
         "90": {
             "id": 90,
-            "name": "qcgws_15",
+            "name": "qcgws_14",
             "op": {
-                "left": 71,
-                "right": 80,
-                "type": "add"
+                "left": 64,
+                "right": 89,
+                "type": "min"
             }
         },
         "91": {
             "id": 91,
+            "name": "qcgws_15",
             "op": {
-                "type": "literal",
-                "value": 0
+                "left": 72,
+                "right": 81,
+                "type": "add"
             }
         },
         "92": {
             "id": 92,
             "op": {
-                "left": 89,
-                "right": 90,
-                "type": "sub"
+                "type": "literal",
+                "value": 0
             }
         },
         "93": {
             "id": 93,
-            "name": "qcgws_16",
             "op": {
-                "left": 91,
-                "right": 92,
-                "type": "max"
+                "left": 90,
+                "right": 91,
+                "type": "sub"
             }
         },
         "94": {
             "id": 94,
-            "name": "qcgws_17",
+            "name": "qcgws_16",
             "op": {
-                "left": 82,
+                "left": 92,
                 "right": 93,
-                "type": "min"
+                "type": "max"
             }
         },
         "95": {
             "id": 95,
+            "name": "qcgws_17",
+            "op": {
+                "left": 83,
+                "right": 94,
+                "type": "min"
+            }
+        },
+        "96": {
+            "id": 96,
             "op": {
                 "type": "literal",
                 "value": 0.15
             }
         },
-        "96": {
-            "id": 96,
-            "name": "qcgws_18",
-            "op": {
-                "left": 94,
-                "right": 95,
-                "type": "mul"
-            }
-        },
         "97": {
             "id": 97,
-            "name": "qcgws_19",
+            "name": "qcgws_18",
             "op": {
-                "left": 80,
-                "right": 94,
-                "type": "add"
+                "left": 95,
+                "right": 96,
+                "type": "mul"
             }
         },
         "98": {
             "id": 98,
-            "name": "qcgws_20",
+            "name": "qcgws_19",
             "op": {
                 "left": 81,
-                "right": 97,
-                "type": "sub"
+                "right": 95,
+                "type": "add"
             }
         },
         "99": {
             "id": 99,
+            "name": "qcgws_20",
             "op": {
-                "type": "literal",
-                "value": 0.2
+                "left": 82,
+                "right": 98,
+                "type": "sub"
             }
         }
     },
@@ -1229,20 +1235,20 @@
         61,
         64,
         59,
-        106,
-        108,
+        107,
+        109,
         36,
-        111,
-        114,
-        116,
-        118,
-        128,
-        132,
-        135,
+        112,
+        115,
+        117,
+        119,
+        129,
+        133,
+        136,
         18,
         45,
-        68,
-        71
+        69,
+        72
     ],
     "tables": {
         "federal_brackets_2024": {

--- a/src/tenforty/forms/us_1040_2025.json
+++ b/src/tenforty/forms/us_1040_2025.json
@@ -126,41 +126,48 @@
         },
         "100": {
             "id": 100,
-            "name": "qcgws_21",
             "op": {
-                "left": 98,
-                "right": 99,
-                "type": "mul"
+                "type": "literal",
+                "value": 0.2
             }
         },
         "101": {
             "id": 101,
-            "name": "qcgws_22",
+            "name": "qcgws_21",
             "op": {
-                "income": 71,
-                "table": "federal_brackets_2025",
-                "type": "bracket_tax"
+                "left": 99,
+                "right": 100,
+                "type": "mul"
             }
         },
         "102": {
             "id": 102,
+            "name": "qcgws_22",
             "op": {
-                "left": 96,
-                "right": 100,
-                "type": "add"
+                "income": 72,
+                "table": "federal_brackets_2025",
+                "type": "bracket_tax"
             }
         },
         "103": {
             "id": 103,
-            "name": "qcgws_23",
             "op": {
-                "left": 102,
+                "left": 97,
                 "right": 101,
                 "type": "add"
             }
         },
         "104": {
             "id": 104,
+            "name": "qcgws_23",
+            "op": {
+                "left": 103,
+                "right": 102,
+                "type": "add"
+            }
+        },
+        "105": {
+            "id": 105,
             "name": "qcgws_24",
             "op": {
                 "income": 64,
@@ -168,27 +175,27 @@
                 "type": "bracket_tax"
             }
         },
-        "105": {
-            "id": 105,
-            "name": "qcgws_25",
-            "op": {
-                "left": 103,
-                "right": 104,
-                "type": "min"
-            }
-        },
         "106": {
             "id": 106,
-            "name": "L16_tax",
+            "name": "qcgws_25",
             "op": {
-                "cond": 68,
-                "otherwise": 104,
-                "then": 105,
-                "type": "if_positive"
+                "left": 104,
+                "right": 105,
+                "type": "min"
             }
         },
         "107": {
             "id": 107,
+            "name": "L16_tax",
+            "op": {
+                "cond": 69,
+                "otherwise": 105,
+                "then": 106,
+                "type": "if_positive"
+            }
+        },
+        "108": {
+            "id": 108,
             "name": "L17_schedule_2_tax",
             "op": {
                 "form": "us_schedule_2",
@@ -197,23 +204,13 @@
                 "year": 2025
             }
         },
-        "108": {
-            "id": 108,
-            "name": "L18_total_tax_before_credits",
-            "op": {
-                "left": 106,
-                "right": 107,
-                "type": "add"
-            }
-        },
         "109": {
             "id": 109,
-            "name": "L19_child_tax_credit",
+            "name": "L18_total_tax_before_credits",
             "op": {
-                "form": "us_form_8812",
-                "line": "L14",
-                "type": "import",
-                "year": 2025
+                "left": 107,
+                "right": 108,
+                "type": "add"
             }
         },
         "11": {
@@ -225,6 +222,16 @@
         },
         "110": {
             "id": 110,
+            "name": "L19_child_tax_credit",
+            "op": {
+                "form": "us_form_8812",
+                "line": "L14",
+                "type": "import",
+                "year": 2025
+            }
+        },
+        "111": {
+            "id": 111,
             "name": "L20_schedule_3_credits",
             "op": {
                 "form": "us_schedule_3",
@@ -233,41 +240,41 @@
                 "year": 2025
             }
         },
-        "111": {
-            "id": 111,
-            "name": "L21_total_credits",
-            "op": {
-                "left": 109,
-                "right": 110,
-                "type": "add"
-            }
-        },
         "112": {
             "id": 112,
+            "name": "L21_total_credits",
             "op": {
-                "type": "literal",
-                "value": 0
+                "left": 110,
+                "right": 111,
+                "type": "add"
             }
         },
         "113": {
             "id": 113,
             "op": {
-                "left": 108,
-                "right": 111,
-                "type": "sub"
+                "type": "literal",
+                "value": 0
             }
         },
         "114": {
             "id": 114,
-            "name": "L22_tax_after_credits",
             "op": {
-                "left": 112,
-                "right": 113,
-                "type": "max"
+                "left": 109,
+                "right": 112,
+                "type": "sub"
             }
         },
         "115": {
             "id": 115,
+            "name": "L22_tax_after_credits",
+            "op": {
+                "left": 113,
+                "right": 114,
+                "type": "max"
+            }
+        },
+        "116": {
+            "id": 116,
             "name": "L23_other_taxes",
             "op": {
                 "form": "us_schedule_2",
@@ -276,40 +283,30 @@
                 "year": 2025
             }
         },
-        "116": {
-            "id": 116,
+        "117": {
+            "id": 117,
             "name": "L24_total_tax",
             "op": {
-                "left": 114,
-                "right": 115,
+                "left": 115,
+                "right": 116,
                 "type": "add"
             }
         },
-        "117": {
-            "id": 117,
+        "118": {
+            "id": 118,
             "op": {
                 "left": 20,
                 "right": 21,
                 "type": "add"
             }
         },
-        "118": {
-            "id": 118,
-            "name": "L25d_total_withholding",
-            "op": {
-                "left": 117,
-                "right": 22,
-                "type": "add"
-            }
-        },
         "119": {
             "id": 119,
-            "name": "L28_additional_ctc",
+            "name": "L25d_total_withholding",
             "op": {
-                "form": "us_form_8812",
-                "line": "L27",
-                "type": "import",
-                "year": 2025
+                "left": 118,
+                "right": 22,
+                "type": "add"
             }
         },
         "12": {
@@ -321,6 +318,16 @@
         },
         "120": {
             "id": 120,
+            "name": "L28_additional_ctc",
+            "op": {
+                "form": "us_form_8812",
+                "line": "L27",
+                "type": "import",
+                "year": 2025
+            }
+        },
+        "121": {
+            "id": 121,
             "name": "L29_aotc",
             "op": {
                 "form": "us_form_8863",
@@ -329,8 +336,8 @@
                 "year": 2025
             }
         },
-        "121": {
-            "id": 121,
+        "122": {
+            "id": 122,
             "name": "L31_schedule_3_payments",
             "op": {
                 "form": "us_schedule_3",
@@ -339,19 +346,11 @@
                 "year": 2025
             }
         },
-        "122": {
-            "id": 122,
-            "op": {
-                "left": 118,
-                "right": 23,
-                "type": "add"
-            }
-        },
         "123": {
             "id": 123,
             "op": {
-                "left": 122,
-                "right": 24,
+                "left": 119,
+                "right": 23,
                 "type": "add"
             }
         },
@@ -359,7 +358,7 @@
             "id": 124,
             "op": {
                 "left": 123,
-                "right": 119,
+                "right": 24,
                 "type": "add"
             }
         },
@@ -375,7 +374,7 @@
             "id": 126,
             "op": {
                 "left": 125,
-                "right": 25,
+                "right": 121,
                 "type": "add"
             }
         },
@@ -383,25 +382,25 @@
             "id": 127,
             "op": {
                 "left": 126,
-                "right": 121,
+                "right": 25,
                 "type": "add"
             }
         },
         "128": {
             "id": 128,
-            "name": "L33_total_payments",
             "op": {
                 "left": 127,
-                "right": 26,
+                "right": 122,
                 "type": "add"
             }
         },
         "129": {
             "id": 129,
+            "name": "L33_total_payments",
             "op": {
                 "left": 128,
-                "right": 116,
-                "type": "sub"
+                "right": 26,
+                "type": "add"
             }
         },
         "13": {
@@ -414,49 +413,57 @@
         "130": {
             "id": 130,
             "op": {
-                "left": 128,
-                "right": 116,
+                "left": 129,
+                "right": 117,
                 "type": "sub"
             }
         },
         "131": {
             "id": 131,
             "op": {
-                "type": "literal",
-                "value": 0
+                "left": 129,
+                "right": 117,
+                "type": "sub"
             }
         },
         "132": {
             "id": 132,
-            "name": "L34_overpayment",
             "op": {
-                "cond": 129,
-                "otherwise": 131,
-                "then": 130,
-                "type": "if_positive"
+                "type": "literal",
+                "value": 0
             }
         },
         "133": {
             "id": 133,
+            "name": "L34_overpayment",
             "op": {
-                "type": "literal",
-                "value": 0
+                "cond": 130,
+                "otherwise": 132,
+                "then": 131,
+                "type": "if_positive"
             }
         },
         "134": {
             "id": 134,
             "op": {
-                "left": 116,
-                "right": 128,
-                "type": "sub"
+                "type": "literal",
+                "value": 0
             }
         },
         "135": {
             "id": 135,
+            "op": {
+                "left": 117,
+                "right": 129,
+                "type": "sub"
+            }
+        },
+        "136": {
+            "id": 136,
             "name": "L37_amount_owed",
             "op": {
-                "left": 133,
-                "right": 134,
+                "left": 134,
+                "right": 135,
                 "type": "max"
             }
         },
@@ -918,35 +925,34 @@
         "66": {
             "id": 66,
             "op": {
+                "type": "literal",
+                "value": 0
+            }
+        },
+        "67": {
+            "id": 67,
+            "op": {
                 "left": 65,
                 "right": 37,
                 "type": "min"
             }
         },
-        "67": {
-            "id": 67,
-            "name": "qcgws_3",
-            "op": {
-                "cond": 65,
-                "otherwise": 37,
-                "then": 66,
-                "type": "if_positive"
-            }
-        },
         "68": {
             "id": 68,
-            "name": "qcgws_4",
+            "name": "qcgws_3",
             "op": {
-                "left": 11,
+                "left": 66,
                 "right": 67,
-                "type": "add"
+                "type": "max"
             }
         },
         "69": {
             "id": 69,
+            "name": "qcgws_4",
             "op": {
-                "type": "literal",
-                "value": 0
+                "left": 11,
+                "right": 68,
+                "type": "add"
             }
         },
         "7": {
@@ -959,83 +965,81 @@
         "70": {
             "id": 70,
             "op": {
-                "left": 64,
-                "right": 68,
-                "type": "sub"
+                "type": "literal",
+                "value": 0
             }
         },
         "71": {
             "id": 71,
-            "name": "qcgws_5",
             "op": {
-                "left": 69,
-                "right": 70,
-                "type": "max"
+                "left": 64,
+                "right": 69,
+                "type": "sub"
             }
         },
         "72": {
             "id": 72,
+            "name": "qcgws_5",
             "op": {
-                "type": "literal",
-                "value": 48350
+                "left": 70,
+                "right": 71,
+                "type": "max"
             }
         },
         "73": {
             "id": 73,
             "op": {
                 "type": "literal",
-                "value": 96700
+                "value": 48350
             }
         },
         "74": {
             "id": 74,
             "op": {
                 "type": "literal",
-                "value": 48350
+                "value": 96700
             }
         },
         "75": {
             "id": 75,
             "op": {
                 "type": "literal",
-                "value": 64750
+                "value": 48350
             }
         },
         "76": {
             "id": 76,
             "op": {
                 "type": "literal",
-                "value": 96700
+                "value": 64750
             }
         },
         "77": {
             "id": 77,
-            "name": "qcgws_6",
             "op": {
-                "type": "by_status",
-                "values": {
-                    "head_of_household": 75,
-                    "married_joint": 73,
-                    "married_separate": 74,
-                    "qualifying_widow": 76,
-                    "single": 72
-                }
+                "type": "literal",
+                "value": 96700
             }
         },
         "78": {
             "id": 78,
-            "name": "qcgws_7",
+            "name": "qcgws_6",
             "op": {
-                "left": 64,
-                "right": 77,
-                "type": "min"
+                "type": "by_status",
+                "values": {
+                    "head_of_household": 76,
+                    "married_joint": 74,
+                    "married_separate": 75,
+                    "qualifying_widow": 77,
+                    "single": 73
+                }
             }
         },
         "79": {
             "id": 79,
-            "name": "qcgws_8",
+            "name": "qcgws_7",
             "op": {
-                "left": 71,
+                "left": 64,
                 "right": 78,
                 "type": "min"
             }
@@ -1049,87 +1053,87 @@
         },
         "80": {
             "id": 80,
-            "name": "qcgws_9",
+            "name": "qcgws_8",
             "op": {
-                "left": 78,
+                "left": 72,
                 "right": 79,
-                "type": "sub"
+                "type": "min"
             }
         },
         "81": {
             "id": 81,
-            "name": "qcgws_10",
+            "name": "qcgws_9",
             "op": {
-                "left": 64,
-                "right": 68,
-                "type": "min"
-            }
-        },
-        "82": {
-            "id": 82,
-            "name": "qcgws_12",
-            "op": {
-                "left": 81,
+                "left": 79,
                 "right": 80,
                 "type": "sub"
             }
         },
+        "82": {
+            "id": 82,
+            "name": "qcgws_10",
+            "op": {
+                "left": 64,
+                "right": 69,
+                "type": "min"
+            }
+        },
         "83": {
             "id": 83,
+            "name": "qcgws_12",
             "op": {
-                "type": "literal",
-                "value": 533400
+                "left": 82,
+                "right": 81,
+                "type": "sub"
             }
         },
         "84": {
             "id": 84,
             "op": {
                 "type": "literal",
-                "value": 600050
+                "value": 533400
             }
         },
         "85": {
             "id": 85,
             "op": {
                 "type": "literal",
-                "value": 266700
+                "value": 600050
             }
         },
         "86": {
             "id": 86,
             "op": {
                 "type": "literal",
-                "value": 566700
+                "value": 300000
             }
         },
         "87": {
             "id": 87,
             "op": {
                 "type": "literal",
-                "value": 600050
+                "value": 566700
             }
         },
         "88": {
             "id": 88,
-            "name": "qcgws_13",
             "op": {
-                "type": "by_status",
-                "values": {
-                    "head_of_household": 86,
-                    "married_joint": 84,
-                    "married_separate": 85,
-                    "qualifying_widow": 87,
-                    "single": 83
-                }
+                "type": "literal",
+                "value": 600050
             }
         },
         "89": {
             "id": 89,
-            "name": "qcgws_14",
+            "name": "qcgws_13",
             "op": {
-                "left": 64,
-                "right": 88,
-                "type": "min"
+                "type": "by_status",
+                "values": {
+                    "head_of_household": 87,
+                    "married_joint": 85,
+                    "married_separate": 86,
+                    "qualifying_widow": 88,
+                    "single": 84
+                }
             }
         },
         "9": {
@@ -1141,85 +1145,87 @@
         },
         "90": {
             "id": 90,
-            "name": "qcgws_15",
+            "name": "qcgws_14",
             "op": {
-                "left": 71,
-                "right": 80,
-                "type": "add"
+                "left": 64,
+                "right": 89,
+                "type": "min"
             }
         },
         "91": {
             "id": 91,
+            "name": "qcgws_15",
             "op": {
-                "type": "literal",
-                "value": 0
+                "left": 72,
+                "right": 81,
+                "type": "add"
             }
         },
         "92": {
             "id": 92,
             "op": {
-                "left": 89,
-                "right": 90,
-                "type": "sub"
+                "type": "literal",
+                "value": 0
             }
         },
         "93": {
             "id": 93,
-            "name": "qcgws_16",
             "op": {
-                "left": 91,
-                "right": 92,
-                "type": "max"
+                "left": 90,
+                "right": 91,
+                "type": "sub"
             }
         },
         "94": {
             "id": 94,
-            "name": "qcgws_17",
+            "name": "qcgws_16",
             "op": {
-                "left": 82,
+                "left": 92,
                 "right": 93,
-                "type": "min"
+                "type": "max"
             }
         },
         "95": {
             "id": 95,
+            "name": "qcgws_17",
+            "op": {
+                "left": 83,
+                "right": 94,
+                "type": "min"
+            }
+        },
+        "96": {
+            "id": 96,
             "op": {
                 "type": "literal",
                 "value": 0.15
             }
         },
-        "96": {
-            "id": 96,
-            "name": "qcgws_18",
-            "op": {
-                "left": 94,
-                "right": 95,
-                "type": "mul"
-            }
-        },
         "97": {
             "id": 97,
-            "name": "qcgws_19",
+            "name": "qcgws_18",
             "op": {
-                "left": 80,
-                "right": 94,
-                "type": "add"
+                "left": 95,
+                "right": 96,
+                "type": "mul"
             }
         },
         "98": {
             "id": 98,
-            "name": "qcgws_20",
+            "name": "qcgws_19",
             "op": {
                 "left": 81,
-                "right": 97,
-                "type": "sub"
+                "right": 95,
+                "type": "add"
             }
         },
         "99": {
             "id": 99,
+            "name": "qcgws_20",
             "op": {
-                "type": "literal",
-                "value": 0.2
+                "left": 82,
+                "right": 98,
+                "type": "sub"
             }
         }
     },
@@ -1229,20 +1235,20 @@
         61,
         64,
         59,
-        106,
-        108,
+        107,
+        109,
         36,
-        111,
-        114,
-        116,
-        118,
-        128,
-        132,
-        135,
+        112,
+        115,
+        117,
+        119,
+        129,
+        133,
+        136,
         18,
         45,
-        68,
-        71
+        69,
+        72
     ],
     "tables": {
         "federal_brackets_2025": {

--- a/src/tenforty/forms/us_form_8959_2024.json
+++ b/src/tenforty/forms/us_form_8959_2024.json
@@ -201,11 +201,9 @@
         },
         "29": {
             "id": 29,
-            "name": "L12_se_subject_to_tax",
             "op": {
-                "left": 19,
-                "right": 28,
-                "type": "min"
+                "type": "literal",
+                "value": 0
             }
         },
         "3": {
@@ -218,81 +216,83 @@
         "30": {
             "id": 30,
             "op": {
-                "type": "literal",
-                "value": 9.0e-3
+                "left": 19,
+                "right": 28,
+                "type": "sub"
             }
         },
         "31": {
             "id": 31,
-            "name": "L13_additional_medicare_se",
+            "name": "L12_se_subject_to_tax",
             "op": {
                 "left": 29,
                 "right": 30,
-                "type": "mul"
+                "type": "max"
             }
         },
         "32": {
             "id": 32,
             "op": {
                 "type": "literal",
-                "value": 200000
+                "value": 9.0e-3
             }
         },
         "33": {
             "id": 33,
+            "name": "L13_additional_medicare_se",
             "op": {
-                "type": "literal",
-                "value": 250000
+                "left": 31,
+                "right": 32,
+                "type": "mul"
             }
         },
         "34": {
             "id": 34,
             "op": {
                 "type": "literal",
-                "value": 125000
+                "value": 200000
             }
         },
         "35": {
             "id": 35,
             "op": {
                 "type": "literal",
-                "value": 200000
+                "value": 250000
             }
         },
         "36": {
             "id": 36,
             "op": {
                 "type": "literal",
-                "value": 200000
+                "value": 125000
             }
         },
         "37": {
             "id": 37,
-            "name": "L15_threshold_rrta",
             "op": {
-                "type": "by_status",
-                "values": {
-                    "head_of_household": 35,
-                    "married_joint": 33,
-                    "married_separate": 34,
-                    "qualifying_widow": 36,
-                    "single": 32
-                }
+                "type": "literal",
+                "value": 200000
             }
         },
         "38": {
             "id": 38,
             "op": {
                 "type": "literal",
-                "value": 0
+                "value": 200000
             }
         },
         "39": {
             "id": 39,
+            "name": "L15_threshold_rrta",
             "op": {
-                "left": 3,
-                "right": 37,
-                "type": "sub"
+                "type": "by_status",
+                "values": {
+                    "head_of_household": 37,
+                    "married_joint": 35,
+                    "married_separate": 36,
+                    "qualifying_widow": 38,
+                    "single": 34
+                }
             }
         },
         "4": {
@@ -304,84 +304,82 @@
         },
         "40": {
             "id": 40,
-            "name": "L16_excess_rrta",
             "op": {
-                "left": 38,
-                "right": 39,
-                "type": "max"
+                "type": "literal",
+                "value": 0
             }
         },
         "41": {
             "id": 41,
             "op": {
-                "type": "literal",
-                "value": 9.0e-3
+                "left": 3,
+                "right": 39,
+                "type": "sub"
             }
         },
         "42": {
             "id": 42,
-            "name": "L17_additional_medicare_rrta",
+            "name": "L16_excess_rrta",
             "op": {
                 "left": 40,
                 "right": 41,
-                "type": "mul"
+                "type": "max"
             }
         },
         "43": {
             "id": 43,
             "op": {
-                "left": 18,
-                "right": 31,
-                "type": "add"
+                "type": "literal",
+                "value": 9.0e-3
             }
         },
         "44": {
             "id": 44,
-            "name": "L18_total_additional_medicare",
+            "name": "L17_additional_medicare_rrta",
             "op": {
-                "left": 43,
-                "right": 42,
-                "type": "add"
+                "left": 42,
+                "right": 43,
+                "type": "mul"
             }
         },
         "45": {
             "id": 45,
             "op": {
-                "type": "literal",
-                "value": 1.45e-2
+                "left": 18,
+                "right": 33,
+                "type": "add"
             }
         },
         "46": {
             "id": 46,
-            "name": "L20_regular_medicare",
+            "name": "L18_total_additional_medicare",
             "op": {
-                "left": 0,
-                "right": 45,
-                "type": "mul"
+                "left": 45,
+                "right": 44,
+                "type": "add"
             }
         },
         "47": {
             "id": 47,
             "op": {
                 "type": "literal",
-                "value": 0
+                "value": 1.45e-2
             }
         },
         "48": {
             "id": 48,
+            "name": "L20_regular_medicare",
             "op": {
-                "left": 4,
-                "right": 46,
-                "type": "sub"
+                "left": 0,
+                "right": 47,
+                "type": "mul"
             }
         },
         "49": {
             "id": 49,
-            "name": "L21_additional_withheld",
             "op": {
-                "left": 47,
-                "right": 48,
-                "type": "max"
+                "type": "literal",
+                "value": 0
             }
         },
         "5": {
@@ -393,9 +391,26 @@
         },
         "50": {
             "id": 50,
-            "name": "L23_total_withheld",
+            "op": {
+                "left": 4,
+                "right": 48,
+                "type": "sub"
+            }
+        },
+        "51": {
+            "id": 51,
+            "name": "L21_additional_withheld",
             "op": {
                 "left": 49,
+                "right": 50,
+                "type": "max"
+            }
+        },
+        "52": {
+            "id": 52,
+            "name": "L23_total_withheld",
+            "op": {
+                "left": 51,
                 "right": 5,
                 "type": "add"
             }
@@ -433,12 +448,12 @@
         }
     },
     "outputs": [
-        29,
         31,
-        42,
+        33,
         44,
-        49,
-        50,
+        46,
+        51,
+        52,
         7,
         18
     ],

--- a/src/tenforty/forms/us_form_8959_2025.json
+++ b/src/tenforty/forms/us_form_8959_2025.json
@@ -201,11 +201,9 @@
         },
         "29": {
             "id": 29,
-            "name": "L12_se_subject_to_tax",
             "op": {
-                "left": 19,
-                "right": 28,
-                "type": "min"
+                "type": "literal",
+                "value": 0
             }
         },
         "3": {
@@ -218,81 +216,83 @@
         "30": {
             "id": 30,
             "op": {
-                "type": "literal",
-                "value": 9.0e-3
+                "left": 19,
+                "right": 28,
+                "type": "sub"
             }
         },
         "31": {
             "id": 31,
-            "name": "L13_additional_medicare_se",
+            "name": "L12_se_subject_to_tax",
             "op": {
                 "left": 29,
                 "right": 30,
-                "type": "mul"
+                "type": "max"
             }
         },
         "32": {
             "id": 32,
             "op": {
                 "type": "literal",
-                "value": 200000
+                "value": 9.0e-3
             }
         },
         "33": {
             "id": 33,
+            "name": "L13_additional_medicare_se",
             "op": {
-                "type": "literal",
-                "value": 250000
+                "left": 31,
+                "right": 32,
+                "type": "mul"
             }
         },
         "34": {
             "id": 34,
             "op": {
                 "type": "literal",
-                "value": 125000
+                "value": 200000
             }
         },
         "35": {
             "id": 35,
             "op": {
                 "type": "literal",
-                "value": 200000
+                "value": 250000
             }
         },
         "36": {
             "id": 36,
             "op": {
                 "type": "literal",
-                "value": 200000
+                "value": 125000
             }
         },
         "37": {
             "id": 37,
-            "name": "L15_threshold_rrta",
             "op": {
-                "type": "by_status",
-                "values": {
-                    "head_of_household": 35,
-                    "married_joint": 33,
-                    "married_separate": 34,
-                    "qualifying_widow": 36,
-                    "single": 32
-                }
+                "type": "literal",
+                "value": 200000
             }
         },
         "38": {
             "id": 38,
             "op": {
                 "type": "literal",
-                "value": 0
+                "value": 200000
             }
         },
         "39": {
             "id": 39,
+            "name": "L15_threshold_rrta",
             "op": {
-                "left": 3,
-                "right": 37,
-                "type": "sub"
+                "type": "by_status",
+                "values": {
+                    "head_of_household": 37,
+                    "married_joint": 35,
+                    "married_separate": 36,
+                    "qualifying_widow": 38,
+                    "single": 34
+                }
             }
         },
         "4": {
@@ -304,84 +304,82 @@
         },
         "40": {
             "id": 40,
-            "name": "L16_excess_rrta",
             "op": {
-                "left": 38,
-                "right": 39,
-                "type": "max"
+                "type": "literal",
+                "value": 0
             }
         },
         "41": {
             "id": 41,
             "op": {
-                "type": "literal",
-                "value": 9.0e-3
+                "left": 3,
+                "right": 39,
+                "type": "sub"
             }
         },
         "42": {
             "id": 42,
-            "name": "L17_additional_medicare_rrta",
+            "name": "L16_excess_rrta",
             "op": {
                 "left": 40,
                 "right": 41,
-                "type": "mul"
+                "type": "max"
             }
         },
         "43": {
             "id": 43,
             "op": {
-                "left": 18,
-                "right": 31,
-                "type": "add"
+                "type": "literal",
+                "value": 9.0e-3
             }
         },
         "44": {
             "id": 44,
-            "name": "L18_total_additional_medicare",
+            "name": "L17_additional_medicare_rrta",
             "op": {
-                "left": 43,
-                "right": 42,
-                "type": "add"
+                "left": 42,
+                "right": 43,
+                "type": "mul"
             }
         },
         "45": {
             "id": 45,
             "op": {
-                "type": "literal",
-                "value": 1.45e-2
+                "left": 18,
+                "right": 33,
+                "type": "add"
             }
         },
         "46": {
             "id": 46,
-            "name": "L20_regular_medicare",
+            "name": "L18_total_additional_medicare",
             "op": {
-                "left": 0,
-                "right": 45,
-                "type": "mul"
+                "left": 45,
+                "right": 44,
+                "type": "add"
             }
         },
         "47": {
             "id": 47,
             "op": {
                 "type": "literal",
-                "value": 0
+                "value": 1.45e-2
             }
         },
         "48": {
             "id": 48,
+            "name": "L20_regular_medicare",
             "op": {
-                "left": 4,
-                "right": 46,
-                "type": "sub"
+                "left": 0,
+                "right": 47,
+                "type": "mul"
             }
         },
         "49": {
             "id": 49,
-            "name": "L21_additional_withheld",
             "op": {
-                "left": 47,
-                "right": 48,
-                "type": "max"
+                "type": "literal",
+                "value": 0
             }
         },
         "5": {
@@ -393,9 +391,26 @@
         },
         "50": {
             "id": 50,
-            "name": "L23_total_withheld",
+            "op": {
+                "left": 4,
+                "right": 48,
+                "type": "sub"
+            }
+        },
+        "51": {
+            "id": 51,
+            "name": "L21_additional_withheld",
             "op": {
                 "left": 49,
+                "right": 50,
+                "type": "max"
+            }
+        },
+        "52": {
+            "id": 52,
+            "name": "L23_total_withheld",
+            "op": {
+                "left": 51,
                 "right": 5,
                 "type": "add"
             }
@@ -433,12 +448,12 @@
         }
     },
     "outputs": [
-        29,
         31,
-        42,
+        33,
         44,
-        49,
-        50,
+        46,
+        51,
+        52,
         7,
         18
     ],

--- a/src/tenforty/forms/us_form_8960_2024.json
+++ b/src/tenforty/forms/us_form_8960_2024.json
@@ -1,6 +1,11 @@
 {
     "imports": [
         {
+            "form": "us_schedule_d",
+            "line": "L16",
+            "year": 2024
+        },
+        {
             "form": "us_1040",
             "line": "L11",
             "year": 2024
@@ -19,8 +24,7 @@
         9,
         10,
         11,
-        12,
-        13
+        12
     ],
     "meta": {
         "form_id": "us_form_8960",
@@ -44,34 +48,27 @@
         },
         "10": {
             "id": 10,
-            "name": "L9a_investment_interest",
+            "name": "L9b_state_local_taxes",
             "op": {
                 "type": "input"
             }
         },
         "11": {
             "id": 11,
-            "name": "L9b_state_local_taxes",
+            "name": "L9c_other_expenses",
             "op": {
                 "type": "input"
             }
         },
         "12": {
             "id": 12,
-            "name": "L9c_other_expenses",
+            "name": "L10_additional_modifications",
             "op": {
                 "type": "input"
             }
         },
         "13": {
             "id": 13,
-            "name": "L10_additional_modifications",
-            "op": {
-                "type": "input"
-            }
-        },
-        "14": {
-            "id": 14,
             "name": "L4c_net_rental_royalty",
             "op": {
                 "left": 3,
@@ -79,12 +76,22 @@
                 "type": "add"
             }
         },
+        "14": {
+            "id": 14,
+            "name": "L5a_net_gain_disposition",
+            "op": {
+                "form": "us_schedule_d",
+                "line": "L16",
+                "type": "import",
+                "year": 2024
+            }
+        },
         "15": {
             "id": 15,
             "name": "L5c_net_gain_adjusted",
             "op": {
-                "left": 5,
-                "right": 6,
+                "left": 14,
+                "right": 5,
                 "type": "add"
             }
         },
@@ -108,7 +115,7 @@
             "id": 18,
             "op": {
                 "left": 17,
-                "right": 14,
+                "right": 13,
                 "type": "add"
             }
         },
@@ -131,7 +138,7 @@
             "id": 20,
             "op": {
                 "left": 19,
-                "right": 7,
+                "right": 6,
                 "type": "add"
             }
         },
@@ -139,7 +146,7 @@
             "id": 21,
             "op": {
                 "left": 20,
-                "right": 8,
+                "right": 7,
                 "type": "add"
             }
         },
@@ -148,15 +155,15 @@
             "name": "L8_total_investment_income",
             "op": {
                 "left": 21,
-                "right": 9,
+                "right": 8,
                 "type": "add"
             }
         },
         "23": {
             "id": 23,
             "op": {
-                "left": 10,
-                "right": 11,
+                "left": 9,
+                "right": 10,
                 "type": "add"
             }
         },
@@ -165,7 +172,7 @@
             "name": "L9d_total_expenses_subtotal",
             "op": {
                 "left": 23,
-                "right": 12,
+                "right": 11,
                 "type": "add"
             }
         },
@@ -174,7 +181,7 @@
             "name": "L11_total_deductions",
             "op": {
                 "left": 24,
-                "right": 13,
+                "right": 12,
                 "type": "add"
             }
         },
@@ -326,35 +333,35 @@
         },
         "5": {
             "id": 5,
-            "name": "L5a_net_gain_disposition",
+            "name": "L5b_adjustment_disposition",
             "op": {
                 "type": "input"
             }
         },
         "6": {
             "id": 6,
-            "name": "L5b_adjustment_disposition",
+            "name": "L5d_net_gain_estate_trust",
             "op": {
                 "type": "input"
             }
         },
         "7": {
             "id": 7,
-            "name": "L5d_net_gain_estate_trust",
+            "name": "L6_cfc_pfic_adjustments",
             "op": {
                 "type": "input"
             }
         },
         "8": {
             "id": 8,
-            "name": "L6_cfc_pfic_adjustments",
+            "name": "L7_other_modifications",
             "op": {
                 "type": "input"
             }
         },
         "9": {
             "id": 9,
-            "name": "L7_other_modifications",
+            "name": "L9a_investment_interest",
             "op": {
                 "type": "input"
             }
@@ -366,7 +373,7 @@
         38,
         39,
         41,
-        14,
+        13,
         15,
         22
     ],

--- a/src/tenforty/forms/us_form_8960_2025.json
+++ b/src/tenforty/forms/us_form_8960_2025.json
@@ -1,6 +1,11 @@
 {
     "imports": [
         {
+            "form": "us_schedule_d",
+            "line": "L16",
+            "year": 2025
+        },
+        {
             "form": "us_1040",
             "line": "L11",
             "year": 2025
@@ -19,8 +24,7 @@
         9,
         10,
         11,
-        12,
-        13
+        12
     ],
     "meta": {
         "form_id": "us_form_8960",
@@ -44,34 +48,27 @@
         },
         "10": {
             "id": 10,
-            "name": "L9a_investment_interest",
+            "name": "L9b_state_local_taxes",
             "op": {
                 "type": "input"
             }
         },
         "11": {
             "id": 11,
-            "name": "L9b_state_local_taxes",
+            "name": "L9c_other_expenses",
             "op": {
                 "type": "input"
             }
         },
         "12": {
             "id": 12,
-            "name": "L9c_other_expenses",
+            "name": "L10_additional_modifications",
             "op": {
                 "type": "input"
             }
         },
         "13": {
             "id": 13,
-            "name": "L10_additional_modifications",
-            "op": {
-                "type": "input"
-            }
-        },
-        "14": {
-            "id": 14,
             "name": "L4c_net_rental_royalty",
             "op": {
                 "left": 3,
@@ -79,12 +76,22 @@
                 "type": "add"
             }
         },
+        "14": {
+            "id": 14,
+            "name": "L5a_net_gain_disposition",
+            "op": {
+                "form": "us_schedule_d",
+                "line": "L16",
+                "type": "import",
+                "year": 2025
+            }
+        },
         "15": {
             "id": 15,
             "name": "L5c_net_gain_adjusted",
             "op": {
-                "left": 5,
-                "right": 6,
+                "left": 14,
+                "right": 5,
                 "type": "add"
             }
         },
@@ -108,7 +115,7 @@
             "id": 18,
             "op": {
                 "left": 17,
-                "right": 14,
+                "right": 13,
                 "type": "add"
             }
         },
@@ -131,7 +138,7 @@
             "id": 20,
             "op": {
                 "left": 19,
-                "right": 7,
+                "right": 6,
                 "type": "add"
             }
         },
@@ -139,7 +146,7 @@
             "id": 21,
             "op": {
                 "left": 20,
-                "right": 8,
+                "right": 7,
                 "type": "add"
             }
         },
@@ -148,15 +155,15 @@
             "name": "L8_total_investment_income",
             "op": {
                 "left": 21,
-                "right": 9,
+                "right": 8,
                 "type": "add"
             }
         },
         "23": {
             "id": 23,
             "op": {
-                "left": 10,
-                "right": 11,
+                "left": 9,
+                "right": 10,
                 "type": "add"
             }
         },
@@ -165,7 +172,7 @@
             "name": "L9d_total_expenses_subtotal",
             "op": {
                 "left": 23,
-                "right": 12,
+                "right": 11,
                 "type": "add"
             }
         },
@@ -174,7 +181,7 @@
             "name": "L11_total_deductions",
             "op": {
                 "left": 24,
-                "right": 13,
+                "right": 12,
                 "type": "add"
             }
         },
@@ -326,35 +333,35 @@
         },
         "5": {
             "id": 5,
-            "name": "L5a_net_gain_disposition",
+            "name": "L5b_adjustment_disposition",
             "op": {
                 "type": "input"
             }
         },
         "6": {
             "id": 6,
-            "name": "L5b_adjustment_disposition",
+            "name": "L5d_net_gain_estate_trust",
             "op": {
                 "type": "input"
             }
         },
         "7": {
             "id": 7,
-            "name": "L5d_net_gain_estate_trust",
+            "name": "L6_cfc_pfic_adjustments",
             "op": {
                 "type": "input"
             }
         },
         "8": {
             "id": 8,
-            "name": "L6_cfc_pfic_adjustments",
+            "name": "L7_other_modifications",
             "op": {
                 "type": "input"
             }
         },
         "9": {
             "id": 9,
-            "name": "L7_other_modifications",
+            "name": "L9a_investment_interest",
             "op": {
                 "type": "input"
             }
@@ -366,7 +373,7 @@
         38,
         39,
         41,
-        14,
+        13,
         15,
         22
     ],

--- a/src/tenforty/forms/us_schedule_se_2024.json
+++ b/src/tenforty/forms/us_schedule_se_2024.json
@@ -126,26 +126,57 @@
         },
         "21": {
             "id": 21,
-            "name": "L10_se_tax",
+            "op": {
+                "type": "literal",
+                "value": 400
+            }
+        },
+        "22": {
+            "id": 22,
+            "op": {
+                "left": 11,
+                "right": 21,
+                "type": "sub"
+            }
+        },
+        "23": {
+            "id": 23,
             "op": {
                 "left": 18,
                 "right": 20,
                 "type": "add"
             }
         },
-        "22": {
-            "id": 22,
+        "24": {
+            "id": 24,
+            "op": {
+                "type": "literal",
+                "value": 0
+            }
+        },
+        "25": {
+            "id": 25,
+            "name": "L10_se_tax",
+            "op": {
+                "cond": 22,
+                "otherwise": 24,
+                "then": 23,
+                "type": "if_positive"
+            }
+        },
+        "26": {
+            "id": 26,
             "op": {
                 "type": "literal",
                 "value": 0.5
             }
         },
-        "23": {
-            "id": 23,
+        "27": {
+            "id": 27,
             "name": "L11_se_tax_deduction",
             "op": {
-                "left": 21,
-                "right": 22,
+                "left": 25,
+                "right": 26,
                 "type": "mul"
             }
         },
@@ -205,8 +236,8 @@
         }
     },
     "outputs": [
-        21,
-        23,
+        25,
+        27,
         6,
         8,
         11,

--- a/src/tenforty/forms/us_schedule_se_2025.json
+++ b/src/tenforty/forms/us_schedule_se_2025.json
@@ -126,26 +126,57 @@
         },
         "21": {
             "id": 21,
-            "name": "L10_se_tax",
+            "op": {
+                "type": "literal",
+                "value": 400
+            }
+        },
+        "22": {
+            "id": 22,
+            "op": {
+                "left": 11,
+                "right": 21,
+                "type": "sub"
+            }
+        },
+        "23": {
+            "id": 23,
             "op": {
                 "left": 18,
                 "right": 20,
                 "type": "add"
             }
         },
-        "22": {
-            "id": 22,
+        "24": {
+            "id": 24,
+            "op": {
+                "type": "literal",
+                "value": 0
+            }
+        },
+        "25": {
+            "id": 25,
+            "name": "L10_se_tax",
+            "op": {
+                "cond": 22,
+                "otherwise": 24,
+                "then": 23,
+                "type": "if_positive"
+            }
+        },
+        "26": {
+            "id": 26,
             "op": {
                 "type": "literal",
                 "value": 0.5
             }
         },
-        "23": {
-            "id": 23,
+        "27": {
+            "id": 27,
             "name": "L11_se_tax_deduction",
             "op": {
-                "left": 21,
-                "right": 22,
+                "left": 25,
+                "right": 26,
                 "type": "mul"
             }
         },
@@ -205,8 +236,8 @@
         }
     },
     "outputs": [
-        21,
-        23,
+        25,
+        27,
         6,
         8,
         11,

--- a/src/tenforty/mappings.py
+++ b/src/tenforty/mappings.py
@@ -42,7 +42,9 @@ _SUBORDINATE_NODES: dict[str, list[str]] = {
     ],
     "taxable_interest": ["us_form_8960_L1_taxable_interest"],
     "ordinary_dividends": ["us_form_8960_L2_ordinary_dividends"],
-    "long_term_capital_gains": ["us_form_8960_L5a_net_gain_disposition"],
+    # Form 8960 line 5a now imports the net capital gain from Schedule D
+    # line 16 (both holding periods), so neither
+    # gain natural is mapped here — see USForm8960_*.hs.
     "rental_income": ["us_form_8960_L4a_rental_royalty_income"],
 }
 

--- a/tenforty-spec/forms/US1040_2024.hs
+++ b/tenforty-spec/forms/US1040_2024.hs
@@ -104,7 +104,7 @@ us1040_2024 = form "us_1040" 2024 $ do
     let qcgws2 = l3a
 
     -- Line 3: If Sched D used, smaller of D15 or D16. If not, L7.
-    qcgws3 <- interior "qcgws_3" "work_l3" $ ifPos l15SchedD (minE l15SchedD l7) l7
+    qcgws3 <- interior "qcgws_3" "work_l3" $ max0 (minE l15SchedD l7)
 
     qcgws4 <- interior "qcgws_4" "work_l4" $ qcgws2 .+. qcgws3
     qcgws5 <- interior "qcgws_5" "work_l5" $ qcgws1 `subtractNotBelowZero` qcgws4

--- a/tenforty-spec/forms/US1040_2025.hs
+++ b/tenforty-spec/forms/US1040_2025.hs
@@ -104,7 +104,7 @@ us1040_2025 = form "us_1040" 2025 $ do
     let qcgws2 = l3a
 
     -- Line 3: If Sched D used, smaller of D15 or D16. If not, L7.
-    qcgws3 <- interior "qcgws_3" "work_l3" $ ifPos l15SchedD (minE l15SchedD l7) l7
+    qcgws3 <- interior "qcgws_3" "work_l3" $ max0 (minE l15SchedD l7)
 
     qcgws4 <- interior "qcgws_4" "work_l4" $ qcgws2 .+. qcgws3
     qcgws5 <- interior "qcgws_5" "work_l5" $ qcgws1 `subtractNotBelowZero` qcgws4
@@ -134,7 +134,7 @@ us1040_2025 = form "us_1040" 2025 $ do
             byStatusE $
                 ByStatus
                     { bsSingle = lit 533400
-                    , bsMarriedSeparate = lit 266700
+                    , bsMarriedSeparate = lit 300000
                     , bsMarriedJoint = lit 600050
                     , bsQualifyingWidow = lit 600050
                     , bsHeadOfHousehold = lit 566700

--- a/tenforty-spec/forms/USForm8959_2024.hs
+++ b/tenforty-spec/forms/USForm8959_2024.hs
@@ -45,7 +45,7 @@ usForm8959_2024 = form "us_form_8959" 2024 $ do
 
     l12 <-
         interior "L12" "se_subject_to_tax" $
-            smallerOf l8 l11
+            l8 `subtractNotBelowZero` l11
 
     l13 <-
         keyOutput "L13" "additional_medicare_se" "Additional Medicare Tax on self-employment income" $

--- a/tenforty-spec/forms/USForm8959_2025.hs
+++ b/tenforty-spec/forms/USForm8959_2025.hs
@@ -45,7 +45,7 @@ usForm8959_2025 = form "us_form_8959" 2025 $ do
 
     l12 <-
         interior "L12" "se_subject_to_tax" $
-            smallerOf l8 l11
+            l8 `subtractNotBelowZero` l11
 
     l13 <-
         keyOutput "L13" "additional_medicare_se" "Additional Medicare Tax on self-employment income" $

--- a/tenforty-spec/forms/USForm8960_2024.hs
+++ b/tenforty-spec/forms/USForm8960_2024.hs
@@ -19,7 +19,7 @@ usForm8960_2024 = form "us_form_8960" 2024 $ do
     l4b <- keyInput "L4b" "adjustment_active_business" "Adjustment for net income/loss from active trade/business"
     l4c <- interior "L4c" "net_rental_royalty" $ l4a .+. l4b
 
-    l5a <- keyInput "L5a" "net_gain_disposition" "Net gain or loss from disposition of property"
+    l5a <- interior "L5a" "net_gain_disposition" $ importForm "us_schedule_d" "L16"
     l5b <- keyInput "L5b" "adjustment_disposition" "Adjustments from disposition of partnership/S corp interest"
     l5c <- interior "L5c" "net_gain_adjusted" $ l5a .+. l5b
     l5d <- keyInput "L5d" "net_gain_estate_trust" "Net gain or loss from estate or trust"

--- a/tenforty-spec/forms/USForm8960_2025.hs
+++ b/tenforty-spec/forms/USForm8960_2025.hs
@@ -19,7 +19,7 @@ usForm8960_2025 = form "us_form_8960" 2025 $ do
     l4b <- keyInput "L4b" "adjustment_active_business" "Adjustment for net income/loss from active trade/business"
     l4c <- interior "L4c" "net_rental_royalty" $ l4a .+. l4b
 
-    l5a <- keyInput "L5a" "net_gain_disposition" "Net gain or loss from disposition of property"
+    l5a <- interior "L5a" "net_gain_disposition" $ importForm "us_schedule_d" "L16"
     l5b <- keyInput "L5b" "adjustment_disposition" "Adjustments from disposition of partnership/S corp interest"
     l5c <- interior "L5c" "net_gain_adjusted" $ l5a .+. l5b
     l5d <- keyInput "L5d" "net_gain_estate_trust" "Net gain or loss from estate or trust"

--- a/tenforty-spec/forms/USScheduleSE_2024.hs
+++ b/tenforty-spec/forms/USScheduleSE_2024.hs
@@ -70,7 +70,9 @@ usScheduleSE_2024 = form "us_schedule_se" 2024 $ do
     -- Line 10: Total self-employment tax. Add lines 8b and 9
     l10 <-
         keyOutput "L10" "se_tax" "Self-employment tax" $
-            l8b .+. l9
+            -- No SE tax when net earnings (line 4c, after the 92.35% factor)
+            -- are under $400 (IRC 1402(b)(2), Schedule SE line 4c stop rule).
+            ifPos (l4c .-. lit 400) (l8b .+. l9) (dollars 0)
 
     -- Line 11: Deductible part of SE tax. Multiply line 10 by 50%
     _l11 <-

--- a/tenforty-spec/forms/USScheduleSE_2025.hs
+++ b/tenforty-spec/forms/USScheduleSE_2025.hs
@@ -70,7 +70,9 @@ usScheduleSE_2025 = form "us_schedule_se" 2025 $ do
     -- Line 10: Total self-employment tax. Add lines 8b and 9
     l10 <-
         keyOutput "L10" "se_tax" "Self-employment tax" $
-            l8b .+. l9
+            -- No SE tax when net earnings (line 4c, after the 92.35% factor)
+            -- are under $400 (IRC 1402(b)(2), Schedule SE line 4c stop rule).
+            ifPos (l4c .-. lit 400) (l8b .+. l9) (dollars 0)
 
     -- Line 11: Deductible part of SE tax. Multiply line 10 by 50%
     _l11 <-

--- a/tests/known_defects_test.py
+++ b/tests/known_defects_test.py
@@ -74,7 +74,6 @@ def test_ots_niit_includes_short_term_gains():
     assert r.federal_niit == pytest.approx(1_900.0, abs=1.0)
 
 
-@pytest.mark.xfail(reason="F4: 8960 L5a omits short-term gains (graph)", strict=True)
 @skip_if_graph_unavailable
 def test_graph_niit_includes_short_term_gains():
     """Same case on the graph backend: NIIT must include short-term gains."""
@@ -143,7 +142,6 @@ def test_business_property_gain_can_be_excluded_from_nii():
     assert "L5b" in wired
 
 
-@pytest.mark.xfail(reason="F5: graph 8959 omits SE earnings", strict=True)
 @skip_if_graph_unavailable
 def test_graph_additional_medicare_includes_se_earnings():
     """$250k wages + $50k SE profit: additional Medicare tax is $865.57, not $450."""
@@ -183,10 +181,6 @@ def test_graph_zip_applies_dividend_normalization():
     assert df["federal_adjusted_gross_income"][0] == pytest.approx(72_000.0, abs=1.0)
 
 
-@pytest.mark.xfail(
-    reason="F10: graph taxes short-term gains at preferential rates",
-    strict=True,
-)
 @skip_if_graph_unavailable
 def test_graph_taxes_short_term_gains_as_ordinary():
     """Single, $50k wages + $25k STCG: income tax $8,341 (STCG is ordinary income)."""
@@ -237,10 +231,6 @@ def test_itemized_category_amt_agrees_across_backends():
     assert ots.federal_amt == pytest.approx(graph.federal_amt, abs=1.0)
 
 
-@pytest.mark.xfail(
-    reason="F13: graph 2025 MFS long-term-gain thresholds diverge from consensus",
-    strict=True,
-)
 @skip_if_graph_unavailable
 def test_graph_2025_mfs_ltcg_matches_consensus():
     """MFS 2025, $150k wages + $200k LTCG: income tax $56,779.50 per OTS+taxcalc."""
@@ -320,10 +310,6 @@ def test_graph_cross_mode_grid_shape_and_alignment():
         assert agi == pytest.approx(w2, abs=1.0)
 
 
-@pytest.mark.xfail(
-    reason="F17: graph charges SE tax below the $400 Schedule SE de-minimis floor",
-    strict=True,
-)
 @skip_if_graph_unavailable
 def test_graph_honors_se_deminimis_floor():
     """Net self-employment earnings under $400 owe no SE tax.

--- a/tests/mapping_completeness_test.py
+++ b/tests/mapping_completeness_test.py
@@ -37,17 +37,11 @@ INVENTORY = {
     ("schedule_se", "self_employment_income"): {"ots": "mapped", "graph": "mapped"},
     ("schedule_se", "w2_income"): {"ots": "mapped", "graph": "mapped"},
     ("form_8959", "w2_income"): {"ots": "mapped", "graph": "mapped"},
-    ("form_8959", "self_employment_income"): {
-        "ots": "mapped",
-        "graph": "missing:F5",
-    },
+    ("form_8959", "self_employment_income"): {"ots": "mapped", "graph": "mapped"},
     ("form_8960", "taxable_interest"): {"ots": "mapped", "graph": "mapped"},
     ("form_8960", "ordinary_dividends"): {"ots": "mapped", "graph": "mapped"},
     ("form_8960", "long_term_capital_gains"): {"ots": "mapped", "graph": "mapped"},
-    ("form_8960", "short_term_capital_gains"): {
-        "ots": "mapped",
-        "graph": "missing:F4",
-    },
+    ("form_8960", "short_term_capital_gains"): {"ots": "mapped", "graph": "mapped"},
     ("form_8995", "self_employment_income"): {
         "ots": "missing:F3",  # no Form 8995 config exists at all
         "graph": "mapped",
@@ -71,6 +65,52 @@ def _ots_mapped(form_key: str, natural: str, year: int = 2024) -> bool:
     return False
 
 
+# The output node whose derivative reveals whether a natural reaches a form,
+# and a base return that puts that output in its active region. Used when a
+# concept reaches a form through a spec-level `importForm` rather than a
+# mapping-table entry (Form 8960 line 5a imports the 1040 capital-gain line;
+# Form 8959 line 8 imports Schedule SE) — invisible to the mapping dict but a
+# real, differentiable edge.
+GRAPH_FORM_OUTPUT = {
+    "schedule_se": "us_schedule_se_L10_se_tax",
+    "form_8959": "us_form_8959_L18_total_additional_medicare",
+    "form_8960": "us_form_8960_L17_niit",
+    "form_8995": "us_form_8995_L16_qbi_deduction",
+}
+# High wages clear the NIIT and Additional-Medicare thresholds; the QBI forms
+# want self-employment income without the wage limitation biting.
+GRAPH_ACTIVE_BASE = {
+    "schedule_se": {"self_employment_income": 60_000.0},
+    "form_8959": {"w2_income": 250_000.0},
+    "form_8960": {"w2_income": 250_000.0},
+    "form_8995": {"self_employment_income": 60_000.0},
+}
+
+
+def _graph_flows(form_key: str, natural: str) -> bool:
+    """Report whether the form's output actually moves with the natural.
+
+    The derivative is the honest test of a consumer edge: it is nonzero
+    exactly when the concept reaches the form's computation, whether it
+    arrived by a mapping entry or a spec import, and it stays zero for a
+    wrong-destination wiring. Requires the graph backend and the fan-out-aware
+    autodiff from #294.
+    """
+    from tenforty.backends import GraphBackend
+    from tenforty.models import TaxReturnInput
+
+    backend = GraphBackend()
+    if not backend.is_available():
+        return _graph_mapped(form_key, natural)
+
+    case = {"year": 2024, "filing_status": "Single", **GRAPH_ACTIVE_BASE[form_key]}
+    case[natural] = case.get(natural, 0.0) + 100_000.0
+    gradient = backend.gradient(
+        TaxReturnInput(**case), GRAPH_FORM_OUTPUT[form_key], natural
+    )
+    return gradient is not None and abs(gradient) > 1e-9
+
+
 def _graph_mapped(form_key: str, natural: str) -> bool:
     prefix = GRAPH_PREFIXES[form_key]
     for natural_name, nodes in NATURAL_TO_NODES.items():
@@ -87,7 +127,7 @@ def test_consumer_edge_matches_inventory(form_key, natural):
     declared = INVENTORY[(form_key, natural)]
     actual = {
         "ots": _ots_mapped(form_key, natural),
-        "graph": _graph_mapped(form_key, natural),
+        "graph": _graph_mapped(form_key, natural) or _graph_flows(form_key, natural),
     }
     for backend, state in declared.items():
         expected = state == "mapped"

--- a/tests/taxcalc/taxcalc_policy.py
+++ b/tests/taxcalc/taxcalc_policy.py
@@ -34,33 +34,6 @@ def _f3_qbi(backend: str, case: dict) -> set[str]:
     return set()
 
 
-def _f4_niit_stcg(backend: str, case: dict) -> set[str]:
-    """F4: Form 8960 L5a omits short-term gains.
-
-    Fixed on OTS, which now imports line 5a from Form 1040 line 7 rather than
-    reconstructing it from the gain naturals. The graph spec still carries the
-    defect, so the signature is narrowed rather than deleted. Delete it with
-    the graph fix.
-    """
-    if backend == "graph" and case.get("stcg", 0):
-        return {"niit", "total_tax"}
-    return set()
-
-
-def _f5_graph_8959(backend: str, case: dict) -> set[str]:
-    """F5: graph Form 8959 omits SE earnings."""
-    if backend == "graph" and case.get("se", 0):
-        return {"addl_medicare", "total_tax"}
-    return set()
-
-
-def _f10_graph_stcg_preferential(backend: str, case: dict) -> set[str]:
-    """F10: graph taxes short-term gains at preferential long-term rates."""
-    if backend == "graph" and case.get("stcg", 0):
-        return {"income_tax", "total_tax"}
-    return set()
-
-
 def _f11_ots_hoh_bracket(backend: str, case: dict) -> set[str]:
     """F11: upstream OTS 2024 HoH table starts the 32% bracket at $191,150.
 
@@ -105,21 +78,6 @@ def _f15_ots_itemized_taxable_income(backend: str, case: dict) -> set[str]:
     return set()
 
 
-def _f17_graph_se_deminimis(backend: str, case: dict) -> set[str]:
-    """F17: graph charges SE tax below the $400 de-minimis floor.
-
-    Schedule SE line 4c: net earnings under $400 owe no self-employment tax
-    (IRC 1402(b)(2)). OTS and taxcalc both honour it. The floor is measured on
-    ADJUSTED earnings, after the 92.35% factor. The half-SE-tax adjustment
-    reaches AGI and taxable income, so those diverge too.
-    """
-    if backend != "graph":
-        return set()
-    if 0 < case.get("se", 0) * 0.9235 < 400:
-        return {"se_tax", "agi", "taxable_income", "income_tax", "total_tax"}
-    return set()
-
-
 def _f7_itemized_semantics(backend: str, case: dict) -> set[str]:
     """F7: OTS forces itemization; taxcalc and graph take best-of."""
     if backend != "ots" or case.get("std_or_item") != "Itemized":
@@ -143,22 +101,6 @@ def _f12_itemized_category_amt(backend: str, case: dict) -> set[str]:
     return set()
 
 
-def _f13_graph_2025_mfs_ltcg(backend: str, case: dict) -> set[str]:
-    """F13: graph 2025 Married/Sep long-term-gain thresholds diverge.
-
-    Roughly $1.4-1.7k above the OTS+taxcalc consensus. Suspect: 2025 MFS
-    preferential breakpoints in the spec. 2-vs-1 against graph.
-    """
-    if (
-        backend == "graph"
-        and case.get("year") == 2025
-        and case.get("status") == "Married/Sep"
-        and case.get("ltcg", 0)
-    ):
-        return {"income_tax", "total_tax"}
-    return set()
-
-
 def _f14_amt_std_deduction_addback(backend: str, case: dict) -> set[str]:
     """F14: AMT standard-deduction add-back divergence on AMT-preference cases.
 
@@ -178,15 +120,10 @@ def _f14_amt_std_deduction_addback(backend: str, case: dict) -> set[str]:
 
 SIGNATURES: list[Callable[[str, dict], set[str]]] = [
     _f3_qbi,
-    _f4_niit_stcg,
-    _f5_graph_8959,
     _f7_itemized_semantics,
-    _f10_graph_stcg_preferential,
     _f11_ots_hoh_bracket,
     _f12_itemized_category_amt,
-    _f13_graph_2025_mfs_ltcg,
     _f15_ots_itemized_taxable_income,
-    _f17_graph_se_deminimis,
     _f14_amt_std_deduction_addback,
 ]
 


### PR DESCRIPTION
Fixes `tenforty-lpe`. Five graph-backend tax defects, all found by the Tax-Calculator differential sweep, fixed together in the Haskell spec. **Two of the mechanisms weren't what the tracking notes predicted** — I reproduced each from the failing case rather than trusting the description.

| finding | before → after | mechanism |
|---|---|---|
| **F10** short-term gains at preferential rates | $6,022 → **$8,341** | QCGWS line 3 read `ifPos L15 (min L15 L16) L16` — fell through to the net total (incl. short-term) when there was no long-term gain. Now `max0 (min L15 L16)`. |
| **F5** 8959 drops SE earnings | $450 → **$865.57** | *Not* a missing import — line 8 already imported it. Line 12 used `smallerOf line8 line11` where the form **subtracts**; above the wage threshold line 11 is 0, so `min(SE, 0)` erased the charge. Now `subtractNotBelowZero`. |
| **F13** 2025 MFS 15% ceiling | $58,444 → **$56,779.50** | A single wrong constant — and not in `Tables2025.hs` as expected (that binding is dead code). The breakpoints are inlined in `US1040_2025.hs`; MFS read $266,700, Rev. Proc. 2024-40 says **$300,000**. $33,300 taxed at 20% not 15% = $1,665. |
| **F4** (graph half) 8960 5a omits STCG | NIIT $0 → **$1,900** | Line 5a now imports Schedule D line 16 (both holding periods netted), mirroring #296's OTS fix; the `long_term_capital_gains → L5a` mapping is dropped. |
| **F17** SE below $400 floor | $56 → **$0** | Schedule SE $400 de-minimis (IRC §1402(b)(2)): line 10 returns zero when line 4c < $400. Unchanged above the floor. |

## Verification

- All five verified against OTS to the penny (F10 to the tax-table step, $8,341 vs $8,347).
- **Differential sweep passes on the graph backend** (`TENFORTY_TAXCALC=1`) — the five signatures (`_f4_niit_stcg`, `_f5_graph_8959`, `_f10_graph_stcg_preferential`, `_f13_graph_2025_mfs_ltcg`, `_f17_graph_se_deminimis`) and their strict-xfail burn-ins are **deleted**, and nothing new goes unexcused.
- Default suite: **703 passed, 12 skipped, 27 xfailed** (five burn-ins flipped).
- Inventory rows `form_8959/self_employment_income` and `form_8960/short_term_capital_gains` → `mapped`.

## A down-payment on the flow-matrix (`tenforty-961`)

F4 and F5 now reach their forms through a spec `importForm`, not a mapping-table entry — invisible to the inventory's dict check. Rather than fake a mapping, `_graph_flows` checks the **derivative**: the concept reaches the form iff `d(form output)/d(natural) ≠ 0` in an active case. That's the honest test of a consumer edge, robust to import-vs-mapping, and correct for both. It uses the fan-out-aware autodiff from #294.

## Note on the F4 approach

First tried importing 1040 line 7 (the line Form 8960 actually names, matching #296). Exporting L7 renumbered nodes and broke ~213 cases with `Node 37 not found` in the linker. Switched to importing Schedule D line 16 directly — already an export, semantically identical (1040 L7 *is* Schedule D L16), no node churn. Worth knowing the outputs list is load-bearing on node identity.

## Found and left for follow-up

- **`tenforty-kf4`** (P2) — graph Schedule D line 16 sums the net gain without the §1211(b) $3,000 loss limitation. Harmless for these gain cases; wrong for a net-loss return, and now also feeds 8960 line 5a. OTS applies it (which is what #296 leaned on).
- **`tenforty-db5`** (P3) — the dead `qualifiedDividendBrackets` tables duplicate the inline 1040 breakpoints. This duplication *is* the F13 smell: two sources, neither authoritative, both drifted.

## Not touched

`spec-lint-strict` fails on pre-existing unused-pragma hints in `test/*.hs` (unrelated to any form). And `make spec-fmt` reformats `USForm6251_*.hs` — pre-existing unformatted-on-main Haskell; reverted from this diff to keep it focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)