### PR TITLE
fix: apply the section 1211(b) capital-loss limitation in the graph (F18)

### DIFF
--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -417,20 +417,24 @@ Two things found and deliberately left for follow-up: `Tables2025.hs`'s
 breakpoints are inline in the 1040, so the two should be reconciled or the
 dead table removed (`tenforty-db5`). And the F18 capital-loss limitation below.
 
-### F18. NEW — graph omits the section 1211(b) $3,000 capital-loss limitation
+### F18. FIXED — graph omits the section 1211(b) $3,000 capital-loss limitation
 
-Graph Schedule D line 16 sums the net gain or loss without the section 1211(b)
-$3,000 cap ($1,500 MFS). 1040 line 7 imports that uncapped figure, so a
-net-loss return understates AGI and taxable income; and F4-graph now imports
-Form 8960 line 5a from the same node, so the uncapped loss also understates
-NIIT — e.g. $300k wages + $100k interest + a $50k short-term loss yields graph
+Graph Schedule D line 16 summed the net gain or loss without the section
+1211(b) $3,000 cap ($1,500 MFS). 1040 line 7 imported that uncapped figure, so
+a net-loss return understated AGI and taxable income; and F4-graph imported
+Form 8960 line 5a from the same node, so the uncapped loss also understated
+NIIT — e.g. $300k wages + $100k interest + a $50k short-term loss yielded graph
 NIIT on the full $50k offset rather than the $3,000 the statute allows ($3,686
 correct). Harmless for the gain cases the sweep exercises; the sweep does not
-appear to emit net-loss cases, which is why F18 is hand-found rather than
+appear to emit net-loss cases, which is why F18 was hand-found rather than
 signature-surfaced.
 
 The fix is structural, not a cap on line 16 (the QCGWS line-3 smaller-of test
-genuinely wants the uncapped net): introduce Schedule D line 21 with the
-$3,000/$1,500-MFS cap, and route 1040 line 7 and 8960 line 5a through line 21
-while leaving the worksheet on line 16. Tracked as `tenforty-kf4`; recorded as
-the strict-xfail `test_graph_niit_honors_the_capital_loss_limitation`.
+genuinely wants the uncapped net): Schedule D now computes line 21 as
+`maxE line16 (byStatus -3000/-1500-MFS)` — a gain passes through, a loss is
+floored at the cap — and 1040 line 7 and 8960 line 5a import line 21 while the
+worksheet stays on line 16. Verified against OTS to the penny across STCG/LTCG
+losses, the MFS half-cap, sub-cap losses, and gain cases (unchanged); AGI on a
+net-loss return now falls by at most the cap. The strict-xfail
+`test_graph_niit_honors_the_capital_loss_limitation` flipped to a passing
+guard. Closed by `tenforty-kf4`.

