### PR TITLE
fix: graph batch paths normalize through TaxReturnInput (F9)

### DIFF
--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -25,7 +25,7 @@ delete the signature, and update this table in the same PR.
 | F6 | OTS 8959 never fires with zero wages | OTS activation semantics | fixed | differential sweep |
 | F7 | "Itemized" force vs best-of divergence | API contract | open (owner decision) | differential sweep |
 | F8 | Cross-mode batch grid explosion | graph batch path | fix in PR #287 | benchmark |
-| F9 | Batch path bypasses TaxReturnInput | graph batch path | open | batch-conformance tests |
+| F9 | Batch path bypasses TaxReturnInput | graph batch path | fixed (tenforty-tve) | batch-conformance tests |
 | F10 | Short-term gains taxed at preferential rates (QCGWS line 3) | graph spec | fixed | differential grid |
 | F11 | 2024 HoH 32% bracket starts \$191,150, not \$191,950 | upstream OpenTaxSolver | adjudicated vs IRS; upstream report pending — not patched locally, we vendor OTS unmodified | differential grid |
 | F12 | Itemized-deduction category changes AMT | API (input model v2) | open (design) | adversarial search |
@@ -149,16 +149,26 @@ diagonal is correct. OTS cross/zip and graph zip are all correct. Prior
 audits used one-row batch cases, where 1×1 = 1 row masks the explosion
 entirely — another instance of easy scenarios hiding a broken path.
 
-### F9. NEW — Graph batch path bypasses TaxReturnInput normalization
+### F9. FIXED — Graph batch path bypasses TaxReturnInput normalization
 
 Found by the differential suite's batch-conformance tests (added post-audit).
-`GraphBackend.evaluate_batch` consumes raw input columns, skipping pydantic
+`GraphBackend.evaluate_batch` consumed raw input columns, skipping pydantic
 model validators and computed fields. Two confirmed symptoms: the
