### PR TITLE
test: F18 strict-xfail burn-in for graph capital-loss limitation

### DIFF
--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -415,7 +415,22 @@ differential sweep passes on the graph backend with none of them.
 Two things found and deliberately left for follow-up: `Tables2025.hs`'s
 `qualifiedDividendBrackets2025` (and the 2024 twin) is dead — the live
 breakpoints are inline in the 1040, so the two should be reconciled or the
-dead table removed. And graph Schedule D line 16 sums the net gain without the
-section 1211(b) $3,000 capital-loss limitation; harmless for the gain cases
-here but wrong for a net-loss return, on both the main tax and the imported
-8960 line 5a.
+dead table removed (`tenforty-db5`). And the F18 capital-loss limitation below.
+
+### F18. NEW — graph omits the section 1211(b) $3,000 capital-loss limitation
+
+Graph Schedule D line 16 sums the net gain or loss without the section 1211(b)
+$3,000 cap ($1,500 MFS). 1040 line 7 imports that uncapped figure, so a
+net-loss return understates AGI and taxable income; and F4-graph now imports
+Form 8960 line 5a from the same node, so the uncapped loss also understates
+NIIT — e.g. $300k wages + $100k interest + a $50k short-term loss yields graph
+NIIT on the full $50k offset rather than the $3,000 the statute allows ($3,686
+correct). Harmless for the gain cases the sweep exercises; the sweep does not
+appear to emit net-loss cases, which is why F18 is hand-found rather than
+signature-surfaced.
+
+The fix is structural, not a cap on line 16 (the QCGWS line-3 smaller-of test
+genuinely wants the uncapped net): introduce Schedule D line 21 with the
+$3,000/$1,500-MFS cap, and route 1040 line 7 and 8960 line 5a through line 21
+while leaving the worksheet on line 16. Tracked as `tenforty-kf4`; recorded as
+the strict-xfail `test_graph_niit_honors_the_capital_loss_limitation`.

--- a/tests/known_defects_test.py
+++ b/tests/known_defects_test.py
@@ -105,6 +105,33 @@ def test_ots_niit_honors_the_capital_loss_limitation():
         assert r.federal_niit == pytest.approx(3_686.0, abs=1.0), kind
 
 
+@pytest.mark.xfail(
+    reason="F18: graph Schedule D line 16 omits the section 1211(b) $3,000 "
+    "capital-loss limitation, so the full net loss flows to Form 8960 line 5a "
+    "(tenforty-kf4)",
+    strict=True,
+)
+@skip_if_graph_unavailable
+def test_graph_niit_honors_the_capital_loss_limitation():
+    """Same case on the graph backend: a net capital loss offsets NII by $3,000.
+
+    Line 5a imports Schedule D line 16, which the graph does not cap under
+    section 1211(b). $100k of interest against a $50k loss must leave $97,000
+    of NII (NIIT = 3.8% x $97,000 = $3,686), not the uncapped $50,000 offset
+    the graph currently applies. Fixed by tenforty-kf4 (Schedule D line 21).
+    """
+    for kind in ("short_term_capital_gains", "long_term_capital_gains"):
+        r = evaluate_return(
+            year=2024,
+            filing_status="Single",
+            w2_income=300_000,
+            taxable_interest=100_000,
+            backend="graph",
+            **{kind: -50_000},
+        )
+        assert r.federal_niit == pytest.approx(3_686.0, abs=1.0), kind
+
+
 def test_ots_niit_fires_when_gains_are_the_only_investment_income():
     """Form 8960 must run when capital gains are the sole investment income.
 


### PR DESCRIPTION
The burn-in that should have shipped with #297 but never got pushed before merge.

## What & why

#297's F4-graph fix routed Form 8960 line 5a through Schedule D line 16, which the graph sums **without** the section 1211(b) $3,000 capital-loss limitation. So a net-loss return now understates AGI/taxable income **and** NIIT. Concretely — $300k wages + $100k interest + a $50k short-term loss:

| | graph | correct |
|---|---|---|
| NII offset from the loss | full $50,000 | $3,000 (statutory cap) |
| NIIT | $1,140 | **$3,686** |

This is tracked as **tenforty-kf4** (now P1). This PR doesn't fix it — it makes it **durable**: a strict-xfail that asserts the correct figure and flips green the moment kf4 lands, mirroring the passing OTS guard (`test_ots_niit_honors_the_capital_loss_limitation`) right beside it.

## Contents

- `tests/known_defects_test.py` — `test_graph_niit_honors_the_capital_loss_limitation` (strict xfail, both STCG/LTCG loss variants).
- `docs/taxcalc-differential-audit.md` — finding **F18**, including the *structural* fix (Schedule D line 21 with the $3,000/$1,500-MFS cap; route 1040 L7 and 8960 L5a through line 21, leave the QCGWS smaller-of test on the uncapped line 16 — **not** a cap on line 16 itself, which would corrupt the worksheet).

Additive only; no computed figures change. Locally: `known_defects_test.py` → 10 passed, 9 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)