### PR TITLE
chore: pin fourmolu + normalize tenforty-spec formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,11 @@ repos:
     files: ^crates/tenforty-graph/demo/.*\.(css|html|js|json)$
 - repo: local
   hooks:
+  - id: fourmolu
+    name: fourmolu (haskell format check)
+    language: system
+    entry: fourmolu --mode check
+    files: ^tenforty-spec/.*\.hs$
   - id: cargo-fmt
     name: cargo fmt
     language: system

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ export UV_INSTALL_MSG
 DEFAULT_GOAL: help
 .PHONY: help clean env env-full env-graph-only jupyter-env test test-full test-all hooks update-hooks run-hooks run-hooks-all-files graph-build graph-build-jit graph-test graph-test-jit graph-bench graph-throughput wasm wasm-dev wasm-serve
 .PHONY: spec-graphs spec-test forms-sync
-.PHONY: spec-fmt spec-lint spec-lint-strict
+.PHONY: spec-fmt spec-fmt-check spec-lint spec-lint-strict
 .PHONY: runner-image bench-zip-mode
 
 check-uv: ## Check if uv is installed
@@ -119,6 +119,9 @@ spec-graphs: ## Generate JSON graphs from tenforty-spec into tenforty-spec/*.jso
 
 spec-fmt: ## Format tenforty-spec (fourmolu, cabal-fmt)
 	$(MAKE) -C tenforty-spec fmt
+
+spec-fmt-check: ## Check tenforty-spec formatting (fourmolu, fails if unformatted)
+	$(MAKE) -C tenforty-spec fmt-check
 
 spec-lint: ## Lint tenforty-spec (hlint, non-blocking)
 	$(MAKE) -C tenforty-spec lint

--- a/tenforty-spec/Makefile
+++ b/tenforty-spec/Makefile
@@ -1,11 +1,11 @@
 .DEFAULT_GOAL := help
-.PHONY: build test compile-all install clean fmt lint lint-strict help
+.PHONY: build test compile-all install clean fmt fmt-check lint lint-strict help
 
 define HASKELL_FMT_INSTALL_MSG
 Missing formatting tools. Install with:
 
     cabal install -j --install-method=copy --installdir "$$HOME/.local/bin" \
-        --overwrite-policy=always -w ghc-9.6 fourmolu cabal-fmt
+        --overwrite-policy=always -w ghc-9.6 fourmolu-0.15.0.0 cabal-fmt
 endef
 export HASKELL_FMT_INSTALL_MSG
 
@@ -33,6 +33,13 @@ fmt: ## Format Haskell (fourmolu) and .cabal (cabal-fmt)
 	fi
 	@find app src forms test -type f -name '*.hs' -print0 | xargs -0 fourmolu -i
 	@find . -maxdepth 1 -type f -name '*.cabal' -print0 | xargs -0 cabal-fmt -i
+
+fmt-check: ## Check Haskell formatting (fourmolu, fails if unformatted)
+	@if ! command -v fourmolu >/dev/null 2>&1; then \
+		echo "$$HASKELL_FMT_INSTALL_MSG"; \
+		exit 1; \
+	fi
+	@find app src forms test -type f -name '*.hs' -print0 | xargs -0 fourmolu --mode check
 
 lint: ## Lint Haskell (hlint, non-blocking)
 	@if ! command -v hlint >/dev/null 2>&1; then \

--- a/tenforty-spec/forms/USForm6251_2024.hs
+++ b/tenforty-spec/forms/USForm6251_2024.hs
@@ -165,24 +165,31 @@ usForm6251_2024 = form "us_form_6251" 2024 $ do
             l7b .+. l7d
 
     -- Part III: Tax Computation Using Maximum Capital Gains Rates
-    preferentialIncome <- interior "P3_pref_income" "preferential_income" $
-        importForm "us_1040" "qcgws_4"
-    ordinaryTaxableIncome <- interior "P3_ord_taxable" "ordinary_taxable_income" $
-        importForm "us_1040" "qcgws_5"
+    preferentialIncome <-
+        interior "P3_pref_income" "preferential_income" $
+            importForm "us_1040" "qcgws_4"
+    ordinaryTaxableIncome <-
+        interior "P3_ord_taxable" "ordinary_taxable_income" $
+            importForm "us_1040" "qcgws_5"
 
     -- Split AMT taxable income into ordinary and preferential portions
