### PR TITLE
refactor: single source for the QCGWS preferential breakpoints (db5)

### DIFF
--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -412,10 +412,12 @@ The five known-defect signatures (`_f4_niit_stcg`, `_f5_graph_8959`,
 `_f17_graph_se_deminimis`) and their strict-xfail burn-ins are deleted; the
 differential sweep passes on the graph backend with none of them.
 
-Two things found and deliberately left for follow-up: `Tables2025.hs`'s
-`qualifiedDividendBrackets2025` (and the 2024 twin) is dead — the live
-breakpoints are inline in the 1040, so the two should be reconciled or the
-dead table removed (`tenforty-db5`). And the F18 capital-loss limitation below.
+Two things found and left for follow-up, both since closed: the dead
+`qualifiedDividendBrackets2025` table (and the 2024 twin) that duplicated the
+inline 1040 breakpoints has been replaced by a single `qualifiedDividend0PctMax`
+/ `qualifiedDividend15PctMax` `ByStatus` source the worksheet reads via
+`byStatusE` — the F13 smell removed (`tenforty-db5`). And the F18 capital-loss
+limitation below.
 
 ### F18. NEW — graph omits the section 1211(b) $3,000 capital-loss limitation
 

--- a/tenforty-spec/forms/Tables2024.hs
+++ b/tenforty-spec/forms/Tables2024.hs
@@ -7,8 +7,8 @@ module Tables2024 (
     standardDeduction2024,
 
     -- * Qualified Dividends / Long-Term Capital Gains
-    qualifiedDividendBrackets2024,
-    qualifiedDividendTable2024,
+    qualifiedDividend0PctMax2024,
+    qualifiedDividend15PctMax2024,
 
     -- * AMT Exemptions and Thresholds
     amtExemption2024,
@@ -110,21 +110,15 @@ Order: Single, MFJ, MFS, HoH, QW
 standardDeduction2024 :: ByStatus (Amount Dollars)
 standardDeduction2024 = byStatus 14600 29200 14600 21900 29200
 
-{- | 2024 Qualified dividends / long-term capital gains brackets
-0% up to these thresholds, 15% to next threshold, 20% above
--}
-qualifiedDividendBrackets2024 :: NonEmpty Bracket
-qualifiedDividendBrackets2024 =
-    Bracket (byStatus 47025 94050 47025 63000 94050) 0.00
-        :| [ Bracket (byStatus 518900 583750 291850 551350 583750) 0.15
-           , Bracket (byStatus 1e12 1e12 1e12 1e12 1e12) 0.20
-           ]
+-- Qualified Dividends and Capital Gain Tax Worksheet, lines 6 and 13: the
+-- maximum taxable income taxed at the 0% and 15% preferential rates. Above the
+-- 15% ceiling the rate is 20%. These are the single source for the worksheet's
+-- breakpoints in US1040_2024.
+qualifiedDividend0PctMax2024 :: ByStatus (Amount Dollars)
+qualifiedDividend0PctMax2024 = byStatus 47025 94050 47025 63000 94050
 
-qualifiedDividendTable2024 :: Table
-qualifiedDividendTable2024 =
-    case mkBracketTable qualifiedDividendBrackets2024 of
-        Right bt -> TableBracket "qualified_dividend_brackets_2024" bt
-        Left err -> error $ "Invalid qualified dividend brackets: " ++ err
+qualifiedDividend15PctMax2024 :: ByStatus (Amount Dollars)
+qualifiedDividend15PctMax2024 = byStatus 518900 583750 291850 551350 583750
 
 {- | 2024 AMT exemption amounts
 Order: Single, MFJ, MFS, HoH, QW

--- a/tenforty-spec/forms/Tables2025.hs
+++ b/tenforty-spec/forms/Tables2025.hs
@@ -7,8 +7,8 @@ module Tables2025 (
     standardDeduction2025,
 
     -- * Qualified Dividends / Long-Term Capital Gains
-    qualifiedDividendBrackets2025,
-    qualifiedDividendTable2025,
+    qualifiedDividend0PctMax2025,
+    qualifiedDividend15PctMax2025,
 
     -- * AMT Exemptions and Thresholds
     amtExemption2025,
@@ -103,18 +103,15 @@ federalBracketsTable2025 =
 standardDeduction2025 :: ByStatus (Amount Dollars)
 standardDeduction2025 = byStatus 15750 31500 15750 23625 31500
 
-qualifiedDividendBrackets2025 :: NonEmpty Bracket
-qualifiedDividendBrackets2025 =
-    Bracket (byStatus 48350 96700 48350 64750 96700) 0.00
-        :| [ Bracket (byStatus 533400 600050 300025 566700 600050) 0.15
-           , Bracket (byStatus 1e12 1e12 1e12 1e12 1e12) 0.20
-           ]
+-- Qualified Dividends and Capital Gain Tax Worksheet, lines 6 and 13: the
+-- maximum taxable income taxed at the 0% and 15% preferential rates. Above the
+-- 15% ceiling the rate is 20%. (Rev. Proc. 2024-40.) These are the single
+-- source for the worksheet's breakpoints in US1040_2025.
+qualifiedDividend0PctMax2025 :: ByStatus (Amount Dollars)
+qualifiedDividend0PctMax2025 = byStatus 48350 96700 48350 64750 96700
 
-qualifiedDividendTable2025 :: Table
-qualifiedDividendTable2025 =
-    case mkBracketTable qualifiedDividendBrackets2025 of
-        Right bt -> TableBracket "qualified_dividend_brackets_2025" bt
-        Left err -> error $ "Invalid qualified dividend brackets: " ++ err
+qualifiedDividend15PctMax2025 :: ByStatus (Amount Dollars)
+qualifiedDividend15PctMax2025 = byStatus 533400 600050 300000 566700 600050
 
 amtExemption2025 :: ByStatus (Amount Dollars)
 amtExemption2025 = byStatus 88100 137000 68500 88100 137000

--- a/tenforty-spec/forms/US1040_2024.hs
+++ b/tenforty-spec/forms/US1040_2024.hs
@@ -112,14 +112,7 @@ us1040_2024 = form "us_1040" 2024 $ do
     -- Line 6 Thresholds (0% bracket)
     qcgws6 <-
         interior "qcgws_6" "work_l6" $
-            byStatusE $
-                ByStatus
-                    { bsSingle = lit 47025
-                    , bsMarriedSeparate = lit 47025
-                    , bsMarriedJoint = lit 94050
-                    , bsQualifyingWidow = lit 94050
-                    , bsHeadOfHousehold = lit 63000
-                    }
+            byStatusE (fmap lit qualifiedDividend0PctMax2024)
 
     qcgws7 <- interior "qcgws_7" "work_l7" $ minE qcgws1 qcgws6
     qcgws8 <- interior "qcgws_8" "work_l8" $ minE qcgws5 qcgws7
@@ -131,14 +124,7 @@ us1040_2024 = form "us_1040" 2024 $ do
     -- Line 13 Thresholds (15% bracket)
     qcgws13 <-
         interior "qcgws_13" "work_l13" $
-            byStatusE $
-                ByStatus
-                    { bsSingle = lit 518900
-                    , bsMarriedSeparate = lit 291850
-                    , bsMarriedJoint = lit 583750
-                    , bsQualifyingWidow = lit 583750
-                    , bsHeadOfHousehold = lit 551350
-                    }
+            byStatusE (fmap lit qualifiedDividend15PctMax2024)
 
     qcgws14 <- interior "qcgws_14" "work_l14" $ minE qcgws1 qcgws13
     qcgws15 <- interior "qcgws_15" "work_l15" $ qcgws5 .+. qcgws9

--- a/tenforty-spec/forms/US1040_2025.hs
+++ b/tenforty-spec/forms/US1040_2025.hs
@@ -112,14 +112,7 @@ us1040_2025 = form "us_1040" 2025 $ do
     -- Line 6 Thresholds (0% bracket)
     qcgws6 <-
         interior "qcgws_6" "work_l6" $
-            byStatusE $
-                ByStatus
-                    { bsSingle = lit 48350
-                    , bsMarriedSeparate = lit 48350
-                    , bsMarriedJoint = lit 96700
-                    , bsQualifyingWidow = lit 96700
-                    , bsHeadOfHousehold = lit 64750
-                    }
+            byStatusE (fmap lit qualifiedDividend0PctMax2025)
 
     qcgws7 <- interior "qcgws_7" "work_l7" $ minE qcgws1 qcgws6
     qcgws8 <- interior "qcgws_8" "work_l8" $ minE qcgws5 qcgws7
@@ -131,14 +124,7 @@ us1040_2025 = form "us_1040" 2025 $ do
     -- Line 13 Thresholds (15% bracket)
     qcgws13 <-
         interior "qcgws_13" "work_l13" $
-            byStatusE $
-                ByStatus
-                    { bsSingle = lit 533400
-                    , bsMarriedSeparate = lit 300000
-                    , bsMarriedJoint = lit 600050
-                    , bsQualifyingWidow = lit 600050
-                    , bsHeadOfHousehold = lit 566700
-                    }
+            byStatusE (fmap lit qualifiedDividend15PctMax2025)
 
     qcgws14 <- interior "qcgws_14" "work_l14" $ minE qcgws1 qcgws13
     qcgws15 <- interior "qcgws_15" "work_l15" $ qcgws5 .+. qcgws9


### PR DESCRIPTION
Closes **tenforty-db5**. Removes the duplication behind the F13 smell.

## The trap

`Tables{2024,2025}.hs` defined `qualifiedDividendBrackets*` and a derived `qualifiedDividendTable*` that **nothing referenced** — the Qualified Dividends and Capital Gain Tax Worksheet in `US1040_{2024,2025}.hs` carried its own inline 0%/15% breakpoints. Two sources, neither authoritative. That's exactly what let F13 happen: the inline 2025 MFS 15% ceiling was wrong ($266,700) while the dead table held a *different* wrong value ($300,025 vs the correct $300,000). A future editor "fixing" the dead table would have seen no effect.

## The change

Replace the dead bracket table with `qualifiedDividend0PctMax*` / `qualifiedDividend15PctMax*` `ByStatus` constants — the same shape as `standardDeduction2024` / `amtExemption2024`, which forms already read via `byStatusE (fmap lit …)` — and point the worksheet at them. One authoritative place per breakpoint per year, matching the established codebase idiom.

## Value-neutral by construction

`byStatusE` over the same literals compiles to the same select node, so **the generated JSON graphs are byte-identical** (`git diff` on `src/tenforty/forms/*.json` is empty) — no computed figure can move, and the `.so` is unchanged.

- Haskell spec tests: **189 examples, 0 failures**.
- 2025 MFS LTCG income tax still $56,779.50 (F13 value preserved).
- `spec-lint-strict`: only the pre-existing `test/*.hs` pragma hints; the deleted `Bracket`/`mkBracketTable` imports are still used by the federal brackets table, so no new unused-import warnings.

Diff is four Haskell files plus a one-line audit-doc note. (Reverted the incidental `USForm6251_*.hs` reformat and left `ots.cpp` untouched, same as #297/#299.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)