### PR TITLE
feat(spec): compile-time cross-form graph resolution (tenforty-ovz Stage 2+3a/3b)

### DIFF
--- a/tenforty-spec/app/Main.hs
+++ b/tenforty-spec/app/Main.hs
@@ -364,20 +364,24 @@ main = do
       if "resolve_" `T.isPrefixOf` formName
         then case T.splitOn "_" (T.drop 8 formName) of
           (yr : states) -> do
-            -- resolve_<year>[_<state>...]: federal + requested states, one graph
-            let prefixes = "us" : states
-                suffix = "_" <> yr <> ".json"
+            -- resolve_<year>          -> ALL forms for the year (one graph per year)
+            -- resolve_<year>_<state>  -> federal + those states (focused subset)
+            let suffix = "_" <> yr <> ".json"
+                forYear = [(T.pack fp, res) | (fp, res) <- allForms, suffix `T.isSuffixOf` T.pack fp]
                 wanted =
-                  [ res
-                  | (fp, res) <- allForms,
-                    let fpt = T.pack fp,
-                    suffix `T.isSuffixOf` fpt,
-                    any (\p -> (p <> "_") `T.isPrefixOf` fpt) prefixes
-                  ]
+                  if null states
+                    then map snd forYear
+                    else [res | (fpt, res) <- forYear, any (\p -> (p <> "_") `T.isPrefixOf` fpt) ("us" : states)]
                 forms = rights wanted
-                resolved = resolveForms (map compileForm forms)
+                cgs = map compileForm forms
+                badImports = unresolvedImports cgs
                 outPath = T.unpack formName ++ ".json"
-            BL.writeFile outPath (AP.encodePretty resolved <> BL8.pack "\n")
+            unless (null badImports) $ do
+              hPutStrLn stderr "resolve: unresolved cross-form imports (fix the importForm reference):"
+              forM_ badImports $ \(src, tf, tl) ->
+                hPutStrLn stderr $ "  " ++ T.unpack src ++ " imports " ++ T.unpack tf ++ ":" ++ T.unpack tl
+              exitFailure
+            BL.writeFile outPath (AP.encodePretty (resolveForms cgs) <> BL8.pack "\n")
             putStrLn $
               "Wrote " ++ outPath ++ " (" ++ show (length forms) ++ " forms -> one resolved graph)"
           [] -> hPutStrLn stderr "resolve: missing year" >> exitFailure

--- a/tenforty-spec/app/Main.hs
+++ b/tenforty-spec/app/Main.hs
@@ -28,6 +28,7 @@ import DEFormPITRES_2025
 import Data.Aeson.Encode.Pretty qualified as AP
 import Data.ByteString.Lazy qualified as BL
 import Data.ByteString.Lazy.Char8 qualified as BL8
+import Data.Either (rights)
 import Data.Text (Text)
 import Data.Text qualified as T
 import FLNoTax_2024
@@ -359,14 +360,35 @@ main = do
 
       -- 3. Write output files
       forM_ allForms $ uncurry (compileToFile opts)
