### PR TITLE
chore: fix tenforty-spec local Haskell gates (hlint + cabal test)

### DIFF
--- a/tenforty-spec/test/ExprProperties.hs
+++ b/tenforty-spec/test/ExprProperties.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 

--- a/tenforty-spec/test/Spec.hs
+++ b/tenforty-spec/test/Spec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 

--- a/tenforty-spec/test/Spec.hs
+++ b/tenforty-spec/test/Spec.hs
@@ -764,7 +764,8 @@ spec n = do
                     Right frm -> do
                         let graph = compileForm frm
                         cgImports graph `shouldSatisfy` (not . null)
-                        cgImports graph `shouldContain` [("us_schedule_d", "L16", tyYear ty)]
+                        cgImports graph `shouldContain` [("us_schedule_d", "L21", tyYear ty)]
+                        cgImports graph `shouldContain` [("us_schedule_d", "L15", tyYear ty)]
                     Left err -> expectationFailure $ show err
 
         forM_ taxYears $ \ty ->


### PR DESCRIPTION
Makes the two **local-only** Haskell QA gates for `tenforty-spec` pass again. Neither is run in CI (`deploy.yml` runs pytest + the taxcalc adapter, not hlint or `cabal test`), so both drifted red on `main` without blocking anything.

## 1. `make spec-lint-strict` — unused LANGUAGE pragmas

hlint flagged three unused pragmas, none actually used (no bang patterns, no `\case`):
- `test/Spec.hs`: `BangPatterns`, `LambdaCase`
- `test/ExprProperties.hs`: `LambdaCase`

## 2. `cabal test tenforty-spec-test` — stale Schedule D import assertion

`Spec.hs` asserted the 1040 imports `us_schedule_d L16`. #299 (§1211(b) capital-loss limitation) rewired 1040 line 7 to import the loss-limited `L21` instead; net long-term gain arrives via `L15`. `L16` is no longer imported, so the assertion failed for both 2024 and 2025. Updated to the current wiring (checks both `L21` and `L15`).

## Verification
- `make spec-lint-strict` → **No hints**
- `cabal test tenforty-spec-test` → **189 examples, 0 failures**
- No computed figures touched; graph JSON unchanged.

## Note (not addressed here)
The repo pins no fourmolu version and has no `fourmolu.yaml`, so `make spec-fmt` output is version-dependent and the committed `.hs` formatting is inconsistent. Worth pinning the formatter separately; left out to keep this focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)