-    prefInAmt <- interior "P3_pref_in_amt" "amt_preferential" $
-        smallerOf l6 preferentialIncome
-    ordinaryAmt <- interior "P3_ord_amt" "amt_ordinary" $
-        l6 `subtractNotBelowZero` prefInAmt
+    prefInAmt <-
+        interior "P3_pref_in_amt" "amt_preferential" $
+            smallerOf l6 preferentialIncome
+    ordinaryAmt <-
+        interior "P3_ord_amt" "amt_ordinary" $
+            l6 `subtractNotBelowZero` prefInAmt
 
     -- 26%/28% tax on ordinary portion
-    ordTaxAt26 <- interior "P3_ord_26" "amt_ord_26_taxable" $
-        smallerOf ordinaryAmt l7Threshold
-    ordTaxAt28 <- interior "P3_ord_28" "amt_ord_28_taxable" $
-        ordinaryAmt `subtractNotBelowZero` l7Threshold
-    ordTax <- interior "P3_ord_tax" "amt_ord_tax" $
-        (ordTaxAt26 .*. lit 0.26) .+. (ordTaxAt28 .*. lit 0.28)
+    ordTaxAt26 <-
+        interior "P3_ord_26" "amt_ord_26_taxable" $
+            smallerOf ordinaryAmt l7Threshold
+    ordTaxAt28 <-
+        interior "P3_ord_28" "amt_ord_28_taxable" $
+            ordinaryAmt `subtractNotBelowZero` l7Threshold
+    ordTax <-
+        interior "P3_ord_tax" "amt_ord_tax" $
+            (ordTaxAt26 .*. lit 0.26) .+. (ordTaxAt28 .*. lit 0.28)
 
     -- 0% bracket for preferential income
     zeroBracket <-
@@ -195,10 +202,12 @@ usForm6251_2024 = form "us_form_6251" 2024 $ do
                     , bsQualifyingWidow = lit 94050
                     , bsHeadOfHousehold = lit 63000
                     }
-    zeroRoom <- interior "P3_zero_room" "amt_cg_zero_room" $
-        zeroBracket `subtractNotBelowZero` ordinaryTaxableIncome
-    zeroAmt <- interior "P3_zero_amt" "amt_cg_zero_amt" $
-        smallerOf zeroRoom prefInAmt
+    zeroRoom <-
+        interior "P3_zero_room" "amt_cg_zero_room" $
+            zeroBracket `subtractNotBelowZero` ordinaryTaxableIncome
+    zeroAmt <-
+        interior "P3_zero_amt" "amt_cg_zero_amt" $
+            smallerOf zeroRoom prefInAmt
 
     -- 15% bracket for preferential income
     fifteenBracket <-
@@ -211,26 +220,34 @@ usForm6251_2024 = form "us_form_6251" 2024 $ do
                     , bsQualifyingWidow = lit 583750
                     , bsHeadOfHousehold = lit 551350
                     }
-    afterZero <- interior "P3_after_zero" "amt_cg_after_zero" $
-        prefInAmt `subtractNotBelowZero` zeroAmt
-    fifteenUsed <- interior "P3_15_used" "amt_cg_15_used" $
-        zeroRoom .+. ordinaryTaxableIncome
-    fifteenRoom <- interior "P3_15_room" "amt_cg_15_room" $
-        fifteenBracket `subtractNotBelowZero` fifteenUsed
-    fifteenAmt <- interior "P3_15_amt" "amt_cg_15_amt" $
-        smallerOf afterZero fifteenRoom
-    fifteenTax <- interior "P3_15_tax" "amt_cg_15_tax" $
-        fifteenAmt .*. lit 0.15
+    afterZero <-
+        interior "P3_after_zero" "amt_cg_after_zero" $
+            prefInAmt `subtractNotBelowZero` zeroAmt
+    fifteenUsed <-
+        interior "P3_15_used" "amt_cg_15_used" $
+            zeroRoom .+. ordinaryTaxableIncome
+    fifteenRoom <-
+        interior "P3_15_room" "amt_cg_15_room" $
+            fifteenBracket `subtractNotBelowZero` fifteenUsed
+    fifteenAmt <-
+        interior "P3_15_amt" "amt_cg_15_amt" $
+            smallerOf afterZero fifteenRoom
+    fifteenTax <-
+        interior "P3_15_tax" "amt_cg_15_tax" $
+            fifteenAmt .*. lit 0.15
 
     -- 20% on remainder