--- a/src/tenforty/forms/us_1040_2024.json
+++ b/src/tenforty/forms/us_1040_2024.json
@@ -2,7 +2,7 @@
     "imports": [
         {
             "form": "us_schedule_d",
-            "line": "L16",
+            "line": "L21",
             "year": 2024
         },
         {
@@ -656,7 +656,7 @@
             "name": "L7_capital_gain_loss",
             "op": {
                 "form": "us_schedule_d",
-                "line": "L16",
+                "line": "L21",
                 "type": "import",
                 "year": 2024
             }

--- a/src/tenforty/forms/us_1040_2025.json
+++ b/src/tenforty/forms/us_1040_2025.json
@@ -2,7 +2,7 @@
     "imports": [
         {
             "form": "us_schedule_d",
-            "line": "L16",
+            "line": "L21",
             "year": 2025
         },
         {
@@ -656,7 +656,7 @@
             "name": "L7_capital_gain_loss",
             "op": {
                 "form": "us_schedule_d",
-                "line": "L16",
+                "line": "L21",
                 "type": "import",
                 "year": 2025
             }

--- a/src/tenforty/forms/us_form_8960_2024.json
+++ b/src/tenforty/forms/us_form_8960_2024.json
@@ -2,7 +2,7 @@
     "imports": [
         {
             "form": "us_schedule_d",
-            "line": "L16",
+            "line": "L21",
             "year": 2024
         },
         {
@@ -81,7 +81,7 @@
             "name": "L5a_net_gain_disposition",
             "op": {
                 "form": "us_schedule_d",
-                "line": "L16",
+                "line": "L21",
                 "type": "import",
                 "year": 2024
             }

--- a/src/tenforty/forms/us_form_8960_2025.json
+++ b/src/tenforty/forms/us_form_8960_2025.json
@@ -2,7 +2,7 @@
     "imports": [
         {
             "form": "us_schedule_d",
-            "line": "L16",
+            "line": "L21",
             "year": 2025
         },
         {
@@ -81,7 +81,7 @@
             "name": "L5a_net_gain_disposition",
             "op": {
                 "form": "us_schedule_d",
-                "line": "L16",
+                "line": "L21",
                 "type": "import",
                 "year": 2025
             }

--- a/src/tenforty/forms/us_schedule_d_2024.json
+++ b/src/tenforty/forms/us_schedule_d_2024.json
@@ -194,11 +194,68 @@
                 "type": "add"
             }
         },
+        "29": {
+            "id": 29,
+            "op": {
+                "type": "literal",
+                "value": -3000
+            }
+        },
         "3": {
             "id": 3,
             "name": "L3_short_term_8949_box_c",
             "op": {
                 "type": "input"
+            }
+        },
+        "30": {
+            "id": 30,
+            "op": {
+                "type": "literal",
+                "value": -3000
+            }
+        },
+        "31": {
+            "id": 31,
+            "op": {
+                "type": "literal",
+                "value": -1500
+            }
+        },
+        "32": {
+            "id": 32,
+            "op": {
+                "type": "literal",
+                "value": -3000
+            }
+        },
+        "33": {
+            "id": 33,
+            "op": {
+                "type": "literal",
+                "value": -3000
+            }
+        },
+        "34": {
+            "id": 34,
+            "op": {
+                "type": "by_status",
+                "values": {
+                    "head_of_household": 32,
+                    "married_joint": 30,
+                    "married_separate": 31,
+                    "qualifying_widow": 33,
+                    "single": 29
+                }
+            }
+        },
+        "35": {
+            "id": 35,
+            "name": "L21_allowable_capital_loss",
+            "op": {
+                "left": 28,
+                "right": 34,
+                "type": "max"
             }
         },
         "4": {
@@ -247,6 +304,7 @@
     "outputs": [
         27,
         28,
+        35,
         20
     ],
     "tables": {}

--- a/src/tenforty/forms/us_schedule_d_2025.json
+++ b/src/tenforty/forms/us_schedule_d_2025.json
@@ -194,11 +194,68 @@
                 "type": "add"
             }
         },
+        "29": {
+            "id": 29,
+            "op": {
+                "type": "literal",
+                "value": -3000
+            }
+        },
         "3": {
             "id": 3,
             "name": "L3_short_term_8949_box_c",
             "op": {
                 "type": "input"
+            }
+        },
+        "30": {
+            "id": 30,
+            "op": {
+                "type": "literal",
+                "value": -3000
+            }
+        },
+        "31": {
+            "id": 31,
+            "op": {
+                "type": "literal",
+                "value": -1500
+            }
+        },
+        "32": {
+            "id": 32,
+            "op": {
+                "type": "literal",
+                "value": -3000
+            }
+        },
+        "33": {
+            "id": 33,
+            "op": {
+                "type": "literal",
+                "value": -3000
+            }
+        },
+        "34": {
+            "id": 34,
+            "op": {
+                "type": "by_status",
+                "values": {
+                    "head_of_household": 32,
+                    "married_joint": 30,
+                    "married_separate": 31,
+                    "qualifying_widow": 33,
+                    "single": 29
+                }
+            }
+        },
+        "35": {
+            "id": 35,
+            "name": "L21_allowable_capital_loss",
+            "op": {
+                "left": 28,
+                "right": 34,
+                "type": "max"
             }
         },
         "4": {
@@ -247,6 +304,7 @@
     "outputs": [
         27,
         28,
+        35,
         20
     ],
     "tables": {}

--- a/tenforty-spec/forms/US1040_2024.hs
+++ b/tenforty-spec/forms/US1040_2024.hs
@@ -104,6 +104,11 @@ us1040_2024 = form "us_1040" 2024 $ do
     let qcgws2 = l3a
 
     -- Line 3: If Sched D used, smaller of D15 or D16. If not, L7.
+    -- NB: l7 is now Schedule D L21 (the section 1211(b)-capped net), not the
+    -- uncapped L16 the instruction names. The proxy is exact here: capped and
+    -- uncapped differ only when the net loss exceeds the cap, and there both
+    -- legs of the min are negative, so max0 floors this term to 0 either way.
+    -- Guarded by test_graph_capital_loss_cap_does_not_leak_into_the_qcgws.
     qcgws3 <- interior "qcgws_3" "work_l3" $ max0 (minE l15SchedD l7)
 
     qcgws4 <- interior "qcgws_4" "work_l4" $ qcgws2 .+. qcgws3

--- a/tenforty-spec/forms/US1040_2024.hs
+++ b/tenforty-spec/forms/US1040_2024.hs
@@ -42,7 +42,7 @@ us1040_2024 = form "us_1040" 2024 $ do
     _l6a <- keyInput "L6a" "social_security_gross" "Total Social Security benefits received"
     l6b <- keyInput "L6b" "social_security_taxable" "Taxable Social Security benefits"
 
-    l7 <- interior "L7" "capital_gain_loss" $ importForm "us_schedule_d" "L16"
+    l7 <- interior "L7" "capital_gain_loss" $ importForm "us_schedule_d" "L21"
 
     l8 <- interior "L8" "schedule_1_income" $ importForm "us_schedule_1" "L10"
 

--- a/tenforty-spec/forms/US1040_2025.hs
+++ b/tenforty-spec/forms/US1040_2025.hs
@@ -104,6 +104,11 @@ us1040_2025 = form "us_1040" 2025 $ do
     let qcgws2 = l3a
 
     -- Line 3: If Sched D used, smaller of D15 or D16. If not, L7.
+    -- NB: l7 is now Schedule D L21 (the section 1211(b)-capped net), not the
+    -- uncapped L16 the instruction names. The proxy is exact here: capped and
+    -- uncapped differ only when the net loss exceeds the cap, and there both
+    -- legs of the min are negative, so max0 floors this term to 0 either way.
+    -- Guarded by test_graph_capital_loss_cap_does_not_leak_into_the_qcgws.
     qcgws3 <- interior "qcgws_3" "work_l3" $ max0 (minE l15SchedD l7)
 
     qcgws4 <- interior "qcgws_4" "work_l4" $ qcgws2 .+. qcgws3

--- a/tenforty-spec/forms/US1040_2025.hs
+++ b/tenforty-spec/forms/US1040_2025.hs
@@ -42,7 +42,7 @@ us1040_2025 = form "us_1040" 2025 $ do
     _l6a <- keyInput "L6a" "social_security_gross" "Total Social Security benefits received"
     l6b <- keyInput "L6b" "social_security_taxable" "Taxable Social Security benefits"
 
-    l7 <- interior "L7" "capital_gain_loss" $ importForm "us_schedule_d" "L16"
+    l7 <- interior "L7" "capital_gain_loss" $ importForm "us_schedule_d" "L21"
 
     l8 <- interior "L8" "schedule_1_income" $ importForm "us_schedule_1" "L10"
 

--- a/tenforty-spec/forms/USForm8960_2024.hs
+++ b/tenforty-spec/forms/USForm8960_2024.hs
@@ -19,7 +19,7 @@ usForm8960_2024 = form "us_form_8960" 2024 $ do
     l4b <- keyInput "L4b" "adjustment_active_business" "Adjustment for net income/loss from active trade/business"
     l4c <- interior "L4c" "net_rental_royalty" $ l4a .+. l4b
 
-    l5a <- interior "L5a" "net_gain_disposition" $ importForm "us_schedule_d" "L16"
+    l5a <- interior "L5a" "net_gain_disposition" $ importForm "us_schedule_d" "L21"
     l5b <- keyInput "L5b" "adjustment_disposition" "Adjustments from disposition of partnership/S corp interest"
     l5c <- interior "L5c" "net_gain_adjusted" $ l5a .+. l5b
     l5d <- keyInput "L5d" "net_gain_estate_trust" "Net gain or loss from estate or trust"

--- a/tenforty-spec/forms/USForm8960_2025.hs
+++ b/tenforty-spec/forms/USForm8960_2025.hs
@@ -19,7 +19,7 @@ usForm8960_2025 = form "us_form_8960" 2025 $ do
     l4b <- keyInput "L4b" "adjustment_active_business" "Adjustment for net income/loss from active trade/business"
     l4c <- interior "L4c" "net_rental_royalty" $ l4a .+. l4b
 
-    l5a <- interior "L5a" "net_gain_disposition" $ importForm "us_schedule_d" "L16"
+    l5a <- interior "L5a" "net_gain_disposition" $ importForm "us_schedule_d" "L21"
     l5b <- keyInput "L5b" "adjustment_disposition" "Adjustments from disposition of partnership/S corp interest"
     l5c <- interior "L5c" "net_gain_adjusted" $ l5a .+. l5b
     l5d <- keyInput "L5d" "net_gain_estate_trust" "Net gain or loss from estate or trust"

--- a/tenforty-spec/forms/USScheduleD_2024.hs
+++ b/tenforty-spec/forms/USScheduleD_2024.hs
@@ -34,8 +34,27 @@ usScheduleD_2024 = form "us_schedule_d" 2024 $ do
             sumOf [l8a, l8b, l9, l10, l11, l12, l13, l14]
 
     -- Part III: Summary
-    _l16 <-
+    l16 <-
         keyOutput "L16" "net_capital_gain_loss" "Net capital gain or loss" $
             l7 .+. l15
 
-    outputs ["L7", "L15", "L16"]
+    -- Line 21: the section 1211(b) limitation. A net capital LOSS is
+    -- deductible against ordinary income only up to $3,000 ($1,500 MFS); the
+    -- rest carries forward. A gain passes through unchanged. `maxE l16 negCap`
+    -- captures both: for a gain it returns line 16, for a loss it floors the
+    -- deduction at the cap. This capped figure is what flows to Form 1040
+    -- line 7 (and thence Form 8960 line 5a). Line 16 stays the true net for
+    -- the Qualified Dividends worksheet's smaller-of-15-or-16 test.
+    l21 <-
+        keyOutput "L21" "allowable_capital_loss" "Allowable capital gain or (loss) after the section 1211(b) limitation" $
+            maxE l16 $
+                byStatusE $
+                    ByStatus
+                        { bsSingle = dollars (-3000)
+                        , bsMarriedJoint = dollars (-3000)
+                        , bsMarriedSeparate = dollars (-1500)
+                        , bsHeadOfHousehold = dollars (-3000)
+                        , bsQualifyingWidow = dollars (-3000)
+                        }
+
+    outputs ["L7", "L15", "L16", "L21"]

--- a/tenforty-spec/forms/USScheduleD_2025.hs
+++ b/tenforty-spec/forms/USScheduleD_2025.hs
@@ -34,8 +34,27 @@ usScheduleD_2025 = form "us_schedule_d" 2025 $ do
             sumOf [l8a, l8b, l9, l10, l11, l12, l13, l14]
 
     -- Part III: Summary
-    _l16 <-
+    l16 <-
         keyOutput "L16" "net_capital_gain_loss" "Net capital gain or loss" $
             l7 .+. l15
 
-    outputs ["L7", "L15", "L16"]
+    -- Line 21: the section 1211(b) limitation. A net capital LOSS is
+    -- deductible against ordinary income only up to $3,000 ($1,500 MFS); the
+    -- rest carries forward. A gain passes through unchanged. `maxE l16 negCap`
+    -- captures both: for a gain it returns line 16, for a loss it floors the
+    -- deduction at the cap. This capped figure is what flows to Form 1040
+    -- line 7 (and thence Form 8960 line 5a). Line 16 stays the true net for
+    -- the Qualified Dividends worksheet's smaller-of-15-or-16 test.
+    l21 <-
+        keyOutput "L21" "allowable_capital_loss" "Allowable capital gain or (loss) after the section 1211(b) limitation" $
+            maxE l16 $
+                byStatusE $
+                    ByStatus
+                        { bsSingle = dollars (-3000)
+                        , bsMarriedJoint = dollars (-3000)
+                        , bsMarriedSeparate = dollars (-1500)
+                        , bsHeadOfHousehold = dollars (-3000)
+                        , bsQualifyingWidow = dollars (-3000)
+                        }
+
+    outputs ["L7", "L15", "L16", "L21"]

--- a/tests/known_defects_test.py
+++ b/tests/known_defects_test.py
@@ -105,20 +105,14 @@ def test_ots_niit_honors_the_capital_loss_limitation():
         assert r.federal_niit == pytest.approx(3_686.0, abs=1.0), kind
 
 
-@pytest.mark.xfail(
-    reason="F18: graph Schedule D line 16 omits the section 1211(b) $3,000 "
-    "capital-loss limitation, so the full net loss flows to Form 8960 line 5a "
-    "(tenforty-kf4)",
-    strict=True,
-)
 @skip_if_graph_unavailable
 def test_graph_niit_honors_the_capital_loss_limitation():
     """Same case on the graph backend: a net capital loss offsets NII by $3,000.
 
-    Line 5a imports Schedule D line 16, which the graph does not cap under
-    section 1211(b). $100k of interest against a $50k loss must leave $97,000
-    of NII (NIIT = 3.8% x $97,000 = $3,686), not the uncapped $50,000 offset
-    the graph currently applies. Fixed by tenforty-kf4 (Schedule D line 21).
+    Line 5a imports Schedule D line 21, which caps the deductible loss under
+    section 1211(b). $100k of interest against a $50k loss leaves $97,000 of
+    NII (NIIT = 3.8% x $97,000 = $3,686), not the uncapped $50,000 offset.
+    Fixed by tenforty-kf4 (Schedule D line 21).
     """
     for kind in ("short_term_capital_gains", "long_term_capital_gains"):
         r = evaluate_return(

--- a/tests/known_defects_test.py
+++ b/tests/known_defects_test.py
@@ -126,6 +126,35 @@ def test_graph_niit_honors_the_capital_loss_limitation():
         assert r.federal_niit == pytest.approx(3_686.0, abs=1.0), kind
 
 
+@skip_if_graph_unavailable
+def test_graph_capital_loss_cap_does_not_leak_into_the_qcgws():
+    """The capped Schedule D line 21 is a safe proxy for line 16 in the QCGWS.
+
+    Form 1040 line 7 imports the section 1211(b)-capped line 21, and the
+    Qualified Dividends and Capital Gain Tax Worksheet reads that same line 7 as
+    its line-3 term ("smaller of Schedule D line 15 or line 16"). Reusing the
+    capped figure there is exact only because the worksheet floors the term at
+    zero whenever the cap bites. This case makes that load-bearing: a net LOSS
+    that carries a positive long-term gain leg (D15 = +$10k, D16 = -$40k, below
+    the -$3k cap) must still see no preferential-rate tax. Pinned to OTS so a
+    future refactor that reads an uncapped node, or otherwise breaks the proxy,
+    diverges here rather than silently mispricing the gain leg.
+    """
+    inputs = dict(
+        year=2024,
+        filing_status="Single",
+        w2_income=300_000,
+        taxable_interest=100_000,
+        long_term_capital_gains=10_000,
+        short_term_capital_gains=-50_000,
+    )
+    graph = evaluate_return(backend="graph", **inputs)
+    ots = evaluate_return(backend="ots", **inputs)
+    assert graph.federal_adjusted_gross_income == pytest.approx(397_000.0, abs=1.0)
+    assert graph.federal_income_tax == pytest.approx(ots.federal_income_tax, abs=1.0)
+    assert graph.federal_total_tax == pytest.approx(ots.federal_total_tax, abs=1.0)
+
+
 def test_ots_niit_fires_when_gains_are_the_only_investment_income():
     """Form 8960 must run when capital gains are the sole investment income.
 


### PR DESCRIPTION
Closes **tenforty-kf4**. Flips the F18 burn-in from #298 to a passing guard.

## The defect

Graph Schedule D line 16 summed the net gain/loss with no floor. 1040 line 7 imported it uncapped, and #297's F4-graph fix routed Form 8960 line 5a through the same node — so a **net-loss return understated AGI, taxable income, and NIIT**. IRC §1211(b) allows a net capital loss to offset ordinary income by at most $3,000 ($1,500 MFS), with the rest carried forward.

## The fix — structural, on Schedule D

Schedule D now computes **line 21 = `maxE line16 (byStatus −3000 / −1500-MFS)`**: a gain passes through unchanged, a loss is floored at the cap. 1040 line 7 and 8960 line 5a import **line 21**; **line 16 stays the uncapped true net** for the Qualified Dividends worksheet's smaller-of-15-or-16 test.

Why line 16 doesn't need the cap: the worksheet's line-3 term is `max0(min(net_LT, line7))`, which is nonzero only when *both* legs are positive — i.e. a gain, where capped == uncapped. Every loss case reads zero either way, so routing line 7 through the cap never perturbs the worksheet. (Verified below.)

Carry-forward of the disallowed loss is a separate, larger question, left unmodeled.

## Verification — OTS to the penny

$300k wages + $100k interest, Single unless noted:

| case | graph NIIT | OTS NIIT |
|---|---|---|
| STCG loss −50k | $3,686 | $3,686 |
| LTCG loss −50k | $3,686 | $3,686 |
| sub-cap loss −1k (flows in full) | $3,762 | $3,762 |
| **MFS** STCG loss −50k (½ cap) | $3,743 | $3,743 |
| STCG **gain** +50k (unchanged) | $5,700 | $5,700 |

Income-tax side: on a net-loss return AGI now falls by at most the cap (−$50k loss → AGI $97,000, matching OTS), and gain cases are byte-unchanged.

- Full suite: **704 passed, 12 skipped, 27 xfailed** (the F18 xfail became a pass).
- `spec-lint-strict`: only the pre-existing `test/*.hs` unused-pragma hints (unrelated; same as #297). No hints in the changed forms.

Scope kept tight: reverted an incidental Cython-version regeneration of `ots.cpp` (local 3.2.8 vs committed 3.2.4 — no OTS logic touched) and the pre-existing `USForm6251_*.hs` reformat, same as #297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)