-qualified>ordinary dividend lift is not applied (Single, w2 $60k, qualified
+qualified>ordinary dividend lift was not applied (Single, w2 $60k, qualified
 dividends $12k: scalar AGI $72,000, zip AGI $60,000; OTS zip correct), and
-the `schedule_se_ss_wages` derivation is absent (the batch xfail shipped
-with PR #279). Durable fix: route batch rows through `TaxReturnInput`, or
-move the derivations into the graph spec.
+the `schedule_se_ss_wages` derivation was absent (the batch xfail shipped
+with PR #279).
+
+Fixed by routing each materialized batch row through `TaxReturnInput` inside
+`evaluate_batch`, right after cross mode expands to zip on the Python side —
+so the status-dependent line-8a derivation is available per row — and taking
+the same `model_dump` (excluding year/state/filing_status/standard_or_itemized)
+the single-scenario path uses. Batch now reproduces scalar row-for-row; the
+`batch_input_gap_quantities` excuser is deleted and batch conformance passes
+unexcused. The two strict-xfail burn-ins
+(`test_graph_zip_applies_dividend_normalization`,
+`test_se_tax_graph_batch_matches_single`) flip to passing guards. Closed by
+`tenforty-tve`.
 
 ### F10. NEW — Graph taxes short-term capital gains at preferential rates
 

--- a/src/tenforty/backends/graph.py
+++ b/src/tenforty/backends/graph.py
@@ -335,6 +335,29 @@ class GraphBackend:
             statuses = expanded_statuses
             mode = "zip"
 
+        # Normalize each materialized row through TaxReturnInput so the batch
+        # path applies the same validators (the qualified>ordinary dividend
+        # lift) and computed fields (schedule_se_ss_wages, Schedule SE line 8a)
+        # that evaluate_return() applies via the single-scenario model. Rows are
+        # concrete here — cross mode expanded to zip above — so each entry in
+        # `statuses` pairs with one value per column, and the status-dependent
+        # line-8a derivation can be done per row on the Python side.
+        model_fields = set(TaxReturnInput.model_fields)
+        scenario_fields = [name for name in inputs if name in model_fields]
+        normalized: dict[str, list[float]] = {}
+        for i, status in enumerate(statuses):
+            dumped = TaxReturnInput(
+                year=year,
+                state=state or OTSState.NONE,
+                filing_status=status,
+                **{name: inputs[name][i] for name in scenario_fields},
+            ).model_dump(
+                exclude={"year", "state", "filing_status", "standard_or_itemized"}
+            )
+            for name, value in dumped.items():
+                normalized.setdefault(name, []).append(float(value))
+        inputs = normalized
+
         # Determine required forms using representative inputs from the batch.
         # We use the max-absolute value per input to capture any non-zero cases.
         resolve_inputs = {

--- a/tests/known_defects_test.py
+++ b/tests/known_defects_test.py
@@ -213,10 +213,6 @@ def test_ots_additional_medicare_fires_without_wages():
     assert r.federal_additional_medicare_tax == pytest.approx(693.45, abs=1.0)
 
 
-@pytest.mark.xfail(
-    reason="F9: graph batch bypasses TaxReturnInput normalization",
-    strict=True,
-)
 @skip_if_graph_unavailable
 def test_graph_zip_applies_dividend_normalization():
     """Zip batch must lift ordinary dividends to cover qualified, like scalar."""

--- a/tests/subordinate_forms_test.py
+++ b/tests/subordinate_forms_test.py
@@ -241,20 +241,16 @@ def test_se_tax_mfj_w2_aggregate_does_not_fill_one_spouses_wage_base():
     assert r.federal_se_tax == pytest.approx(expected, abs=0.01)
 
 
-@pytest.mark.xfail(
-    reason=(
-        "The graph batch path does not apply the line 8a derivation. evaluate_return() "
-        "builds a TaxReturnInput, so it picks up the computed schedule_se_ss_wages field; "
-        "GraphBackend.evaluate_batch() takes raw input columns instead, and in cross mode "
-        "the filing-status axis is expanded inside the Rust graph, so a status-dependent "
-        "column cannot be derived on the Python side. The fix belongs in the graph spec, "
-        "which should compute the filer's own SS wages itself."
-    ),
-    strict=True,
-)
 @skip_if_graph_unavailable
 def test_se_tax_graph_batch_matches_single():
-    """Batch and single evaluation must agree on SE tax."""
+    """Batch and single evaluation must agree on SE tax.
+
+    evaluate_batch() now normalizes each materialized row through TaxReturnInput
+    before mapping to graph nodes, so the computed schedule_se_ss_wages field
+    (Schedule SE line 8a) is derived per row on the Python side — cross mode
+    expands to zip in Python before the Rust call, so the filing status is known
+    for each row. Fixed by tenforty-tve (F9).
+    """
     from tenforty import evaluate_returns
 
     kwargs = dict(

--- a/tests/taxcalc/batch_conformance_test.py
+++ b/tests/taxcalc/batch_conformance_test.py
@@ -16,7 +16,7 @@ import pytest
 
 from tenforty import evaluate_return, evaluate_returns
 
-from .taxcalc_policy import batch_input_gap_quantities, evaluate_components
+from .taxcalc_policy import evaluate_components
 
 FIXTURE = Path(__file__).parent / "fixtures" / "taxcalc_goldens.json"
 
@@ -82,10 +82,7 @@ def test_zip_batch_matches_scalar(backend):
     mismatches = []
     for i, case in enumerate(cases):
         scalar = evaluate_components(case, backend)
-        excused = batch_input_gap_quantities(backend, case)
         for quantity, column in BATCH_QUANTITY_COLUMNS.items():
-            if quantity in excused:
-                continue
             batch_value = float(df[column][i])
             if abs(batch_value - scalar[quantity]) > 0.02:
                 mismatches.append(

--- a/tests/taxcalc/taxcalc_policy.py
+++ b/tests/taxcalc/taxcalc_policy.py
@@ -230,27 +230,3 @@ def unexcused_violations(
                 f"expected=[{lo:,.2f}, {hi:,.2f}] (diff {diff:,.2f} > {tol})"
             )
     return violations
-
-
-def batch_input_gap_quantities(backend: str, case: dict) -> set[str]:
-    """F9: graph batch consumes raw columns, bypassing TaxReturnInput.
-
-    Two confirmed symptoms, excused only for batch-vs-scalar conformance:
-    the schedule_se_ss_wages derivation (PR #279's batch xfail) and the
-    qualified>ordinary dividend lift, each cascading through AGI.
-    """
-    if backend != "graph":
-        return set()
-    excused: set[str] = set()
-    if case.get("w2", 0) and case.get("se", 0):
-        excused |= {
-            "se_tax",
-            "agi",
-            "taxable_income",
-            "income_tax",
-            "total_tax",
-            "niit",
-        }
-    if case.get("qual_div", 0) > case.get("ord_div", 0):
-        excused |= {"agi", "taxable_income", "income_tax", "total_tax", "niit"}
-    return excused


### PR DESCRIPTION
Closes **tenforty-tve**. Burns down taxcalc finding **F9**.

## The problem

`GraphBackend.evaluate_batch` consumed raw input columns, skipping the pydantic model validators and computed fields that `evaluate_return()` applies via `TaxReturnInput`. One root cause, two confirmed symptoms, each cascading through AGI:

- **Qualified-dividend lift not applied** — Single, w2 \$60k, qualified dividends \$12k: scalar AGI \$72,000, but zip AGI \$60,000.
- **`schedule_se_ss_wages` derivation absent** — Schedule SE line 8a (the filer's own SS wages, which cap the OASDI charge) was never derived; this was the batch strict-xfail shipped with #279.

## The fix — one place, both modes

Normalize each materialized row through `TaxReturnInput` inside `evaluate_batch`, **immediately after cross mode expands to zip on the Python side** — so the status-dependent line-8a derivation is available per row (the filing status is known for each materialized row) — and take the same `model_dump` (excluding `year`/`state`/`filing_status`/`standard_or_itemized`) the single-scenario path uses. Batch now reproduces scalar **row-for-row** across both `zip` and `cross`.

This retires the stale premise in the old xfail ("the filing-status axis is expanded inside the Rust graph, so a status-dependent column cannot be derived on the Python side") — since #287/#288, cross expands to zip in Python *before* the Rust call.

## Verification

- Full suite: **713 passed, 10 skipped, 26 xfailed** (`TENFORTY_TAXCALC=1`).
- **Batch conformance passes unexcused** — the `batch_input_gap_quantities` excuser is deleted, and `batch_conformance_test.py` compares every quantity with no exemptions (4/4).
- The two strict-xfail burn-ins flip to passing guards: `test_graph_zip_applies_dividend_normalization`, `test_se_tax_graph_batch_matches_single`.
- Ledger + F9 section in `docs/taxcalc-differential-audit.md` → **fixed**.

**Perf note** (for `tenforty-5jl`): this constructs one `TaxReturnInput` per row. Correct and scalar-faithful; a future vectorized normalization can replace it without changing semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)