### PR TITLE
fix: graph QBI base nets the half-SE deduction (F3, graph half)

### DIFF
--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -19,7 +19,7 @@ delete the signature, and update this table in the same PR.
 |----|---------|----------|--------|----------|
 | F1 | Schedule SE L8a never filled | mapping, both backends | fixed (#279, v2025.11) | @bg002h, #278 |
 | F2 | SE-tax error propagates to AGI | consequence of F1 | fixed with F1 | @bg002h, #278 |
-| F3 | QBI: missing (OTS) / gross base (graph) | OTS orchestration + graph spec | open | @bg002h, #278 |
+| F3 | QBI: missing (OTS) / gross base (graph) | OTS orchestration + graph spec | graph base fixed (tenforty-6hr); OTS omission + graph above-threshold open | @bg002h, #278 |
 | F4 | Form 8960 L5a omits short-term gains | mapping, both backends | fixed (OTS #296, graph: L5a imports Schedule D L16) | mapping assessment + differential sweep |
 | F5 | Graph Form 8959 Part II drops SE earnings (line 12 used min, not subtract) | graph spec | fixed | mapping assessment + differential sweep |
 | F6 | OTS 8959 never fires with zero wages | OTS activation semantics | fixed | differential sweep |
@@ -77,13 +77,16 @@ everything downstream of them.
   AGI shift — the decomposition closes to within $2 in **all 145** SE-income
   cases. Pure missing orchestration: no Form 8995 config exists.
 - Graph: the spec **does** implement the 20%-of-taxable-income limitation
-  (a first-pass read of this audit said otherwise). Its sole defect is the
-  base: Form 8995 L1 receives *gross* Schedule C profit instead of profit
+  (a first-pass read of this audit said otherwise). Its sole defect was the
+  base: Form 8995 L1 received *gross* Schedule C profit instead of profit
   net of the §164(f) half-SE deduction. When the base term binds the error
-  is 20% × the half-SE deduction (e.g., $1,130.36 at Single w2 $50k /
-  SE $80k); when the cap binds (the grid's 20 `w2=0` cases) the graph is
-  exactly correct. The 125-case "20% of gross" fit and the up-to-$70,453
-  taxable understatement are the base-bound cases.
+  was 20% × the half-SE deduction (e.g., $1,130.36 at Single w2 $50k /
+  SE $80k); when the cap binds (the grid's 20 `w2=0` cases) the graph was
+  already exactly correct. **Fixed (tenforty-6hr):** Form 8995 now imports
+  Schedule SE line 11 and nets it out before the 20%, so below the §199A
+  threshold the graph agrees with taxcalc to the cent (verified at both the
+  base-bound Single w2 $50k / SE $80k → taxable $94,878.54 and the cap-bound
+  MFJ SE $80k → taxable $36,118.54).
 - Above the §199A thresholds the correct deduction additionally depends on
   business W-2 wages / UBIA / SSTB status — concepts absent from tenforty's
   API (taxcalc assumes zero business wages, phasing the deduction to zero

--- a/src/tenforty/forms/us_form_8995_2024.json
+++ b/src/tenforty/forms/us_form_8995_2024.json
@@ -1,6 +1,11 @@
 {
     "imports": [
         {
+            "form": "us_schedule_se",
+            "line": "L11",
+            "year": 2024
+        },
+        {
             "form": "us_1040",
             "line": "L15_pre_qbi",
             "year": 2024
@@ -38,36 +43,53 @@
         "10": {
             "id": 10,
             "op": {
-                "type": "literal",
-                "value": 0
+                "left": 9,
+                "right": 3,
+                "type": "add"
             }
         },
         "11": {
             "id": 11,
+            "name": "L5_total_qbi",
             "op": {
                 "left": 10,
-                "right": 9,
-                "type": "max"
+                "right": 7,
+                "type": "sub"
             }
         },
         "12": {
             "id": 12,
             "op": {
                 "type": "literal",
-                "value": 0.2
+                "value": 0
             }
         },
         "13": {
             "id": 13,
-            "name": "L6_qbi_component",
             "op": {
-                "left": 11,
-                "right": 12,
-                "type": "mul"
+                "left": 12,
+                "right": 11,
+                "type": "max"
             }
         },
         "14": {
             "id": 14,
+            "op": {
+                "type": "literal",
+                "value": 0.2
+            }
+        },
+        "15": {
+            "id": 15,
+            "name": "L6_qbi_component",
+            "op": {
+                "left": 13,
+                "right": 14,
+                "type": "mul"
+            }
+        },
+        "16": {
+            "id": 16,
             "name": "L9_reit_ptp_total",
             "op": {
                 "left": 4,
@@ -75,44 +97,26 @@
                 "type": "add"
             }
         },
-        "15": {
-            "id": 15,
+        "17": {
+            "id": 17,
             "op": {
                 "type": "literal",
                 "value": 0
             }
         },
-        "16": {
-            "id": 16,
-            "op": {
-                "left": 15,
-                "right": 14,
-                "type": "max"
-            }
-        },
-        "17": {
-            "id": 17,
-            "op": {
-                "type": "literal",
-                "value": 0.2
-            }
-        },
         "18": {
             "id": 18,
-            "name": "L10_reit_ptp_component",
             "op": {
-                "left": 16,
-                "right": 17,
-                "type": "mul"
+                "left": 17,
+                "right": 16,
+                "type": "max"
             }
         },
         "19": {
             "id": 19,
-            "name": "L11_combined_qbi_component",
             "op": {
-                "left": 13,
-                "right": 18,
-                "type": "add"
+                "type": "literal",
+                "value": 0.2
             }
         },
         "2": {
@@ -124,6 +128,24 @@
         },
         "20": {
             "id": 20,
+            "name": "L10_reit_ptp_component",
+            "op": {
+                "left": 18,
+                "right": 19,
+                "type": "mul"
+            }
+        },
+        "21": {
+            "id": 21,
+            "name": "L11_combined_qbi_component",
+            "op": {
+                "left": 15,
+                "right": 20,
+                "type": "add"
+            }
+        },
+        "22": {
+            "id": 22,
             "name": "L12_taxable_income_before",
             "op": {
                 "form": "us_1040",
@@ -132,52 +154,52 @@
                 "year": 2024
             }
         },
-        "21": {
-            "id": 21,
+        "23": {
+            "id": 23,
             "op": {
                 "type": "literal",
                 "value": 0
             }
         },
-        "22": {
-            "id": 22,
+        "24": {
+            "id": 24,
             "op": {
-                "left": 20,
+                "left": 22,
                 "right": 6,
                 "type": "sub"
             }
         },
-        "23": {
-            "id": 23,
+        "25": {
+            "id": 25,
             "name": "L14_taxable_income_less_cg",
             "op": {
-                "left": 21,
-                "right": 22,
+                "left": 23,
+                "right": 24,
                 "type": "max"
             }
         },
-        "24": {
-            "id": 24,
+        "26": {
+            "id": 26,
             "op": {
                 "type": "literal",
                 "value": 0.2
             }
         },
-        "25": {
-            "id": 25,
+        "27": {
+            "id": 27,
             "name": "L15_income_limitation",
             "op": {
-                "left": 23,
-                "right": 24,
+                "left": 25,
+                "right": 26,
                 "type": "mul"
             }
         },
-        "26": {
-            "id": 26,
+        "28": {
+            "id": 28,
             "name": "L16_qbi_deduction",
             "op": {
-                "left": 19,
-                "right": 25,
+                "left": 21,
+                "right": 27,
                 "type": "min"
             }
         },
@@ -211,39 +233,40 @@
         },
         "7": {
             "id": 7,
+            "name": "se_half_deduction",
+            "op": {
+                "form": "us_schedule_se",
+                "line": "L11",
+                "type": "import",
+                "year": 2024
+            }
+        },
+        "8": {
+            "id": 8,
             "op": {
                 "left": 0,
                 "right": 1,
                 "type": "add"
             }
         },
-        "8": {
-            "id": 8,
-            "op": {
-                "left": 7,
-                "right": 2,
-                "type": "add"
-            }
-        },
         "9": {
             "id": 9,
-            "name": "L5_total_qbi",
             "op": {
                 "left": 8,
-                "right": 3,
+                "right": 2,
                 "type": "add"
             }
         }
     },
     "outputs": [
-        18,
-        19,
-        23,
+        20,
+        21,
         25,
-        26,
-        9,
-        13,
-        14
+        27,
+        28,
+        11,
+        15,
+        16
     ],
     "tables": {}
 }

--- a/src/tenforty/forms/us_form_8995_2025.json
+++ b/src/tenforty/forms/us_form_8995_2025.json
@@ -1,6 +1,11 @@
 {
     "imports": [
         {
+            "form": "us_schedule_se",
+            "line": "L11",
+            "year": 2025
+        },
+        {
             "form": "us_1040",
             "line": "L15_pre_qbi",
             "year": 2025
@@ -38,36 +43,53 @@
         "10": {
             "id": 10,
             "op": {
-                "type": "literal",
-                "value": 0
+                "left": 9,
+                "right": 3,
+                "type": "add"
             }
         },
         "11": {
             "id": 11,
+            "name": "L5_total_qbi",
             "op": {
                 "left": 10,
-                "right": 9,
-                "type": "max"
+                "right": 7,
+                "type": "sub"
             }
         },
         "12": {
             "id": 12,
             "op": {
                 "type": "literal",
-                "value": 0.2
+                "value": 0
             }
         },
         "13": {
             "id": 13,
-            "name": "L6_qbi_component",
             "op": {
-                "left": 11,
-                "right": 12,
-                "type": "mul"
+                "left": 12,
+                "right": 11,
+                "type": "max"
             }
         },
         "14": {
             "id": 14,
+            "op": {
+                "type": "literal",
+                "value": 0.2
+            }
+        },
+        "15": {
+            "id": 15,
+            "name": "L6_qbi_component",
+            "op": {
+                "left": 13,
+                "right": 14,
+                "type": "mul"
+            }
+        },
+        "16": {
+            "id": 16,
             "name": "L9_reit_ptp_total",
             "op": {
                 "left": 4,
@@ -75,44 +97,26 @@
                 "type": "add"
             }
         },
-        "15": {
-            "id": 15,
+        "17": {
+            "id": 17,
             "op": {
                 "type": "literal",
                 "value": 0
             }
         },
-        "16": {
-            "id": 16,
-            "op": {
-                "left": 15,
-                "right": 14,
-                "type": "max"
-            }
-        },
-        "17": {
-            "id": 17,
-            "op": {
-                "type": "literal",
-                "value": 0.2
-            }
-        },
         "18": {
             "id": 18,
-            "name": "L10_reit_ptp_component",
             "op": {
-                "left": 16,
-                "right": 17,
-                "type": "mul"
+                "left": 17,
+                "right": 16,
+                "type": "max"
             }
         },
         "19": {
             "id": 19,
-            "name": "L11_combined_qbi_component",
             "op": {
-                "left": 13,
-                "right": 18,
-                "type": "add"
+                "type": "literal",
+                "value": 0.2
             }
         },
         "2": {
@@ -124,6 +128,24 @@
         },
         "20": {
             "id": 20,
+            "name": "L10_reit_ptp_component",
+            "op": {
+                "left": 18,
+                "right": 19,
+                "type": "mul"
+            }
+        },
+        "21": {
+            "id": 21,
+            "name": "L11_combined_qbi_component",
+            "op": {
+                "left": 15,
+                "right": 20,
+                "type": "add"
+            }
+        },
+        "22": {
+            "id": 22,
             "name": "L12_taxable_income_before",
             "op": {
                 "form": "us_1040",
@@ -132,52 +154,52 @@
                 "year": 2025
             }
         },
-        "21": {
-            "id": 21,
+        "23": {
+            "id": 23,
             "op": {
                 "type": "literal",
                 "value": 0
             }
         },
-        "22": {
-            "id": 22,
+        "24": {
+            "id": 24,
             "op": {
-                "left": 20,
+                "left": 22,
                 "right": 6,
                 "type": "sub"
             }
         },
-        "23": {
-            "id": 23,
+        "25": {
+            "id": 25,
             "name": "L14_taxable_income_less_cg",
             "op": {
-                "left": 21,
-                "right": 22,
+                "left": 23,
+                "right": 24,
                 "type": "max"
             }
         },
-        "24": {
-            "id": 24,
+        "26": {
+            "id": 26,
             "op": {
                 "type": "literal",
                 "value": 0.2
             }
         },
-        "25": {
-            "id": 25,
+        "27": {
+            "id": 27,
             "name": "L15_income_limitation",
             "op": {
-                "left": 23,
-                "right": 24,
+                "left": 25,
+                "right": 26,
                 "type": "mul"
             }
         },
-        "26": {
-            "id": 26,
+        "28": {
+            "id": 28,
             "name": "L16_qbi_deduction",
             "op": {
-                "left": 19,
-                "right": 25,
+                "left": 21,
+                "right": 27,
                 "type": "min"
             }
         },
@@ -211,39 +233,40 @@
         },
         "7": {
             "id": 7,
+            "name": "se_half_deduction",
+            "op": {
+                "form": "us_schedule_se",
+                "line": "L11",
+                "type": "import",
+                "year": 2025
+            }
+        },
+        "8": {
+            "id": 8,
             "op": {
                 "left": 0,
                 "right": 1,
                 "type": "add"
             }
         },
-        "8": {
-            "id": 8,
-            "op": {
-                "left": 7,
-                "right": 2,
-                "type": "add"
-            }
-        },
         "9": {
             "id": 9,
-            "name": "L5_total_qbi",
             "op": {
                 "left": 8,
-                "right": 3,
+                "right": 2,
                 "type": "add"
             }
         }
     },
     "outputs": [
-        18,
-        19,
-        23,
+        20,
+        21,
         25,
-        26,
-        9,
-        13,
-        14
+        27,
+        28,
+        11,
+        15,
+        16
     ],
     "tables": {}
 }

--- a/tenforty-spec/forms/USForm8995_2024.hs
+++ b/tenforty-spec/forms/USForm8995_2024.hs
@@ -23,10 +23,18 @@ usForm8995_2024 = form "us_form_8995" 2024 $ do
     l3 <- keyInput "L3" "qbi_business_3" "Qualified business income from trade/business 3"
     l4 <- keyInput "L4" "qbi_business_4" "Qualified business income from trade/business 4"
 
-    -- Line 5: Total qualified business income
+    -- Qualified business income is net of the deductible half of the
+    -- self-employment tax attributable to the business (IRC 199A(c); the
+    -- Schedule C profit that seeds L1 is gross). Import Schedule SE line 11 —
+    -- the deductible part of SE tax — and net it out before the 20%.
+    seHalfDeduction <-
+        interior "se_half_deduction" "Deductible half of SE tax reducing QBI" $
+            importForm "us_schedule_se" "L11"
+
+    -- Line 5: Total qualified business income (net of the half-SE deduction)
     l5 <-
         interior "L5" "total_qbi" $
-            l1 .+. l2 .+. l3 .+. l4
+            (l1 .+. l2 .+. l3 .+. l4) .-. seHalfDeduction
 
     -- Line 6: QBI component. Multiply line 5 by 20% (0.20)
     l6 <-

--- a/tenforty-spec/forms/USForm8995_2025.hs
+++ b/tenforty-spec/forms/USForm8995_2025.hs
@@ -23,10 +23,18 @@ usForm8995_2025 = form "us_form_8995" 2025 $ do
     l3 <- keyInput "L3" "qbi_business_3" "Qualified business income from trade/business 3"
     l4 <- keyInput "L4" "qbi_business_4" "Qualified business income from trade/business 4"
 
-    -- Line 5: Total qualified business income
+    -- Qualified business income is net of the deductible half of the
+    -- self-employment tax attributable to the business (IRC 199A(c); the
+    -- Schedule C profit that seeds L1 is gross). Import Schedule SE line 11 —
+    -- the deductible part of SE tax — and net it out before the 20%.
+    seHalfDeduction <-
+        interior "se_half_deduction" "Deductible half of SE tax reducing QBI" $
+            importForm "us_schedule_se" "L11"
+
+    -- Line 5: Total qualified business income (net of the half-SE deduction)
     l5 <-
         interior "L5" "total_qbi" $
-            l1 .+. l2 .+. l3 .+. l4
+            (l1 .+. l2 .+. l3 .+. l4) .-. seHalfDeduction
 
     -- Line 6: QBI component. Multiply line 5 by 20% (0.20)
     l6 <-

--- a/tests/known_defects_test.py
+++ b/tests/known_defects_test.py
@@ -40,18 +40,15 @@ def test_ots_qbi_deduction_reaches_1040():
     assert r.federal_taxable_income == pytest.approx(36_118.54, abs=1.0)
 
 
-@pytest.mark.xfail(
-    reason="F3: graph QBI base is gross profit, not net of half-SE",
-    strict=True,
-)
 @skip_if_graph_unavailable
 def test_graph_qbi_uses_net_base():
     """Single, $50k wages + $80k SE: QBI base must be net of the half-SE deduction.
 
     Correct deduction is 20% of net profit ($14,869.64), not 20% of gross
     ($16,000). The graph's taxable-income limitation is already correct; only
-    the base is wrong, so this case makes the base term bind (taxable income
-    stays below both the cap and the §199A threshold).
+    the base was wrong, so this case makes the base term bind (taxable income
+    stays below both the cap and the §199A threshold). Form 8995 now imports
+    Schedule SE line 11 and nets it out before the 20%. Fixed by tenforty-6hr.
     """
     r = evaluate_return(
         year=2024,

--- a/tests/taxcalc/taxcalc_policy.py
+++ b/tests/taxcalc/taxcalc_policy.py
@@ -28,7 +28,16 @@ STANDARD_DEDUCTION = {
 
 
 def _f3_qbi(backend: str, case: dict) -> set[str]:
-    """F3: OTS omits the QBI deduction; graph uses gross base."""
+    """F3: QBI divergence on self-employment cases, now from two causes.
+
+    OTS omits the deduction entirely (it reads 1040 line 13 as a direct input
+    and nothing supplies it — tenforty-6hr follow-up). The graph now nets the
+    half-SE deduction into the QBI base and agrees with taxcalc below the
+    section 199A threshold; above it the graph still uses the simplified Form
+    8995 (no W-2-wage/UBIA limit), so it diverges from taxcalc there — a
+    distinct limitation tracked separately. Both faults land on the same
+    self-employment cases, so the excusal stays broad until each is closed.
+    """
     if case.get("se", 0):
         return {"taxable_income", "income_tax", "total_tax"}
     return set()


### PR DESCRIPTION
Advances **tenforty-6hr** (graph half of taxcalc finding **F3**). Split from the OTS half per review.

## The problem

Form 8995 line 1 received *gross* Schedule C profit, so the graph computed the §199A deduction on gross self-employment income instead of profit **net of the §164(f) half-SE deduction**. When the base term binds, the deduction was overstated by 20% × the half-SE deduction (e.g. \$1,130.36 at Single w2 \$50k / SE \$80k).

## The fix

Form 8995 now imports **Schedule SE line 11** (the deductible part of SE tax) and nets it out before the 20%. The import edge pulls Schedule SE into the linked graph automatically whenever 8995 is active (and 8995 is active only when SE income is present, so they always co-occur — no cycle: Schedule SE depends on neither 8995 nor the 1040).

## Verification (below the §199A threshold, to the cent)

| case | binds | graph taxable | expected |
|---|---|---|---|
| Single w2 \$50k / SE \$80k | base | \$94,878.54 | \$94,878.54 |
| MFJ SE \$80k | cap | \$36,118.54 | \$36,118.54 |

- Full suite `TENFORTY_TAXCALC=1`: **712 passed, 10 skipped, 27 xfailed**; differential clean.
- `test_graph_qbi_uses_net_base` flips to a passing guard. Link-year canary passes (existing `.so` loads the regenerated JSON — no rebuild).

## Why this is only the graph half

Two remaining causes are deliberately deferred and filed:

- **`tenforty-2u6`** (P1) — **OTS omission.** OTS's 1040 reads line 13 (QBI) as a direct input that nothing supplies. The follow-up carries a design fork: inject a tenforty-computed QBI (simple, but OTS's QBI becomes tenforty's formula — correlated with the graph, so OTS stops independently validating it) vs. run OTS's own f8995 (preserves independence, needs a 1040 re-run pass the feed-forward orchestration doesn't have). Plus the above-threshold assumption sign-off.
- **`tenforty-mhe`** (P2) — **graph above-threshold.** Above the §199A threshold the graph still uses the simplified Form 8995 (no W-2-wage/UBIA limit), so it diverges from taxcalc there. This is why `_f3_qbi` stays broad rather than narrowing to OTS-only; its docstring names both causes. `test_ots_qbi_deduction_reaches_1040` stays xfail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)