-    twentyAmt <- interior "P3_20_amt" "amt_cg_20_amt" $
-        prefInAmt `subtractNotBelowZero` (zeroAmt .+. fifteenAmt)
-    twentyTax <- interior "P3_20_tax" "amt_cg_20_tax" $
-        twentyAmt .*. lit 0.20
+    twentyAmt <-
+        interior "P3_20_amt" "amt_cg_20_amt" $
+            prefInAmt `subtractNotBelowZero` (zeroAmt .+. fifteenAmt)
+    twentyTax <-
+        interior "P3_20_tax" "amt_cg_20_tax" $
+            twentyAmt .*. lit 0.20
 
     -- Use preferential-rate computation if applicable, else flat 26/28
-    prefRateTax <- interior "P3_pref_tax" "amt_pref_rate_tax" $
-        ordTax .+. fifteenTax .+. twentyTax
+    prefRateTax <-
+        interior "P3_pref_tax" "amt_pref_rate_tax" $
+            ordTax .+. fifteenTax .+. twentyTax
 
     l7 <-
         interior "L7" "tentative_min_tax_before_cg" $

--- a/tenforty-spec/forms/USForm6251_2025.hs
+++ b/tenforty-spec/forms/USForm6251_2025.hs
@@ -165,24 +165,31 @@ usForm6251_2025 = form "us_form_6251" 2025 $ do
             l7b .+. l7d
 
     -- Part III: Tax Computation Using Maximum Capital Gains Rates
-    preferentialIncome <- interior "P3_pref_income" "preferential_income" $
-        importForm "us_1040" "qcgws_4"
-    ordinaryTaxableIncome <- interior "P3_ord_taxable" "ordinary_taxable_income" $
-        importForm "us_1040" "qcgws_5"
+    preferentialIncome <-
+        interior "P3_pref_income" "preferential_income" $
+            importForm "us_1040" "qcgws_4"
+    ordinaryTaxableIncome <-
+        interior "P3_ord_taxable" "ordinary_taxable_income" $
+            importForm "us_1040" "qcgws_5"
 
     -- Split AMT taxable income into ordinary and preferential portions
-    prefInAmt <- interior "P3_pref_in_amt" "amt_preferential" $
-        smallerOf l6 preferentialIncome
-    ordinaryAmt <- interior "P3_ord_amt" "amt_ordinary" $
-        l6 `subtractNotBelowZero` prefInAmt
+    prefInAmt <-
+        interior "P3_pref_in_amt" "amt_preferential" $
+            smallerOf l6 preferentialIncome
+    ordinaryAmt <-
+        interior "P3_ord_amt" "amt_ordinary" $
+            l6 `subtractNotBelowZero` prefInAmt
 
     -- 26%/28% tax on ordinary portion
-    ordTaxAt26 <- interior "P3_ord_26" "amt_ord_26_taxable" $
-        smallerOf ordinaryAmt l7Threshold
-    ordTaxAt28 <- interior "P3_ord_28" "amt_ord_28_taxable" $
-        ordinaryAmt `subtractNotBelowZero` l7Threshold
-    ordTax <- interior "P3_ord_tax" "amt_ord_tax" $
-        (ordTaxAt26 .*. lit 0.26) .+. (ordTaxAt28 .*. lit 0.28)
+    ordTaxAt26 <-
+        interior "P3_ord_26" "amt_ord_26_taxable" $
+            smallerOf ordinaryAmt l7Threshold
+    ordTaxAt28 <-
+        interior "P3_ord_28" "amt_ord_28_taxable" $
+            ordinaryAmt `subtractNotBelowZero` l7Threshold
+    ordTax <-
+        interior "P3_ord_tax" "amt_ord_tax" $
+            (ordTaxAt26 .*. lit 0.26) .+. (ordTaxAt28 .*. lit 0.28)
 
     -- 0% bracket for preferential income
     zeroBracket <-