-    else do
-      let filename = T.unpack formName ++ ".json"
-      case lookup filename allForms of
-        Just res -> compileAndOutput opts res
-        Nothing -> do
-          hPutStrLn stderr $ "Unknown form: " ++ T.unpack formName
-          hPutStrLn stderr "Available forms: us_1040, us_schedule_1, us_schedule_2, us_schedule_3, us_schedule_a, us_schedule_b, us_schedule_d, us_schedule_eic, us_schedule_se, us_form_2441, us_form_6251, us_form_8812, us_form_8863, us_form_8959, us_form_8960, us_form_8995, ak_notax, al_40, ar_ar1000f, az_140, ca_540, ca_schedule_ca, ca_ftb_3506, ca_ftb_3514, co_form104, ct_1, dc_d40, de_pit_res, fl_notax, ga_500, hi_n11, ia_ia1040, id_form40, il_1040, in_it40, ks_k40, ky_740, la_it540, ma_1, md_502, me_1040me, mi_1040, ms_80105, mn_m1, mo_1040, mt_form2, nc_d400, nd_1, ne_1040n, nh_dp10, nj_1040, nm_pit1, nv_notax, ny_it201, oh_it1040, ok_511, or_40, pa_40, ri_1040, sc_1040, sd_notax, tn_notax, tx_notax, ut_tc40, va_760, vt_in111, wa_notax, wv_it140, wi_form1, wy_notax (append _2024 or _2025), all"
-          exitFailure
+    else
+      if "resolve_" `T.isPrefixOf` formName
+        then case T.splitOn "_" (T.drop 8 formName) of
+          (yr : states) -> do
+            -- resolve_<year>[_<state>...]: federal + requested states, one graph
+            let prefixes = "us" : states
+                suffix = "_" <> yr <> ".json"
+                wanted =
+                  [ res
+                  | (fp, res) <- allForms,
+                    let fpt = T.pack fp,
+                    suffix `T.isSuffixOf` fpt,
+                    any (\p -> (p <> "_") `T.isPrefixOf` fpt) prefixes
+                  ]
+                forms = rights wanted
+                resolved = resolveForms (map compileForm forms)
+                outPath = T.unpack formName ++ ".json"
+            BL.writeFile outPath (AP.encodePretty resolved <> BL8.pack "\n")
+            putStrLn $
+              "Wrote " ++ outPath ++ " (" ++ show (length forms) ++ " forms -> one resolved graph)"
+          [] -> hPutStrLn stderr "resolve: missing year" >> exitFailure
+        else do
+          let filename = T.unpack formName ++ ".json"
+          case lookup filename allForms of
+            Just res -> compileAndOutput opts res
+            Nothing -> do
+              hPutStrLn stderr $ "Unknown form: " ++ T.unpack formName
+              hPutStrLn stderr "Available forms: us_1040, us_schedule_1, us_schedule_2, us_schedule_3, us_schedule_a, us_schedule_b, us_schedule_d, us_schedule_eic, us_schedule_se, us_form_2441, us_form_6251, us_form_8812, us_form_8863, us_form_8959, us_form_8960, us_form_8995, ak_notax, al_40, ar_ar1000f, az_140, ca_540, ca_schedule_ca, ca_ftb_3506, ca_ftb_3514, co_form104, ct_1, dc_d40, de_pit_res, fl_notax, ga_500, hi_n11, ia_ia1040, id_form40, il_1040, in_it40, ks_k40, ky_740, la_it540, ma_1, md_502, me_1040me, mi_1040, ms_80105, mn_m1, mo_1040, mt_form2, nc_d400, nd_1, ne_1040n, nh_dp10, nj_1040, nm_pit1, nv_notax, ny_it201, oh_it1040, ok_511, or_40, pa_40, ri_1040, sc_1040, sd_notax, tn_notax, tx_notax, ut_tc40, va_760, vt_in111, wa_notax, wv_it140, wi_form1, wy_notax (append _2024 or _2025), all"
+              exitFailure
 
 compileAndOutput :: Options -> Either FormError Form -> IO ()
 compileAndOutput opts formResult =

--- a/tenforty-spec/src/TenForty.hs
+++ b/tenforty-spec/src/TenForty.hs
@@ -6,6 +6,7 @@ module TenForty
     compileForm,
     compileFormToJSON,
     resolveForms,
+    unresolvedImports,
 
     -- * Graph Types (JSON output)
     ComputationGraph (..),

--- a/tenforty-spec/src/TenForty.hs
+++ b/tenforty-spec/src/TenForty.hs
@@ -5,6 +5,7 @@ module TenForty
     -- * Compilation
     compileForm,
     compileFormToJSON,
+    resolveForms,
 
     -- * Graph Types (JSON output)
     ComputationGraph (..),

--- a/tenforty-spec/src/TenForty/Compile/JSON.hs
+++ b/tenforty-spec/src/TenForty/Compile/JSON.hs
@@ -4,6 +4,7 @@ module TenForty.Compile.JSON
   ( -- * Compilation
     compileForm,
     compileFormToJSON,
+    resolveForms,
 
     -- * Graph Types
     ComputationGraph (..),
@@ -336,6 +337,119 @@ getTableId tbl = unTableId (T.tableId tbl)
 
 compileFormToJSON :: Form -> ByteString
 compileFormToJSON = Aeson.encode . compileForm
+
+-- | Resolve a set of per-form compiled graphs into ONE graph (tenforty-ovz,
+-- Stage 2). Assign fresh global node ids by traversal, resolve every cross-form
+-- Import to a direct node reference, and prefix node names + table ids by form.
+-- The result carries no imports: the runtime just loads and evaluates it, with
+-- no linker and no positional-id coupling.
+resolveForms :: [ComputationGraph] -> ComputationGraph
+resolveForms [] = ComputationGraph (GraphMeta "resolved" 0 "resolveForms") Map.empty Map.empty [] [] []
+resolveForms cgs@(cg0 : _) =
+  ComputationGraph
+    { cgMeta = GraphMeta "resolved" (gmYear (cgMeta cg0)) "resolveForms",
+      cgNodes = mergedNodes,
+      cgTables = mergedTables,
+      cgInputs = mergedInputs,
+      cgOutputs = mergedOutputs,
+      cgImports = []
+    }
+  where
+    formOf cg = gmFormId (cgMeta cg)
+
+    -- every (formId, local node) flattened, form order then node-id order
+    flat :: [(Text, Node)]
+    flat = [(formOf cg, n) | cg <- cgs, n <- Map.elems (cgNodes cg)]
+
+    -- fresh global id per node, assigned by traversal
+    gidOf :: Map (Text, Int) Int
+    gidOf = Map.fromList [((f, nodeId n), g) | ((f, n), g) <- zip flat [0 ..]]
+
+    global :: Text -> Int -> Int
+    global f localId = gidOf Map.! (f, localId)
+
+    -- (formId, key) -> global id for named nodes; key is the full name and the
+    -- lid base (before the first '_'). OUTPUT nodes are registered first so they
+    -- win the base key — mirrors the linker: import "L15" must hit the L15 output,
+    -- not an interior L15_pre_qbi / L15_sched_d that happens to emit earlier.
+    outputNodes :: [(Text, Node)]
+    outputNodes =
+      [(formOf cg, n) | cg <- cgs, oid <- cgOutputs cg, Just n <- [Map.lookup oid (cgNodes cg)]]
+
+    resMap :: Map (Text, Text) Int
+    resMap = foldl' ins Map.empty (outputNodes ++ flat)
+      where
+        ins m (f, n) = case nodeName n of
+          Nothing -> m
+          Just nm ->
+            let g = global f (nodeId n)
+                base = T.takeWhile (/= '_') nm
+                keep = Map.insertWith (\_ old -> old)
+             in keep (f, base) g (keep (f, nm) g m)
+
+    -- global id of each import node -> resolved target global id
+    importRedirect :: Map Int Int
+    importRedirect =
+      Map.fromList
+        [ (global f (nodeId n), tgt)
+        | (f, n) <- flat,
+          OpImport tf tl _ <- [nodeOp n],
+          Just tgt <- [Map.lookup (tf, tl) resMap]
+        ]
+
+    -- a form-local operand -> its global id, following import redirects
+    ref :: Text -> Int -> Int
+    ref f localId = let g = global f localId in Map.findWithDefault g g importRedirect
+
+    isImport op = case op of OpImport {} -> True; _ -> False
+
+    remapOp :: Text -> Op -> Op
+    remapOp f op = case op of
+      OpInput -> OpInput
+      OpLiteral d -> OpLiteral d
+      OpImport {} -> op
+      OpAdd a b -> OpAdd (ref f a) (ref f b)
+      OpSub a b -> OpSub (ref f a) (ref f b)
+      OpMul a b -> OpMul (ref f a) (ref f b)
+      OpDiv a b -> OpDiv (ref f a) (ref f b)
+      OpNeg a -> OpNeg (ref f a)
+      OpAbs a -> OpAbs (ref f a)
+      OpFloor a -> OpFloor (ref f a)
+      OpMax a b -> OpMax (ref f a) (ref f b)
+      OpMin a b -> OpMin (ref f a) (ref f b)
+      OpClamp a lo hi -> OpClamp (ref f a) lo hi
+      OpIfPositive c t e -> OpIfPositive (ref f c) (ref f t) (ref f e)
+      OpBracketTax tbl inc -> OpBracketTax (f <> "__" <> tbl) (ref f inc)
+      OpPhaseOut base sv rate agi -> OpPhaseOut base sv rate (ref f agi)
+      OpByStatus (StatusNodeIds a b c d e) ->
+        OpByStatus (StatusNodeIds (ref f a) (ref f b) (ref f c) (ref f d) (ref f e))
+
+    mergedNodes :: Map Int Node
+    mergedNodes =
+      Map.fromList
+        [ ( g,
+            Node
+              { nodeId = g,
+                nodeName = ((f <> "_") <>) <$> nodeName n,
+                nodeOp = remapOp f (nodeOp n)
+              }
+          )
+        | (f, n) <- flat,
+          not (isImport (nodeOp n)),
+          let g = global f (nodeId n)
+        ]
+
+    mergedTables :: Map Text BracketTable
+    mergedTables =
+      Map.fromList
+        [ (formOf cg <> "__" <> tn, t) | cg <- cgs, (tn, t) <- Map.toList (cgTables cg)
+        ]
+
+    mergedInputs :: [Int]
+    mergedInputs = [global (formOf cg) i | cg <- cgs, i <- cgInputs cg]
+
+    mergedOutputs :: [Int]
+    mergedOutputs = [ref (formOf cg) o | cg <- cgs, o <- cgOutputs cg]
 
 compileLines :: Form -> Compile [Int]
 compileLines frm = do

--- a/tenforty-spec/src/TenForty/Compile/JSON.hs
+++ b/tenforty-spec/src/TenForty/Compile/JSON.hs
@@ -5,6 +5,7 @@ module TenForty.Compile.JSON
     compileForm,
     compileFormToJSON,
     resolveForms,
+    unresolvedImports,
 
     -- * Graph Types
     ComputationGraph (..),
@@ -337,6 +338,31 @@ getTableId tbl = unTableId (T.tableId tbl)
 
 compileFormToJSON :: Form -> ByteString
 compileFormToJSON = Aeson.encode . compileForm
+
+-- | Cross-form imports that do not resolve against the given form set, as
+-- (source form, imported form, imported line). Non-empty means a bad
+-- @importForm@ reference: the compile driver fails the build on it, turning what
+-- would be a runtime "node not found" into a compile-time error (tenforty-ovz).
+unresolvedImports :: [ComputationGraph] -> [(Text, Text, Text)]
+unresolvedImports cgs =
+  [ (gmFormId (cgMeta cg), tf, tl)
+  | cg <- cgs,
+    n <- Map.elems (cgNodes cg),
+    OpImport tf tl _ <- [nodeOp n],
+    Map.notMember (tf, tl) resKeys
+  ]
+  where
+    -- (formId, key) present, key = full name and lid base (matches resolveForms)
+    resKeys :: Map (Text, Text) ()
+    resKeys =
+      Map.fromList $
+        concat
+          [ case nodeName n of
+              Nothing -> []
+              Just nm -> [((gmFormId (cgMeta cg), nm), ()), ((gmFormId (cgMeta cg), T.takeWhile (/= '_') nm), ())]
+          | cg <- cgs,
+            n <- Map.elems (cgNodes cg)
+          ]
 
 -- | Resolve a set of per-form compiled graphs into ONE graph (tenforty-ovz,
 -- Stage 2). Assign fresh global node ids by traversal, resolve every cross-form


### PR DESCRIPTION
The Haskell-side of the one-graph-per-year refactor (**tenforty-ovz**): resolve cross-form imports at *compile time* instead of leaving them for the Rust runtime linker. **Purely additive** — `compileForm` and every committed per-form JSON are unchanged; existing spec tests 189/0. Not yet wired to the runtime (that's the next PR).

## What's here
- **`resolveForms :: [ComputationGraph] -> ComputationGraph`** — merges per-form graphs into one: fresh global ids by traversal, every `OpImport` replaced by a direct node reference (outputs win the lid-base key, so `L15` binds the L15 output not an interior `L15_pre_qbi`), names + tables form-prefixed, **no imports** in the result.
- **`unresolvedImports`** — build-time validation: a bad `importForm` reference *fails the build* (source/target reported) instead of surfacing as a runtime "node not found". The stringly-typed cross-form boundary is now checked.
- **CLI:** `tenforty-compile resolve_<year>` → the whole per-year graph (federal + all 51 states); `resolve_<year>_<state>` → a focused subset.

## Verified end-to-end
- `resolve_2024` / `resolve_2025` → 3057 / 3055 nodes, **0 imports, 0 dangling edges**.
- Loaded via `Graph.from_json` and evaluated, the resolved graphs match the current per-form + linker path **to the cent** — federal total, AMT, SE, NIIT, and state total — across **CA, NY, no-state, both years**.
- Parity caught a real resolution bug (base-name `L15` → `L15_pre_qbi`), fixed via outputs-first resolution.

## Next (separate PRs)
- **3c:** wire the Python backend to load the resolved per-year graph; retire `resolve_forms` + the Rust linker.
- **3d/4:** JIT/autodiff reachable-slice; benchmark vs the recorded baseline (#312).

Refs tenforty-ovz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)