@@ -195,10 +202,12 @@ usForm6251_2025 = form "us_form_6251" 2025 $ do
                     , bsQualifyingWidow = lit 96700
                     , bsHeadOfHousehold = lit 64750
                     }
-    zeroRoom <- interior "P3_zero_room" "amt_cg_zero_room" $
-        zeroBracket `subtractNotBelowZero` ordinaryTaxableIncome
-    zeroAmt <- interior "P3_zero_amt" "amt_cg_zero_amt" $
-        smallerOf zeroRoom prefInAmt
+    zeroRoom <-
+        interior "P3_zero_room" "amt_cg_zero_room" $
+            zeroBracket `subtractNotBelowZero` ordinaryTaxableIncome
+    zeroAmt <-
+        interior "P3_zero_amt" "amt_cg_zero_amt" $
+            smallerOf zeroRoom prefInAmt
 
     -- 15% bracket for preferential income
     fifteenBracket <-
@@ -211,26 +220,34 @@ usForm6251_2025 = form "us_form_6251" 2025 $ do
                     , bsQualifyingWidow = lit 600050
                     , bsHeadOfHousehold = lit 566700
                     }
-    afterZero <- interior "P3_after_zero" "amt_cg_after_zero" $
-        prefInAmt `subtractNotBelowZero` zeroAmt
-    fifteenUsed <- interior "P3_15_used" "amt_cg_15_used" $
-        zeroRoom .+. ordinaryTaxableIncome
-    fifteenRoom <- interior "P3_15_room" "amt_cg_15_room" $
-        fifteenBracket `subtractNotBelowZero` fifteenUsed
-    fifteenAmt <- interior "P3_15_amt" "amt_cg_15_amt" $
-        smallerOf afterZero fifteenRoom
-    fifteenTax <- interior "P3_15_tax" "amt_cg_15_tax" $
-        fifteenAmt .*. lit 0.15
+    afterZero <-
+        interior "P3_after_zero" "amt_cg_after_zero" $
+            prefInAmt `subtractNotBelowZero` zeroAmt
+    fifteenUsed <-
+        interior "P3_15_used" "amt_cg_15_used" $
+            zeroRoom .+. ordinaryTaxableIncome
+    fifteenRoom <-
+        interior "P3_15_room" "amt_cg_15_room" $
+            fifteenBracket `subtractNotBelowZero` fifteenUsed
+    fifteenAmt <-
+        interior "P3_15_amt" "amt_cg_15_amt" $
+            smallerOf afterZero fifteenRoom
+    fifteenTax <-
+        interior "P3_15_tax" "amt_cg_15_tax" $
+            fifteenAmt .*. lit 0.15
 
     -- 20% on remainder
-    twentyAmt <- interior "P3_20_amt" "amt_cg_20_amt" $
-        prefInAmt `subtractNotBelowZero` (zeroAmt .+. fifteenAmt)
-    twentyTax <- interior "P3_20_tax" "amt_cg_20_tax" $
-        twentyAmt .*. lit 0.20
+    twentyAmt <-
+        interior "P3_20_amt" "amt_cg_20_amt" $
+            prefInAmt `subtractNotBelowZero` (zeroAmt .+. fifteenAmt)
+    twentyTax <-
+        interior "P3_20_tax" "amt_cg_20_tax" $
+            twentyAmt .*. lit 0.20
 
     -- Use preferential-rate computation if applicable, else flat 26/28
-    prefRateTax <- interior "P3_pref_tax" "amt_pref_rate_tax" $
-        ordTax .+. fifteenTax .+. twentyTax
+    prefRateTax <-
+        interior "P3_pref_tax" "amt_pref_rate_tax" $
+            ordTax .+. fifteenTax .+. twentyTax
 
     l7 <-
         interior "L7" "tentative_min_tax_before_cg" $

--- a/tenforty-spec/fourmolu.yaml
+++ b/tenforty-spec/fourmolu.yaml
@@ -1,0 +1,53 @@
+# Number of spaces per indentation step
+indentation: 4
+
+# Max line length for automatic line breaking
+column-limit: none
+
+# Styling of arrows in type signatures (choices: trailing, leading, or leading-args)
+function-arrows: trailing
+
+# How to place commas in multi-line lists, records, etc. (choices: leading or trailing)
+comma-style: leading
+
+# Styling of import/export lists (choices: leading, trailing, or diff-friendly)
+import-export-style: diff-friendly
+
+# Whether to full-indent or half-indent 'where' bindings past the preceding body
+indent-wheres: false
+
+# Whether to leave a space before an opening record brace
+record-brace-space: false
+
+# Number of spaces between top-level declarations
+newlines-between-decls: 1
+
+# How to print Haddock comments (choices: single-line, multi-line, or multi-line-compact)
+haddock-style: multi-line
+
+# How to print module docstring
+haddock-style-module:
+
+# Styling of let blocks (choices: auto, inline, newline, or mixed)
+let-style: auto
+
+# How to align the 'in' keyword with respect to the 'let' keyword (choices: left-align, right-align, or no-space)
+in-style: right-align
+
+# Whether to put parentheses around a single constraint (choices: auto, always, or never)
+single-constraint-parens: always
+
+# Whether to put parentheses around a single deriving class (choices: auto, always, or never)
+single-deriving-parens: always
+
+# Output Unicode syntax (choices: detect, always, or never)
+unicode: never
+
+# Give the programmer more choice on where to insert blank lines
+respectful: true
+
+# Fixity information for operators
+fixities: []
+
+# Module reexports Fourmolu should know about
+reexports: []


### PR DESCRIPTION
Establishes a reproducible Haskell formatting policy for `tenforty-spec` and brings the tree into compliance. Split into **policy** and **application** commits.

## Why
`tenforty-spec` had no committed formatter config and no version pin, so `make spec-fmt` produced version-dependent output — running it churned files a different fourmolu had written, and nothing caught the drift (formatting isn't gated in CI or pre-commit). This is what leaked a large 6251 reformat into #303.

## On the "black/ruff" question
Haskell's zero-config "black" is **Ormolu**. **Fourmolu** (already used here) is the configurable member of that family — the ruff-format / prettier analog — driven by a committed `fourmolu.yaml`, and it has `--mode check` (the `black --check` analog).

## 1. Policy (`eb58fa8`)
- **`tenforty-spec/fourmolu.yaml`** — fourmolu 0.15.0.0 defaults made explicit, so the style survives version bumps.
- **Version pin** — `fourmolu-0.15.0.0` in the Makefile install instructions.
- **`make spec-fmt-check`** — `fourmolu --mode check`, a runnable gate.
- **Pre-commit enforcement** — a local `fourmolu` hook mirroring the existing `cargo-fmt` hook, so drift is caught on commit.

## 2. Application (`7f467be`)
One-time reformat. **Only the two Form 6251 specs** were non-conformant (their line-2a / Part III blocks predate the current fourmolu); every other `.hs` already matched. Pure formatting — `make spec-graphs` output is **byte-identical**, no computed figure moves.

## Verification
- `make spec-fmt-check` → clean.
- `cabal build` compiles; graph JSON regeneration produces **zero drift**.
- `cabal test` shows only the 2 pre-existing stale-assertion failures fixed by #304 — no new failures from the reformat.

## Merge-order notes
- Overlaps #303 and #304 on the 6251 files: this PR reformats them; #303's `a238cdb` accidentally made the same reformat, and #304 removes unused pragmas from `test/*.hs`. The changes are compatible (identical or disjoint lines); whichever lands first, the others reconcile trivially.
- Not addressed here (kept focused): pinning **hlint**, and wiring these local gates into CI. Happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)