### PR TITLE
feat(spec): type cross-form imports with LineRef handles; outputs-only (tenforty-9yh)

### DIFF
--- a/tenforty-spec/README.md
+++ b/tenforty-spec/README.md
@@ -100,7 +100,8 @@ tenforty-spec/
 ├── forms/
 │   ├── Tables2025.hs    -- 2025 bracket tables
 │   ├── US1040_2025.hs   -- Form 1040
-│   └── USSchedule1_2025.hs
+│   ├── USSchedule1_2025.hs
+│   └── FormRefs.hs      -- Typed cross-form output handles (imports no form)
 ├── app/Main.hs          -- CLI compiler
 ├── test/Spec.hs         -- QuickCheck tests
 └── dist/                -- Compiled JSON output (gitignored)
@@ -113,6 +114,48 @@ tenforty-spec/
 - **ByStatus records** enforce exhaustive handling of all 5 filing statuses
 - **Cycle detection** at form build time
 - **Table validation** ensures monotonic bracket thresholds
+- **Typed cross-form references** (see below) — a mistyped or renamed import is a compile error, not a resolver-time failure
+
+### Typed cross-form references (`FormRefs`)
+
+Forms reference each other's outputs through typed handles, not strings:
+
+```haskell
+-- FormRefs.hs
+us1040L11 :: LineRef Dollars
+us1040L11 = lineRef "us_1040" "L11"
+
+-- an importing form
+l13 <- interior "L13" "modified_agi" $ importForm us1040L11
+```
+
+`importForm :: LineRef u -> Expr u`. A mistyped or since-renamed reference is a
+GHC *"not in scope"* error at the reference site; the old `importForm "us_1040"
+"L11"` string form let those through to the resolver (or, before the graph was
+resolved in Haskell, to runtime). Because a handle names an exact line, the
+`L15` / `L15_pre_qbi` base-name ambiguity in the resolver can't arise.
+
+**Why handles live in their own module.** The form-module dependency graph is
+**cyclic**, even though the line-level computation graph is a DAG: `us_1040`
+imports `us_form_8995`'s QBI deduction while `us_form_8995` imports `us_1040`'s
+`L15_pre_qbi` (and `us_1040 → schedule_2 → 6251 → us_1040`, etc.). `us_1040` is
+the hub every cycle runs through; the value graph stays acyclic only because
+`L15_pre_qbi` is computed *before* the QBI deduction (see the comment in
+`US1040_*.hs`).
+
+If an importing form imported the *exporting form's module* to get its handle,
+GHC would reject the mutual imports as a module cycle — solvable only with
+`.hs-boot` files at the hub. Instead, all handles live in `FormRefs`, which
+**imports no form module**. Importers depend only on `FormRefs`, so the
+form-module graph stays acyclic with no boot files and no hub special-case.
+
+**Outputs-only.** A cross-form import may target a form's *declared outputs*
+only, never an interior line. `resolveForms` / `unresolvedImports` (in
+`Compile/JSON.hs`) and `validateFormSet` (in `Form.hs`) enforce this at build
+time; importing an interior line fails the build.
+
+> Note: `importForm` takes a `LineRef` in form definitions. The raw
+> string-keyed `importLine` remains only for the resolver's own tests.
 
 ## JSON Output Format
 

--- a/tenforty-spec/forms/ALForm40_2024.hs
+++ b/tenforty-spec/forms/ALForm40_2024.hs
@@ -5,6 +5,7 @@ module ALForm40_2024
   )
 where
 
+import FormRefs
 import TablesAL2024
 import TenForty
 
@@ -14,7 +15,7 @@ alForm40_2024 = form "al_40" 2024 $ do
 
   -- Line 8: Total Income (imported from US 1040 Line 9)
   -- This includes wages, interest, dividends, capital gains, etc.
-  let federalTotalIncome = importForm "us_1040" "L9"
+  let federalTotalIncome = importForm us1040L9
   l8 <-
     keyOutput "L8" "total_income" "Total income" $
       federalTotalIncome .+. dollars 0

--- a/tenforty-spec/forms/ALForm40_2025.hs
+++ b/tenforty-spec/forms/ALForm40_2025.hs
@@ -5,6 +5,7 @@ module ALForm40_2025
   )
 where
 
+import FormRefs
 import TablesAL2025
 import TenForty
 
@@ -14,7 +15,7 @@ alForm40_2025 = form "al_40" 2025 $ do
 
   -- Line 8: Total Income (imported from US 1040 Line 9)
   -- This includes wages, interest, dividends, capital gains, etc.
-  let federalTotalIncome = importForm "us_1040" "L9"
+  let federalTotalIncome = importForm us1040L9
   l8 <-
     keyOutput "L8" "total_income" "Total income" $
       federalTotalIncome .+. dollars 0

--- a/tenforty-spec/forms/ARAR1000F_2024.hs
+++ b/tenforty-spec/forms/ARAR1000F_2024.hs
@@ -5,6 +5,7 @@ module ARAR1000F_2024
   )
 where
 
+import FormRefs
 import TablesAR2024
 import TenForty
 
@@ -13,7 +14,7 @@ arAR1000F_2024 = form "ar_ar1000f" 2024 $ do
   defineTable arBracketsTable2024
 
   -- Line 1: Federal adjusted gross income (imported from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <-
     keyOutput "L1" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/ARAR1000F_2025.hs
+++ b/tenforty-spec/forms/ARAR1000F_2025.hs
@@ -5,6 +5,7 @@ module ARAR1000F_2025
   )
 where
 
+import FormRefs
 import TablesAR2025
 import TenForty
 
@@ -13,7 +14,7 @@ arAR1000F_2025 = form "ar_ar1000f" 2025 $ do
   defineTable arBracketsTable2025
 
   -- Line 1: Federal adjusted gross income (imported from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <-
     keyOutput "L1" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/AZForm140_2024.hs
+++ b/tenforty-spec/forms/AZForm140_2024.hs
@@ -5,6 +5,7 @@ module AZForm140_2024
   )
 where
 
+import FormRefs
 import TablesAZ2024
 import TenForty
 
@@ -12,7 +13,7 @@ azForm140_2024 :: Either FormError Form
 azForm140_2024 = form "az_140" 2024 $ do
   -- Line 12: Federal Adjusted Gross Income (from US 1040 Line 11)
   -- Note: For 2024, US 1040 AGI is on line 11 (not L11b)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l12 <-
     keyOutput "L12" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/AZForm140_2025.hs
+++ b/tenforty-spec/forms/AZForm140_2025.hs
@@ -5,13 +5,14 @@ module AZForm140_2025
   )
 where
 
+import FormRefs
 import TablesAZ2025
 import TenForty
 
 azForm140_2025 :: Either FormError Form
 azForm140_2025 = form "az_140" 2025 $ do
   -- Line 12: Federal Adjusted Gross Income (from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l12 <-
     keyOutput "L12" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/CA540_2024.hs
+++ b/tenforty-spec/forms/CA540_2024.hs
@@ -5,6 +5,7 @@ module CA540_2024
   )
 where
 
+import FormRefs
 import TablesCA2024
 import TenForty
 
@@ -13,17 +14,17 @@ ca540_2024 = form "ca_540" 2024 $ do
   defineTable californiaBracketsTable2024
 
   -- Line 13: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l13 <- keyOutput "L13" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 14: California adjustments - subtractions (from Schedule CA)
-  l14 <- interior "L14" "ca_subtractions" $ importForm "ca_schedule_ca" "TOTAL_SUB"
+  l14 <- interior "L14" "ca_subtractions" $ importForm caScheduleCaTotalSub
 
   -- Line 15: Federal AGI minus subtractions
   l15 <- interior "L15" "agi_minus_subtractions" $ l13 .-. l14
 
   -- Line 16: California adjustments - additions (from Schedule CA)
-  l16 <- interior "L16" "ca_additions" $ importForm "ca_schedule_ca" "TOTAL_ADD"
+  l16 <- interior "L16" "ca_additions" $ importForm caScheduleCaTotalAdd
 
   -- Line 17: California AGI
   l17 <-
@@ -112,7 +113,7 @@ ca540_2024 = form "ca_540" 2024 $ do
 
   -- Refundable credits
   -- Line 91: CA EITC (from FTB 3514)
-  l91 <- interior "L91" "ca_eitc" $ importForm "ca_ftb_3514" "L18"
+  l91 <- interior "L91" "ca_eitc" $ importForm caFtb3514L18
   l92 <- keyInput "L92" "young_child_credit" "Young Child Tax Credit"
   l93 <- keyInput "L93" "foster_youth_credit" "Foster Youth Tax Credit"
   l94 <- keyInput "L94" "other_refundable_credits" "Other refundable credits"

--- a/tenforty-spec/forms/CA540_2025.hs
+++ b/tenforty-spec/forms/CA540_2025.hs
@@ -5,6 +5,7 @@ module CA540_2025
   )
 where
 
+import FormRefs
 import TablesCA2025
 import TenForty
 
@@ -13,17 +14,17 @@ ca540_2025 = form "ca_540" 2025 $ do
   defineTable californiaBracketsTable2025
 
   -- Line 13: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l13 <- keyOutput "L13" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 14: California adjustments - subtractions (from Schedule CA)
-  l14 <- interior "L14" "ca_subtractions" $ importForm "ca_schedule_ca" "TOTAL_SUB"
+  l14 <- interior "L14" "ca_subtractions" $ importForm caScheduleCaTotalSub
 
   -- Line 15: Federal AGI minus subtractions
   l15 <- interior "L15" "agi_minus_subtractions" $ l13 .-. l14
 
   -- Line 16: California adjustments - additions (from Schedule CA)
-  l16 <- interior "L16" "ca_additions" $ importForm "ca_schedule_ca" "TOTAL_ADD"
+  l16 <- interior "L16" "ca_additions" $ importForm caScheduleCaTotalAdd
 
   -- Line 17: California AGI
   l17 <-
@@ -113,7 +114,7 @@ ca540_2025 = form "ca_540" 2025 $ do
 
   -- Refundable credits
   -- Line 91: CA EITC (from FTB 3514)
-  l91 <- interior "L91" "ca_eitc" $ importForm "ca_ftb_3514" "L18"
+  l91 <- interior "L91" "ca_eitc" $ importForm caFtb3514L18
   l92 <- keyInput "L92" "young_child_credit" "Young Child Tax Credit"
   l93 <- keyInput "L93" "foster_youth_credit" "Foster Youth Tax Credit"
   l94 <- keyInput "L94" "other_refundable_credits" "Other refundable credits"

--- a/tenforty-spec/forms/CAFTB3506_2024.hs
+++ b/tenforty-spec/forms/CAFTB3506_2024.hs
@@ -5,6 +5,7 @@ module CAFTB3506_2024
   )
 where
 
+import FormRefs
 import TablesCA2024
 import TenForty
 
@@ -51,7 +52,7 @@ caFTB3506_2024 = form "ca_ftb_3506" 2024 $ do
       smallerOf l4 (smallerOf l5 l6)
 
   -- Line 8: California AGI (from CA 540 Line 17 or Schedule CA)
-  l8 <- interior "L8" "ca_agi" $ importForm "ca_540" "L17"
+  l8 <- interior "L8" "ca_agi" $ importForm ca540L17
 
   -- Line 9: Credit percentage based on CA AGI
   -- California uses a sliding scale: 50% at low AGI, phases to 0% at $100,000+

--- a/tenforty-spec/forms/CAFTB3506_2025.hs
+++ b/tenforty-spec/forms/CAFTB3506_2025.hs
@@ -5,6 +5,7 @@ module CAFTB3506_2025
   )
 where
 
+import FormRefs
 import TablesCA2025
 import TenForty
 
@@ -51,7 +52,7 @@ caFTB3506_2025 = form "ca_ftb_3506" 2025 $ do
       smallerOf l4 (smallerOf l5 l6)
 
   -- Line 8: California AGI (from CA 540 Line 17 or Schedule CA)
-  l8 <- interior "L8" "ca_agi" $ importForm "ca_540" "L17"
+  l8 <- interior "L8" "ca_agi" $ importForm ca540L17
 
   -- Line 9: Credit percentage based on CA AGI
   -- California uses a sliding scale: 50% at low AGI, phases to 0% at threshold

--- a/tenforty-spec/forms/CAFTB3514_2024.hs
+++ b/tenforty-spec/forms/CAFTB3514_2024.hs
@@ -5,6 +5,7 @@ module CAFTB3514_2024
   )
 where
 
+import FormRefs
 import TablesCA2024
 import TenForty
 
@@ -37,7 +38,7 @@ caFTB3514_2024 = form "ca_ftb_3514" 2024 $ do
   -- Part III: California AGI and Investment Income Tests
 
   -- Line 6: California AGI (from CA 540 or import)
-  _l6 <- interior "L6" "ca_agi" $ importForm "ca_540" "L17"
+  _l6 <- interior "L6" "ca_agi" $ importForm ca540L17
 
   -- Line 7: Investment income (disqualified if > $11,000 for 2024)
   -- Used to determine eligibility (not modeled as disqualifier here)

--- a/tenforty-spec/forms/CAFTB3514_2025.hs
+++ b/tenforty-spec/forms/CAFTB3514_2025.hs
@@ -5,6 +5,7 @@ module CAFTB3514_2025
   )
 where
 
+import FormRefs
 import TablesCA2025
 import TenForty
 
@@ -37,7 +38,7 @@ caFTB3514_2025 = form "ca_ftb_3514" 2025 $ do
   -- Part III: California AGI and Investment Income Tests
 
   -- Line 6: California AGI (from CA 540 or import)
-  _l6 <- interior "L6" "ca_agi" $ importForm "ca_540" "L17"
+  _l6 <- interior "L6" "ca_agi" $ importForm ca540L17
 
   -- Line 7: Investment income (disqualified if > threshold)
   -- Used to determine eligibility (not modeled as disqualifier here)

--- a/tenforty-spec/forms/CAScheduleCA_2024.hs
+++ b/tenforty-spec/forms/CAScheduleCA_2024.hs
@@ -5,6 +5,7 @@ module CAScheduleCA_2024
   )
 where
 
+import FormRefs
 import TenForty
 
 caScheduleCA_2024 :: Either FormError Form
@@ -119,7 +120,7 @@ caScheduleCA_2024 = form "ca_schedule_ca" 2024 $ do
 
   -- QBI Deduction add-back (California does not allow federal QBI deduction)
   -- Import from Form 8995 if available
-  aQBI <- interior "A_QBI" "qbi_addback" $ importForm "us_form_8995" "L16"
+  aQBI <- interior "A_QBI" "qbi_addback" $ importForm usForm8995L16
 
   -- Line 22-24: Other additions
   aOther <- keyInput "A22_24" "other_additions" "Other additions"

--- a/tenforty-spec/forms/CAScheduleCA_2025.hs
+++ b/tenforty-spec/forms/CAScheduleCA_2025.hs
@@ -5,6 +5,7 @@ module CAScheduleCA_2025
   )
 where
 
+import FormRefs
 import TenForty
 
 caScheduleCA_2025 :: Either FormError Form
@@ -119,7 +120,7 @@ caScheduleCA_2025 = form "ca_schedule_ca" 2025 $ do
 
   -- QBI Deduction add-back (California does not allow federal QBI deduction)
   -- Import from Form 8995 if available
-  aQBI <- interior "A_QBI" "qbi_addback" $ importForm "us_form_8995" "L16"
+  aQBI <- interior "A_QBI" "qbi_addback" $ importForm usForm8995L16
 
   -- Line 22-24: Other additions
   aOther <- keyInput "A22_24" "other_additions" "Other additions"

--- a/tenforty-spec/forms/COForm104_2024.hs
+++ b/tenforty-spec/forms/COForm104_2024.hs
@@ -5,13 +5,14 @@ module COForm104_2024
   )
 where
 
+import FormRefs
 import TablesCO2024
 import TenForty
 
 coForm104_2024 :: Either FormError Form
 coForm104_2024 = form "co_form104" 2024 $ do
   -- Line 1: Federal Taxable Income (from US 1040 Line 15)
-  let federalTaxableIncome = importForm "us_1040" "L15"
+  let federalTaxableIncome = importForm us1040L15
   l1 <-
     keyOutput "L1" "federal_taxable_income" "Federal taxable income" $
       federalTaxableIncome .+. dollars 0

--- a/tenforty-spec/forms/COForm104_2025.hs
+++ b/tenforty-spec/forms/COForm104_2025.hs
@@ -5,13 +5,14 @@ module COForm104_2025
   )
 where
 
+import FormRefs
 import TablesCO2025
 import TenForty
 
 coForm104_2025 :: Either FormError Form
 coForm104_2025 = form "co_form104" 2025 $ do
   -- Line 1: Federal Taxable Income (from US 1040 Line 15)
-  let federalTaxableIncome = importForm "us_1040" "L15"
+  let federalTaxableIncome = importForm us1040L15
   l1 <-
     keyOutput "L1" "federal_taxable_income" "Federal taxable income" $
       federalTaxableIncome .+. dollars 0

--- a/tenforty-spec/forms/CTForm1_2024.hs
+++ b/tenforty-spec/forms/CTForm1_2024.hs
@@ -5,6 +5,7 @@ module CTForm1_2024
   )
 where
 
+import FormRefs
 import TablesCT2024
 import TenForty
 
@@ -13,7 +14,7 @@ ctForm1_2024 = form "ct_1" 2024 $ do
   defineTable ctBracketsTable2024
 
   -- Line 1: Connecticut AGI (imports federal AGI from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- interior "L1" "ct_agi" federalAgi
 
   -- Line 2: Personal exemption with phaseout

--- a/tenforty-spec/forms/CTForm1_2025.hs
+++ b/tenforty-spec/forms/CTForm1_2025.hs
@@ -5,6 +5,7 @@ module CTForm1_2025
   )
 where
 
+import FormRefs
 import TablesCT2025
 import TenForty
 
@@ -13,7 +14,7 @@ ctForm1_2025 = form "ct_1" 2025 $ do
   defineTable ctBracketsTable2025
 
   -- Line 1: Connecticut AGI (imports federal AGI from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- interior "L1" "ct_agi" federalAgi
 
   -- Line 2: Personal exemption with phaseout

--- a/tenforty-spec/forms/DCFormD40_2024.hs
+++ b/tenforty-spec/forms/DCFormD40_2024.hs
@@ -5,6 +5,7 @@ module DCFormD40_2024
   )
 where
 
+import FormRefs
 import TablesDC2024
 import TenForty
 
@@ -13,7 +14,7 @@ dcFormD40_2024 = form "dc_d40" 2024 $ do
   defineTable dcBracketsTable2024
 
   -- Line 1: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 2: Net additions to Federal AGI from DC Schedule I

--- a/tenforty-spec/forms/DCFormD40_2025.hs
+++ b/tenforty-spec/forms/DCFormD40_2025.hs
@@ -5,6 +5,7 @@ module DCFormD40_2025
   )
 where
 
+import FormRefs
 import TablesDC2025
 import TenForty
 
@@ -13,7 +14,7 @@ dcFormD40_2025 = form "dc_d40" 2025 $ do
   defineTable dcBracketsTable2025
 
   -- Line 1: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 2: Net additions to Federal AGI from DC Schedule I

--- a/tenforty-spec/forms/DEFormPITRES_2024.hs
+++ b/tenforty-spec/forms/DEFormPITRES_2024.hs
@@ -5,6 +5,7 @@ module DEFormPITRES_2024
   )
 where
 
+import FormRefs
 import TablesDE2024
 import TenForty
 
@@ -13,7 +14,7 @@ deFormPITRES_2024 = form "de_pit_res" 2024 $ do
   defineTable delawareBracketsTable2024
 
   -- Line 1: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 2: Delaware additions to AGI (e.g., state tax refund, municipal bond interest)

--- a/tenforty-spec/forms/DEFormPITRES_2025.hs
+++ b/tenforty-spec/forms/DEFormPITRES_2025.hs
@@ -5,6 +5,7 @@ module DEFormPITRES_2025
   )
 where
 
+import FormRefs
 import TablesDE2025
 import TenForty
 
@@ -13,7 +14,7 @@ deFormPITRES_2025 = form "de_pit_res" 2025 $ do
   defineTable delawareBracketsTable2025
 
   -- Line 1: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 2: Delaware additions to AGI (e.g., state tax refund, municipal bond interest)

--- a/tenforty-spec/forms/FormRefs.hs
+++ b/tenforty-spec/forms/FormRefs.hs
@@ -1,0 +1,120 @@
+-- | Typed cross-form output handles.
+--
+-- This module imports no form module, so importers reference these handles
+-- without depending on the exporting form's module — the form-module graph
+-- stays acyclic even where two forms reference each other's lines. Each
+-- handle names a (form, line); the importing form's year fixes resolution.
+module FormRefs where
+
+import TenForty (Dollars, LineRef, lineRef)
+
+ca540L17 :: LineRef Dollars
+ca540L17 = lineRef "ca_540" "L17"
+
+caFtb3514L18 :: LineRef Dollars
+caFtb3514L18 = lineRef "ca_ftb_3514" "L18"
+
+caScheduleCaTotalAdd :: LineRef Dollars
+caScheduleCaTotalAdd = lineRef "ca_schedule_ca" "TOTAL_ADD"
+
+caScheduleCaTotalSub :: LineRef Dollars
+caScheduleCaTotalSub = lineRef "ca_schedule_ca" "TOTAL_SUB"
+
+us1040L11 :: LineRef Dollars
+us1040L11 = lineRef "us_1040" "L11"
+
+us1040L12final :: LineRef Dollars
+us1040L12final = lineRef "us_1040" "L12Final"
+
+us1040L15 :: LineRef Dollars
+us1040L15 = lineRef "us_1040" "L15"
+
+us1040L15PreQbi :: LineRef Dollars
+us1040L15PreQbi = lineRef "us_1040" "L15_pre_qbi"
+
+us1040L16 :: LineRef Dollars
+us1040L16 = lineRef "us_1040" "L16"
+
+us1040L18 :: LineRef Dollars
+us1040L18 = lineRef "us_1040" "L18"
+
+us1040L22 :: LineRef Dollars
+us1040L22 = lineRef "us_1040" "L22"
+
+us1040L6b :: LineRef Dollars
+us1040L6b = lineRef "us_1040" "L6b"
+
+us1040L9 :: LineRef Dollars
+us1040L9 = lineRef "us_1040" "L9"
+
+us1040Qcgws4 :: LineRef Dollars
+us1040Qcgws4 = lineRef "us_1040" "qcgws_4"
+
+us1040Qcgws5 :: LineRef Dollars
+us1040Qcgws5 = lineRef "us_1040" "qcgws_5"
+
+usForm2441L11 :: LineRef Dollars
+usForm2441L11 = lineRef "us_form_2441" "L11"
+
+usForm6251L11 :: LineRef Dollars
+usForm6251L11 = lineRef "us_form_6251" "L11"
+
+usForm8812L14 :: LineRef Dollars
+usForm8812L14 = lineRef "us_form_8812" "L14"
+
+usForm8812L27 :: LineRef Dollars
+usForm8812L27 = lineRef "us_form_8812" "L27"
+
+usForm8863L19 :: LineRef Dollars
+usForm8863L19 = lineRef "us_form_8863" "L19"
+
+usForm8863L9 :: LineRef Dollars
+usForm8863L9 = lineRef "us_form_8863" "L9"
+
+usForm8959L18 :: LineRef Dollars
+usForm8959L18 = lineRef "us_form_8959" "L18"
+
+usForm8960L17 :: LineRef Dollars
+usForm8960L17 = lineRef "us_form_8960" "L17"
+
+usForm8995L16 :: LineRef Dollars
+usForm8995L16 = lineRef "us_form_8995" "L16"
+
+usSchedule1L1 :: LineRef Dollars
+usSchedule1L1 = lineRef "us_schedule_1" "L1"
+
+usSchedule1L10 :: LineRef Dollars
+usSchedule1L10 = lineRef "us_schedule_1" "L10"
+
+usSchedule1L26 :: LineRef Dollars
+usSchedule1L26 = lineRef "us_schedule_1" "L26"
+
+usSchedule2L21 :: LineRef Dollars
+usSchedule2L21 = lineRef "us_schedule_2" "L21"
+
+usSchedule2L3 :: LineRef Dollars
+usSchedule2L3 = lineRef "us_schedule_2" "L3"
+
+usSchedule3L15 :: LineRef Dollars
+usSchedule3L15 = lineRef "us_schedule_3" "L15"
+
+usSchedule3L8 :: LineRef Dollars
+usSchedule3L8 = lineRef "us_schedule_3" "L8"
+
+usScheduleAL17 :: LineRef Dollars
+usScheduleAL17 = lineRef "us_schedule_a" "L17"
+
+usScheduleDL15 :: LineRef Dollars
+usScheduleDL15 = lineRef "us_schedule_d" "L15"
+
+usScheduleDL21 :: LineRef Dollars
+usScheduleDL21 = lineRef "us_schedule_d" "L21"
+
+usScheduleSeL10 :: LineRef Dollars
+usScheduleSeL10 = lineRef "us_schedule_se" "L10"
+
+usScheduleSeL11 :: LineRef Dollars
+usScheduleSeL11 = lineRef "us_schedule_se" "L11"
+
+usScheduleSeL4a :: LineRef Dollars
+usScheduleSeL4a = lineRef "us_schedule_se" "L4a"

--- a/tenforty-spec/forms/GAForm500_2024.hs
+++ b/tenforty-spec/forms/GAForm500_2024.hs
@@ -5,13 +5,14 @@ module GAForm500_2024
   )
 where
 
+import FormRefs
 import TablesGA2024
 import TenForty
 
 gaForm500_2024 :: Either FormError Form
 gaForm500_2024 = form "ga_500" 2024 $ do
   -- Line 1: Federal Adjusted Gross Income (from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <-
     keyOutput "L1" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/GAForm500_2025.hs
+++ b/tenforty-spec/forms/GAForm500_2025.hs
@@ -5,13 +5,14 @@ module GAForm500_2025
   )
 where
 
+import FormRefs
 import TablesGA2025
 import TenForty
 
 gaForm500_2025 :: Either FormError Form
 gaForm500_2025 = form "ga_500" 2025 $ do
   -- Line 1: Federal Adjusted Gross Income (from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <-
     keyOutput "L1" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/HIHIN11_2024.hs
+++ b/tenforty-spec/forms/HIHIN11_2024.hs
@@ -5,6 +5,7 @@ module HIHIN11_2024
   )
 where
 
+import FormRefs
 import TablesHI2024
 import TenForty
 
@@ -13,7 +14,7 @@ hihiN11_2024 = form "hi_n11" 2024 $ do
   defineTable hawaiiBracketsTable2024
 
   -- Line 7: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l7 <- keyOutput "L7" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Lines 8-9: Hawaii additions to income

--- a/tenforty-spec/forms/HIHIN11_2025.hs
+++ b/tenforty-spec/forms/HIHIN11_2025.hs
@@ -5,6 +5,7 @@ module HIHIN11_2025
   )
 where
 
+import FormRefs
 import TablesHI2025
 import TenForty
 
@@ -13,7 +14,7 @@ hihiN11_2025 = form "hi_n11" 2025 $ do
   defineTable hawaiiBracketsTable2025
 
   -- Line 7: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l7 <- keyOutput "L7" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Lines 8-9: Hawaii additions to income

--- a/tenforty-spec/forms/IAIA1040_2024.hs
+++ b/tenforty-spec/forms/IAIA1040_2024.hs
@@ -5,6 +5,7 @@ module IAIA1040_2024
   )
 where
 
+import FormRefs
 import TablesIA2024
 import TenForty
 
@@ -13,13 +14,13 @@ iaIA1040_2024 = form "ia_ia1040" 2024 $ do
   defineTable iowaBracketsTable2024
 
   -- Line 1c: Federal AGI (imported from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   _ <-
     keyOutput "L1c" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0
 
   -- Line 2: Federal Taxable Income (imported from US 1040 Line 15)
-  let federalTaxableIncome = importForm "us_1040" "L15"
+  let federalTaxableIncome = importForm us1040L15
   l2 <-
     keyOutput "L2" "federal_taxable_income" "Federal taxable income" $
       federalTaxableIncome .+. dollars 0

--- a/tenforty-spec/forms/IAIA1040_2025.hs
+++ b/tenforty-spec/forms/IAIA1040_2025.hs
@@ -5,19 +5,20 @@ module IAIA1040_2025
   )
 where
 
+import FormRefs
 import TablesIA2025
 import TenForty
 
 iaIA1040_2025 :: Either FormError Form
 iaIA1040_2025 = form "ia_ia1040" 2025 $ do
   -- Line 1c: Federal AGI (imported from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   _ <-
     keyOutput "L1c" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0
 
   -- Line 2: Federal Taxable Income (imported from US 1040 Line 15)
-  let federalTaxableIncome = importForm "us_1040" "L15"
+  let federalTaxableIncome = importForm us1040L15
   l2 <-
     keyOutput "L2" "federal_taxable_income" "Federal taxable income" $
       federalTaxableIncome .+. dollars 0

--- a/tenforty-spec/forms/IDFORM40_2024.hs
+++ b/tenforty-spec/forms/IDFORM40_2024.hs
@@ -5,13 +5,14 @@ module IDFORM40_2024
   )
 where
 
+import FormRefs
 import TablesID2024
 import TenForty
 
 idForm40_2024 :: Either FormError Form
 idForm40_2024 = form "id_form40" 2024 $ do
   -- Line 7: Federal Adjusted Gross Income
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l7 <-
     keyOutput "L7" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/IDFORM40_2025.hs
+++ b/tenforty-spec/forms/IDFORM40_2025.hs
@@ -5,13 +5,14 @@ module IDFORM40_2025
   )
 where
 
+import FormRefs
 import TablesID2025
 import TenForty
 
 idForm40_2025 :: Either FormError Form
 idForm40_2025 = form "id_form40" 2025 $ do
   -- Line 7: Federal Adjusted Gross Income
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l7 <-
     keyOutput "L7" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/IL1040_2024.hs
+++ b/tenforty-spec/forms/IL1040_2024.hs
@@ -5,13 +5,14 @@ module IL1040_2024
   )
 where
 
+import FormRefs
 import TablesIL2024
 import TenForty
 
 il1040_2024 :: Either FormError Form
 il1040_2024 = form "il_1040" 2024 $ do
   -- Line 1: Federal Adjusted Gross Income (from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <-
     keyOutput "L1" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/IL1040_2025.hs
+++ b/tenforty-spec/forms/IL1040_2025.hs
@@ -5,13 +5,14 @@ module IL1040_2025
   )
 where
 
+import FormRefs
 import TablesIL2025
 import TenForty
 
 il1040_2025 :: Either FormError Form
 il1040_2025 = form "il_1040" 2025 $ do
   -- Line 1: Federal Adjusted Gross Income (from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <-
     keyOutput "L1" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/INFormIT40_2024.hs
+++ b/tenforty-spec/forms/INFormIT40_2024.hs
@@ -5,13 +5,14 @@ module INFormIT40_2024
   )
 where
 
+import FormRefs
 import TablesIN2024
 import TenForty
 
 inFormIT40_2024 :: Either FormError Form
 inFormIT40_2024 = form "in_it40" 2024 $ do
   -- Line 1: Federal Adjusted Gross Income (from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <-
     keyOutput "L1" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/INFormIT40_2025.hs
+++ b/tenforty-spec/forms/INFormIT40_2025.hs
@@ -5,13 +5,14 @@ module INFormIT40_2025
   )
 where
 
+import FormRefs
 import TablesIN2025
 import TenForty
 
 inFormIT40_2025 :: Either FormError Form
 inFormIT40_2025 = form "in_it40" 2025 $ do
   -- Line 1: Federal Adjusted Gross Income (from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <-
     keyOutput "L1" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/KSFormK40_2024.hs
+++ b/tenforty-spec/forms/KSFormK40_2024.hs
@@ -5,6 +5,7 @@ module KSFormK40_2024
   )
 where
 
+import FormRefs
 import TablesKS2024
 import TenForty
 
@@ -13,7 +14,7 @@ ksFormK40_2024 = form "ks_k40" 2024 $ do
   defineTable kansasBracketsTable2024
 
   -- Line 1: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 2: Modifications (from Schedule S) - keyInput since we don't model Schedule S

--- a/tenforty-spec/forms/KSFormK40_2025.hs
+++ b/tenforty-spec/forms/KSFormK40_2025.hs
@@ -5,6 +5,7 @@ module KSFormK40_2025
   )
 where
 
+import FormRefs
 import TablesKS2025
 import TenForty
 
@@ -13,7 +14,7 @@ ksFormK40_2025 = form "ks_k40" 2025 $ do
   defineTable kansasBracketsTable2025
 
   -- Line 1: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 2: Modifications (from Schedule S) - keyInput since we don't model Schedule S

--- a/tenforty-spec/forms/KYForm740_2024.hs
+++ b/tenforty-spec/forms/KYForm740_2024.hs
@@ -5,13 +5,14 @@ module KYForm740_2024
   )
 where
 
+import FormRefs
 import TablesKY2024
 import TenForty
 
 kyForm740_2024 :: Either FormError Form
 kyForm740_2024 = form "ky_740" 2024 $ do
   -- Line 5: Federal Adjusted Gross Income (from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l5 <-
     keyOutput "L5" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/KYForm740_2025.hs
+++ b/tenforty-spec/forms/KYForm740_2025.hs
@@ -5,13 +5,14 @@ module KYForm740_2025
   )
 where
 
+import FormRefs
 import TablesKY2025
 import TenForty
 
 kyForm740_2025 :: Either FormError Form
 kyForm740_2025 = form "ky_740" 2025 $ do
   -- Line 5: Federal Adjusted Gross Income (from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l5 <-
     keyOutput "L5" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/LAIT540_2024.hs
+++ b/tenforty-spec/forms/LAIT540_2024.hs
@@ -5,6 +5,7 @@ module LAIT540_2024
   )
 where
 
+import FormRefs
 import TablesLA2024
 import TenForty
 
@@ -13,7 +14,7 @@ laIT540_2024 = form "la_it540" 2024 $ do
   defineTable louisianaBracketsTable2024
 
   -- Line 7: Federal Adjusted Gross Income (from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l7 <-
     keyOutput "L7" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/LAIT540_2025.hs
+++ b/tenforty-spec/forms/LAIT540_2025.hs
@@ -5,13 +5,14 @@ module LAIT540_2025
   )
 where
 
+import FormRefs
 import TablesLA2025
 import TenForty
 
 laIT540_2025 :: Either FormError Form
 laIT540_2025 = form "la_it540" 2025 $ do
   -- Line 7: Federal Adjusted Gross Income (from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l7 <-
     keyOutput "L7" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/MAForm1_2024.hs
+++ b/tenforty-spec/forms/MAForm1_2024.hs
@@ -5,6 +5,7 @@ module MAForm1_2024
   )
 where
 
+import FormRefs
 import TablesMA2024
 import TenForty
 
@@ -14,7 +15,7 @@ maForm1_2024 = form "ma_1" 2024 $ do
   -- Line 4: Taxable pensions and annuities (from US 1040)
   -- Lines 5-9: Various income sources
   -- Line 10: Total income (approximated by federal AGI for this implementation)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l10 <-
     keyOutput
       "L10"

--- a/tenforty-spec/forms/MAForm1_2025.hs
+++ b/tenforty-spec/forms/MAForm1_2025.hs
@@ -5,6 +5,7 @@ module MAForm1_2025
   )
 where
 
+import FormRefs
 import TablesMA2025
 import TenForty
 
@@ -14,7 +15,7 @@ maForm1_2025 = form "ma_1" 2025 $ do
   -- Line 4: Taxable pensions and annuities (from US 1040)
   -- Lines 5-9: Various income sources
   -- Line 10: Total income (approximated by federal AGI for this implementation)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l10 <-
     keyOutput
       "L10"

--- a/tenforty-spec/forms/MDForm502_2024.hs
+++ b/tenforty-spec/forms/MDForm502_2024.hs
@@ -5,6 +5,7 @@ module MDForm502_2024
   )
 where
 
+import FormRefs
 import TablesMD2024
 import TenForty
 
@@ -14,7 +15,7 @@ mdForm502_2024 = form "md_502" 2024 $ do
   defineTable marylandBracketsJointTable2024
 
   -- Line 1: Federal adjusted gross income (from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Lines 2-12: Maryland additions to income

--- a/tenforty-spec/forms/MDForm502_2025.hs
+++ b/tenforty-spec/forms/MDForm502_2025.hs
@@ -5,6 +5,7 @@ module MDForm502_2025
   )
 where
 
+import FormRefs
 import TablesMD2025
 import TenForty
 
@@ -15,7 +16,7 @@ mdForm502_2025 = form "md_502" 2025 $ do
 
   -- Line 1: Federal adjusted gross income (from US 1040)
   -- Note: 2025 federal return has AGI on L11b, but importForm handles year-specific mapping
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Lines 2-12: Maryland additions to income

--- a/tenforty-spec/forms/MEME1040_2024.hs
+++ b/tenforty-spec/forms/MEME1040_2024.hs
@@ -5,6 +5,7 @@ module MEME1040_2024
   )
 where
 
+import FormRefs
 import TablesME2024
 import TenForty
 
@@ -13,7 +14,7 @@ meme1040_2024 = form "me_1040me" 2024 $ do
   defineTable maineBracketsTable2024
 
   -- Line 1: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Lines 2-5: Maine additions to income

--- a/tenforty-spec/forms/MEME1040_2025.hs
+++ b/tenforty-spec/forms/MEME1040_2025.hs
@@ -5,6 +5,7 @@ module MEME1040_2025
   )
 where
 
+import FormRefs
 import TablesME2025
 import TenForty
 
@@ -13,7 +14,7 @@ meme1040_2025 = form "me_1040me" 2025 $ do
   defineTable maineBracketsTable2025
 
   -- Line 1: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Lines 2-5: Maine additions to income

--- a/tenforty-spec/forms/MI1040_2024.hs
+++ b/tenforty-spec/forms/MI1040_2024.hs
@@ -5,13 +5,14 @@ module MI1040_2024
   )
 where
 
+import FormRefs
 import TablesMI2024
 import TenForty
 
 mi1040_2024 :: Either FormError Form
 mi1040_2024 = form "mi_1040" 2024 $ do
   -- Line 7: Federal adjusted gross income (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l7 <- keyOutput "L7" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 8: Additions to federal AGI (from Michigan Schedule 1)

--- a/tenforty-spec/forms/MI1040_2025.hs
+++ b/tenforty-spec/forms/MI1040_2025.hs
@@ -5,13 +5,14 @@ module MI1040_2025
   )
 where
 
+import FormRefs
 import TablesMI2025
 import TenForty
 
 mi1040_2025 :: Either FormError Form
 mi1040_2025 = form "mi_1040" 2025 $ do
   -- Line 7: Federal adjusted gross income (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l7 <- keyOutput "L7" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 8: Additions to federal AGI (from Michigan Schedule 1)

--- a/tenforty-spec/forms/MNFormM1_2024.hs
+++ b/tenforty-spec/forms/MNFormM1_2024.hs
@@ -5,6 +5,7 @@ module MNFormM1_2024
   )
 where
 
+import FormRefs
 import TablesMN2024
 import TenForty
 
@@ -13,7 +14,7 @@ mnFormM1_2024 = form "mn_m1" 2024 $ do
   defineTable mnBracketsTable2024
 
   -- Line 1: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <-
     keyOutput "L1" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/MNFormM1_2025.hs
+++ b/tenforty-spec/forms/MNFormM1_2025.hs
@@ -5,6 +5,7 @@ module MNFormM1_2025
   )
 where
 
+import FormRefs
 import TablesMN2025
 import TenForty
 
@@ -13,7 +14,7 @@ mnFormM1_2025 = form "mn_m1" 2025 $ do
   defineTable mnBracketsTable2025
 
   -- Line 1: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <-
     keyOutput "L1" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/MOForm1040_2024.hs
+++ b/tenforty-spec/forms/MOForm1040_2024.hs
@@ -5,6 +5,7 @@ module MOForm1040_2024
   )
 where
 
+import FormRefs
 import TablesMO2024
 import TenForty
 
@@ -13,7 +14,7 @@ moForm1040_2024 = form "mo_1040" 2024 $ do
   defineTable missouriBracketsTable2024
 
   -- Line 1: Federal adjusted gross income (from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Lines 2-5: Missouri additions to federal AGI

--- a/tenforty-spec/forms/MOForm1040_2025.hs
+++ b/tenforty-spec/forms/MOForm1040_2025.hs
@@ -5,6 +5,7 @@ module MOForm1040_2025
   )
 where
 
+import FormRefs
 import TablesMO2025
 import TenForty
 
@@ -13,7 +14,7 @@ moForm1040_2025 = form "mo_1040" 2025 $ do
   defineTable missouriBracketsTable2025
 
   -- Line 1: Federal adjusted gross income (from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Lines 2-5: Missouri additions to federal AGI

--- a/tenforty-spec/forms/MS80105_2024.hs
+++ b/tenforty-spec/forms/MS80105_2024.hs
@@ -5,6 +5,7 @@ module MS80105_2024
   )
 where
 
+import FormRefs
 import TablesMS2024
 import TenForty
 
@@ -12,7 +13,7 @@ ms80105_2024 :: Either FormError Form
 ms80105_2024 = form "ms_80105" 2024 $ do
   -- Line 13: Mississippi Adjusted Gross Income
   -- Starts with Federal AGI and applies Mississippi modifications
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l13 <-
     keyOutput "L13" "ms_agi" "Mississippi adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/MS80105_2025.hs
+++ b/tenforty-spec/forms/MS80105_2025.hs
@@ -5,6 +5,7 @@ module MS80105_2025
   )
 where
 
+import FormRefs
 import TablesMS2025
 import TenForty
 
@@ -12,7 +13,7 @@ ms80105_2025 :: Either FormError Form
 ms80105_2025 = form "ms_80105" 2025 $ do
   -- Line 13: Mississippi Adjusted Gross Income
   -- Starts with Federal AGI and applies Mississippi modifications
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l13 <-
     keyOutput "L13" "ms_agi" "Mississippi adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/MTForm2_2024.hs
+++ b/tenforty-spec/forms/MTForm2_2024.hs
@@ -5,6 +5,7 @@ module MTForm2_2024
   )
 where
 
+import FormRefs
 import TablesMT2024
 import TenForty
 
@@ -18,7 +19,7 @@ mtForm2_2024 = form "mt_form2" 2024 $ do
   -- additions and subtractions via Schedule I.
   -- For this implementation, we approximate by importing federal taxable income
   -- and accepting adjustments as a single input.
-  let federalTaxableIncome = importForm "us_1040" "L15"
+  let federalTaxableIncome = importForm us1040L15
 
   adjustments <- keyInput "L_Schedule_I" "mt_adjustments" "Montana Schedule I adjustments (additions minus subtractions)"
 

--- a/tenforty-spec/forms/MTForm2_2025.hs
+++ b/tenforty-spec/forms/MTForm2_2025.hs
@@ -5,6 +5,7 @@ module MTForm2_2025
   )
 where
 
+import FormRefs
 import TablesMT2025
 import TenForty
 
@@ -18,7 +19,7 @@ mtForm2_2025 = form "mt_form2" 2025 $ do
   -- additions and subtractions via Schedule I.
   -- For this implementation, we approximate by importing federal taxable income
   -- and accepting adjustments as a single input.
-  let federalTaxableIncome = importForm "us_1040" "L15"
+  let federalTaxableIncome = importForm us1040L15
 
   adjustments <- keyInput "L_Schedule_I" "mt_adjustments" "Montana Schedule I adjustments (additions minus subtractions)"
 

--- a/tenforty-spec/forms/NCFormD400_2024.hs
+++ b/tenforty-spec/forms/NCFormD400_2024.hs
@@ -5,13 +5,14 @@ module NCFormD400_2024
   )
 where
 
+import FormRefs
 import TablesNC2024
 import TenForty
 
 ncFormD400_2024 :: Either FormError Form
 ncFormD400_2024 = form "nc_d400" 2024 $ do
   -- Line 6: Federal Adjusted Gross Income (from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l6 <-
     keyOutput "L6" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/NCFormD400_2025.hs
+++ b/tenforty-spec/forms/NCFormD400_2025.hs
@@ -5,13 +5,14 @@ module NCFormD400_2025
   )
 where
 
+import FormRefs
 import TablesNC2025
 import TenForty
 
 ncFormD400_2025 :: Either FormError Form
 ncFormD400_2025 = form "nc_d400" 2025 $ do
   -- Line 6: Federal Adjusted Gross Income (from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l6 <-
     keyOutput "L6" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/NDForm1_2024.hs
+++ b/tenforty-spec/forms/NDForm1_2024.hs
@@ -5,6 +5,7 @@ module NDForm1_2024
   )
 where
 
+import FormRefs
 import TablesND2024
 import TenForty
 
@@ -13,7 +14,7 @@ ndForm1_2024 = form "nd_1" 2024 $ do
   defineTable ndBracketsTable2024
 
   -- Line 1a: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1a <- keyOutput "L1a" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 1b-1l: Additions to federal AGI

--- a/tenforty-spec/forms/NDForm1_2025.hs
+++ b/tenforty-spec/forms/NDForm1_2025.hs
@@ -5,6 +5,7 @@ module NDForm1_2025
   )
 where
 
+import FormRefs
 import TablesND2025
 import TenForty
 
@@ -13,7 +14,7 @@ ndForm1_2025 = form "nd_1" 2025 $ do
   defineTable ndBracketsTable2025
 
   -- Line 1a: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1a <- keyOutput "L1a" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 1b-1l: Additions to federal AGI

--- a/tenforty-spec/forms/NEForm1040N_2024.hs
+++ b/tenforty-spec/forms/NEForm1040N_2024.hs
@@ -5,6 +5,7 @@ module NEForm1040N_2024
   )
 where
 
+import FormRefs
 import TablesNE2024
 import TenForty
 
@@ -13,7 +14,7 @@ neForm1040N_2024 = form "ne_1040n" 2024 $ do
   defineTable nebraskaBracketsTable2024
 
   -- Line 5: Federal Adjusted Gross Income (imported from US 1040 L11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l5 <- keyOutput "L5" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 6: Nebraska standard deduction

--- a/tenforty-spec/forms/NEForm1040N_2025.hs
+++ b/tenforty-spec/forms/NEForm1040N_2025.hs
@@ -5,6 +5,7 @@ module NEForm1040N_2025
   )
 where
 
+import FormRefs
 import TablesNE2025
 import TenForty
 
@@ -13,7 +14,7 @@ neForm1040N_2025 = form "ne_1040n" 2025 $ do
   defineTable nebraskaBracketsTable2025
 
   -- Line 5: Federal Adjusted Gross Income (imported from US 1040 L11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l5 <- keyOutput "L5" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 6: Nebraska standard deduction

--- a/tenforty-spec/forms/NJ1040_2024.hs
+++ b/tenforty-spec/forms/NJ1040_2024.hs
@@ -5,6 +5,7 @@ module NJ1040_2024
   )
 where
 
+import FormRefs
 import TablesNJ2024
 import TenForty
 
@@ -16,7 +17,7 @@ nj1040_2024 = form "nj_1040" 2024 $ do
   -- Line 14: Federal adjusted gross income (imported from US 1040 L11)
   -- Note: NJ form technically builds from gross income, but for graph backend
   -- we simplify by starting from federal AGI as a reasonable approximation
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   _l14 <-
     keyOutput "L14" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/NJ1040_2025.hs
+++ b/tenforty-spec/forms/NJ1040_2025.hs
@@ -5,6 +5,7 @@ module NJ1040_2025
   )
 where
 
+import FormRefs
 import TablesNJ2025
 import TenForty
 
@@ -16,7 +17,7 @@ nj1040_2025 = form "nj_1040" 2025 $ do
   -- Line 14: Federal adjusted gross income (imported from US 1040 L11)
   -- Note: NJ form technically builds from gross income, but for graph backend
   -- we simplify by starting from federal AGI as a reasonable approximation
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   _l14 <-
     keyOutput "L14" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/NMPIT1_2024.hs
+++ b/tenforty-spec/forms/NMPIT1_2024.hs
@@ -5,6 +5,7 @@ module NMPIT1_2024
   )
 where
 
+import FormRefs
 import TablesNM2024
 import TenForty
 
@@ -13,7 +14,7 @@ nmPIT1_2024 = form "nm_pit1" 2024 $ do
   defineTable newMexicoBracketsTable2024
 
   -- Line 9: Federal Adjusted Gross Income (imported from US 1040 L11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l9 <- keyOutput "L9" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 10: State and local tax deduction from federal Schedule A
@@ -26,7 +27,7 @@ nmPIT1_2024 = form "nm_pit1" 2024 $ do
   -- Line 12: Federal standard or itemized deduction
   -- (NM subtracts this from AGI since NM uses federal deductions)
   -- Import from US 1040 Line 12
-  let federalDeduction = importForm "us_1040" "L12Final"
+  let federalDeduction = importForm us1040L12final
   l12 <- interior "L12" "federal_deduction" federalDeduction
 
   -- Line 13: Deduction for certain dependents

--- a/tenforty-spec/forms/NMPIT1_2025.hs
+++ b/tenforty-spec/forms/NMPIT1_2025.hs
@@ -5,6 +5,7 @@ module NMPIT1_2025
   )
 where
 
+import FormRefs
 import TablesNM2025
 import TenForty
 
@@ -13,7 +14,7 @@ nmPIT1_2025 = form "nm_pit1" 2025 $ do
   defineTable newMexicoBracketsTable2025
 
   -- Line 9: Federal Adjusted Gross Income (imported from US 1040 L11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l9 <- keyOutput "L9" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 10: State and local tax deduction from federal Schedule A
@@ -26,7 +27,7 @@ nmPIT1_2025 = form "nm_pit1" 2025 $ do
   -- Line 12: Federal standard or itemized deduction
   -- (NM subtracts this from AGI since NM uses federal deductions)
   -- Import from US 1040 Line 12
-  let federalDeduction = importForm "us_1040" "L12Final"
+  let federalDeduction = importForm us1040L12final
   l12 <- interior "L12" "federal_deduction" federalDeduction
 
   -- Line 13: Deduction for certain dependents

--- a/tenforty-spec/forms/NYIT201_2024.hs
+++ b/tenforty-spec/forms/NYIT201_2024.hs
@@ -5,6 +5,7 @@ module NYIT201_2024
   )
 where
 
+import FormRefs
 import TablesNY2024
 import TenForty
 
@@ -14,7 +15,7 @@ nyIT201_2024 = form "ny_it201" 2024 $ do
   defineTable nycBracketsTable2024
 
   -- Line 19: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l19 <- keyOutput "L19" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Lines 20-23: New York additions to income
@@ -29,9 +30,9 @@ nyIT201_2024 = form "ny_it201" 2024 $ do
       sumOf [l19, l20, l21, l22, l23]
 
   -- Lines 25-31: New York subtractions from income
-  l25 <- interior "L25" "ny_sub_refunds" $ importForm "us_schedule_1" "L1"
+  l25 <- interior "L25" "ny_sub_refunds" $ importForm usSchedule1L1
   l26 <- keyInput "L26" "ny_sub_gov_pensions" "Pensions of NYS/local/federal governments"
-  l27 <- interior "L27" "ny_sub_socsec" $ importForm "us_1040" "L6b"
+  l27 <- interior "L27" "ny_sub_socsec" $ importForm us1040L6b
   l28 <- keyInput "L28" "ny_sub_us_bond_interest" "Interest income on U.S. government bonds"
   l29 <- keyInput "L29" "ny_sub_pension_exclusion" "Pension and annuity income exclusion"
   l30 <- keyInput "L30" "ny_sub_college_tuition" "College choice tuition savings deduction"

--- a/tenforty-spec/forms/NYIT201_2025.hs
+++ b/tenforty-spec/forms/NYIT201_2025.hs
@@ -5,6 +5,7 @@ module NYIT201_2025
   )
 where
 
+import FormRefs
 import TablesNY2025
 import TenForty
 
@@ -14,7 +15,7 @@ nyIT201_2025 = form "ny_it201" 2025 $ do
   defineTable nycBracketsTable2025
 
   -- Line 19: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l19 <- keyOutput "L19" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Lines 20-23: New York additions to income
@@ -29,9 +30,9 @@ nyIT201_2025 = form "ny_it201" 2025 $ do
       sumOf [l19, l20, l21, l22, l23]
 
   -- Lines 25-31: New York subtractions from income
-  l25 <- interior "L25" "ny_sub_refunds" $ importForm "us_schedule_1" "L1"
+  l25 <- interior "L25" "ny_sub_refunds" $ importForm usSchedule1L1
   l26 <- keyInput "L26" "ny_sub_gov_pensions" "Pensions of NYS/local/federal governments"
-  l27 <- interior "L27" "ny_sub_socsec" $ importForm "us_1040" "L6b"
+  l27 <- interior "L27" "ny_sub_socsec" $ importForm us1040L6b
   l28 <- keyInput "L28" "ny_sub_us_bond_interest" "Interest income on U.S. government bonds"
   l29 <- keyInput "L29" "ny_sub_pension_exclusion" "Pension and annuity income exclusion"
   l30 <- keyInput "L30" "ny_sub_college_tuition" "College choice tuition savings deduction"

--- a/tenforty-spec/forms/OHIT1040_2024.hs
+++ b/tenforty-spec/forms/OHIT1040_2024.hs
@@ -5,6 +5,7 @@ module OHIT1040_2024
   )
 where
 
+import FormRefs
 import TablesOH2024
 import TenForty
 
@@ -13,7 +14,7 @@ ohIT1040_2024 = form "oh_it1040" 2024 $ do
   defineTable ohioBracketsTable2024
 
   -- Line 1: Federal Adjusted Gross Income (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 2: Additions to federal AGI (from Schedule of Adjustments)

--- a/tenforty-spec/forms/OHIT1040_2025.hs
+++ b/tenforty-spec/forms/OHIT1040_2025.hs
@@ -5,6 +5,7 @@ module OHIT1040_2025
   )
 where
 
+import FormRefs
 import TablesOH2025
 import TenForty
 
@@ -13,7 +14,7 @@ ohIT1040_2025 = form "oh_it1040" 2025 $ do
   defineTable ohioBracketsTable2025
 
   -- Line 1: Federal Adjusted Gross Income (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 2: Additions to federal AGI (from Schedule of Adjustments)

--- a/tenforty-spec/forms/OK511_2024.hs
+++ b/tenforty-spec/forms/OK511_2024.hs
@@ -5,6 +5,7 @@ module OK511_2024
   )
 where
 
+import FormRefs
 import TablesOK2024
 import TenForty
 
@@ -13,7 +14,7 @@ ok511_2024 = form "ok_511" 2024 $ do
   defineTable okBracketsTable2024
 
   -- Line 7: Federal adjusted gross income (imported from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l7 <-
     keyOutput "L7" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/OK511_2025.hs
+++ b/tenforty-spec/forms/OK511_2025.hs
@@ -5,6 +5,7 @@ module OK511_2025
   )
 where
 
+import FormRefs
 import TablesOK2025
 import TenForty
 
@@ -13,7 +14,7 @@ ok511_2025 = form "ok_511" 2025 $ do
   defineTable okBracketsTable2025
 
   -- Line 7: Federal adjusted gross income (imported from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l7 <-
     keyOutput "L7" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/ORForm40_2024.hs
+++ b/tenforty-spec/forms/ORForm40_2024.hs
@@ -5,6 +5,7 @@ module ORForm40_2024
   )
 where
 
+import FormRefs
 import TablesOR2024
 import TenForty
 
@@ -13,7 +14,7 @@ orForm40_2024 = form "or_40" 2024 $ do
   defineTable oregonBracketsTable2024
 
   -- Line 7: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l7 <- keyOutput "L7" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Lines 8-12: Oregon additions to income
@@ -37,7 +38,7 @@ orForm40_2024 = form "or_40" 2024 $ do
   -- The phaseout is linear: $8,250 at AGI $0-$125k (Single/MFS) or $0-$250k (MFJ/HoH/QW),
   -- then reduces by $1,650 per $5,000 of AGI until $0 at $145k (Single/MFS) or $290k (MFJ/HoH/QW).
   -- This is a 20% reduction per $5,000 increment: rate = $1,650 / $5,000 = 0.33
-  let _federalTaxFromReturn = importForm "us_1040" "L22"
+  let _federalTaxFromReturn = importForm us1040L22
   let fedTaxPhaseoutSpec =
         PhaseOutSpec
           { poBase = 8250,

--- a/tenforty-spec/forms/ORForm40_2025.hs
+++ b/tenforty-spec/forms/ORForm40_2025.hs
@@ -5,6 +5,7 @@ module ORForm40_2025
   )
 where
 
+import FormRefs
 import TablesOR2025
 import TenForty
 
@@ -13,7 +14,7 @@ orForm40_2025 = form "or_40" 2025 $ do
   defineTable oregonBracketsTable2025
 
   -- Line 7: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l7 <- keyOutput "L7" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Lines 8-12: Oregon additions to income
@@ -37,7 +38,7 @@ orForm40_2025 = form "or_40" 2025 $ do
   -- The phaseout is linear: $8,500 at AGI $0-$125k (Single/MFS) or $0-$250k (MFJ/HoH/QW),
   -- then reduces by $1,700 per $5,000 of AGI until $0 at $145k (Single/MFS) or $290k (MFJ/HoH/QW).
   -- This is a 20% reduction per $5,000 increment: rate = $1,700 / $5,000 = 0.34
-  let _federalTaxFromReturn = importForm "us_1040" "L22"
+  let _federalTaxFromReturn = importForm us1040L22
   let fedTaxPhaseoutSpec =
         PhaseOutSpec
           { poBase = 8500,

--- a/tenforty-spec/forms/RIForm1040_2024.hs
+++ b/tenforty-spec/forms/RIForm1040_2024.hs
@@ -5,6 +5,7 @@ module RIForm1040_2024
   )
 where
 
+import FormRefs
 import TablesRI2024
 import TenForty
 
@@ -13,7 +14,7 @@ riRI1040_2024 = form "ri_1040" 2024 $ do
   defineTable riBracketsTable2024
 
   -- Line 1: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 2: Net modifications to Federal AGI from RI Schedule M

--- a/tenforty-spec/forms/RIForm1040_2025.hs
+++ b/tenforty-spec/forms/RIForm1040_2025.hs
@@ -5,6 +5,7 @@ module RIForm1040_2025
   )
 where
 
+import FormRefs
 import TablesRI2025
 import TenForty
 
@@ -13,7 +14,7 @@ riRI1040_2025 = form "ri_1040" 2025 $ do
   defineTable riBracketsTable2025
 
   -- Line 1: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 2: Net modifications to Federal AGI from RI Schedule M

--- a/tenforty-spec/forms/SCForm1040_2024.hs
+++ b/tenforty-spec/forms/SCForm1040_2024.hs
@@ -5,6 +5,7 @@ module SCForm1040_2024
   )
 where
 
+import FormRefs
 import TablesSC2024
 import TenForty
 
@@ -13,7 +14,7 @@ scForm1040_2024 = form "sc_1040" 2024 $ do
   defineTable scBracketsTable2024
 
   -- Line 1: Federal Taxable Income (from US 1040 Line 15)
-  let federalTaxableIncome = importForm "us_1040" "L15"
+  let federalTaxableIncome = importForm us1040L15
   l1 <-
     keyOutput "L1" "federal_taxable_income" "Federal taxable income" $
       federalTaxableIncome .+. dollars 0

--- a/tenforty-spec/forms/SCForm1040_2025.hs
+++ b/tenforty-spec/forms/SCForm1040_2025.hs
@@ -5,6 +5,7 @@ module SCForm1040_2025
   )
 where
 
+import FormRefs
 import TablesSC2025
 import TenForty
 
@@ -13,7 +14,7 @@ scForm1040_2025 = form "sc_1040" 2025 $ do
   defineTable scBracketsTable2025
 
   -- Line 1: Federal Taxable Income (from US 1040 Line 15)
-  let federalTaxableIncome = importForm "us_1040" "L15"
+  let federalTaxableIncome = importForm us1040L15
   l1 <-
     keyOutput "L1" "federal_taxable_income" "Federal taxable income" $
       federalTaxableIncome .+. dollars 0

--- a/tenforty-spec/forms/US1040_2024.hs
+++ b/tenforty-spec/forms/US1040_2024.hs
@@ -5,6 +5,7 @@ module US1040_2024
   )
 where
 
+import FormRefs
 import Tables2024
 import TenForty
 
@@ -43,9 +44,9 @@ us1040_2024 = form "us_1040" 2024 $ do
   _l6a <- keyInput "L6a" "social_security_gross" "Total Social Security benefits received"
   l6b <- keyInput "L6b" "social_security_taxable" "Taxable Social Security benefits"
 
-  l7 <- interior "L7" "capital_gain_loss" $ importForm "us_schedule_d" "L21"
+  l7 <- interior "L7" "capital_gain_loss" $ importForm usScheduleDL21
 
-  l8 <- interior "L8" "schedule_1_income" $ importForm "us_schedule_1" "L10"
+  l8 <- interior "L8" "schedule_1_income" $ importForm usSchedule1L10
 
   -- Line 9: Add lines 1z through 8.
   l9 <-
@@ -53,14 +54,14 @@ us1040_2024 = form "us_1040" 2024 $ do
       sumOf [l1z, l2b, l3b, l4b, l5b, l6b, l7, l8]
 
   -- Line 10-11: Adjustments and AGI
-  l10 <- interior "L10" "schedule_1_adjustments" $ importForm "us_schedule_1" "L26"
+  l10 <- interior "L10" "schedule_1_adjustments" $ importForm usSchedule1L26
 
   l11 <-
     keyOutput "L11" "agi" "Adjusted gross income (AGI)" $
       l9 .-. l10
 
   -- Lines 12-14: Deductions
-  l12 <- interior "L12" "itemized_deductions" $ importForm "us_schedule_a" "L17"
+  l12 <- interior "L12" "itemized_deductions" $ importForm usScheduleAL17
 
   -- Additional standard deduction for blind/65+ (from 1040 line 12 worksheet)
   additionalStdDed <- keyInput "AddStdDed" "additional_std_ded" "Additional standard deduction for blind/65+"
@@ -84,7 +85,7 @@ us1040_2024 = form "us_1040" 2024 $ do
     interior "L15_pre_qbi" "taxable_income_before_qbi" $
       l11 `subtractNotBelowZero` l12Final
 
-  l13 <- interior "L13" "qbi_deduction" $ importForm "us_form_8995" "L16"
+  l13 <- interior "L13" "qbi_deduction" $ importForm usForm8995L16
 
   l14 <-
     interior "L14" "total_deductions" $
@@ -99,7 +100,7 @@ us1040_2024 = form "us_1040" 2024 $ do
 
   -- Qualified Dividends and Capital Gain Tax Worksheet
   -- See 2024 Instructions for Form 1040, Line 16.
-  l15SchedD <- interior "L15_sched_d_net_long_term" "Net long-term capital gain" $ importForm "us_schedule_d" "L15"
+  l15SchedD <- interior "L15_sched_d_net_long_term" "Net long-term capital gain" $ importForm usScheduleDL15
 
   let qcgws1 = l15
   let qcgws2 = l3a
@@ -154,16 +155,16 @@ us1040_2024 = form "us_1040" 2024 $ do
     keyOutput "L16" "tax" "Tax from tax tables or Schedule D" $
       ifPos hasPreferential qcgws25 qcgws24
 
-  l17 <- interior "L17" "schedule_2_tax" $ importForm "us_schedule_2" "L3"
+  l17 <- interior "L17" "schedule_2_tax" $ importForm usSchedule2L3
 
   l18 <-
     interior "L18" "total_tax_before_credits" $
       l16 .+. l17
 
   -- Lines 19-21: Credits
-  l19 <- interior "L19" "child_tax_credit" $ importForm "us_form_8812" "L14"
+  l19 <- interior "L19" "child_tax_credit" $ importForm usForm8812L14
 
-  l20 <- interior "L20" "schedule_3_credits" $ importForm "us_schedule_3" "L8"
+  l20 <- interior "L20" "schedule_3_credits" $ importForm usSchedule3L8
 
   l21 <-
     interior "L21" "total_credits" $
@@ -175,7 +176,7 @@ us1040_2024 = form "us_1040" 2024 $ do
       l18 `subtractNotBelowZero` l21
 
   -- Line 23-24: Other Taxes
-  l23 <- interior "L23" "other_taxes" $ importForm "us_schedule_2" "L21"
+  l23 <- interior "L23" "other_taxes" $ importForm usSchedule2L21
 
   l24 <-
     keyOutput "L24" "total_tax" "Total tax liability" $
@@ -192,10 +193,10 @@ us1040_2024 = form "us_1040" 2024 $ do
 
   l26 <- keyInput "L26" "estimated_payments" "Estimated tax payments for the year"
   l27 <- keyInput "L27" "eic" "Earned income credit"
-  l28 <- interior "L28" "additional_ctc" $ importForm "us_form_8812" "L27"
-  l29 <- interior "L29" "aotc" $ importForm "us_form_8863" "L9"
+  l28 <- interior "L28" "additional_ctc" $ importForm usForm8812L27
+  l29 <- interior "L29" "aotc" $ importForm usForm8863L9
   l30 <- keyInput "L30" "recovery_rebate" "Recovery rebate credit"
-  l31 <- interior "L31" "schedule_3_payments" $ importForm "us_schedule_3" "L15"
+  l31 <- interior "L31" "schedule_3_payments" $ importForm usSchedule3L15
   l32 <- keyInput "L32" "extension_payment" "Amount paid with extension request"
 
   l33 <-

--- a/tenforty-spec/forms/US1040_2025.hs
+++ b/tenforty-spec/forms/US1040_2025.hs
@@ -5,6 +5,7 @@ module US1040_2025
   )
 where
 
+import FormRefs
 import Tables2025
 import TenForty
 
@@ -43,9 +44,9 @@ us1040_2025 = form "us_1040" 2025 $ do
   _l6a <- keyInput "L6a" "social_security_gross" "Total Social Security benefits received"
   l6b <- keyInput "L6b" "social_security_taxable" "Taxable Social Security benefits"
 
-  l7 <- interior "L7" "capital_gain_loss" $ importForm "us_schedule_d" "L21"
+  l7 <- interior "L7" "capital_gain_loss" $ importForm usScheduleDL21
 
-  l8 <- interior "L8" "schedule_1_income" $ importForm "us_schedule_1" "L10"
+  l8 <- interior "L8" "schedule_1_income" $ importForm usSchedule1L10
 
   -- Line 9: Add lines 1z through 8.
   l9 <-
@@ -53,14 +54,14 @@ us1040_2025 = form "us_1040" 2025 $ do
       sumOf [l1z, l2b, l3b, l4b, l5b, l6b, l7, l8]
 
   -- Line 10-11: Adjustments and AGI
-  l10 <- interior "L10" "schedule_1_adjustments" $ importForm "us_schedule_1" "L26"
+  l10 <- interior "L10" "schedule_1_adjustments" $ importForm usSchedule1L26
 
   l11 <-
     keyOutput "L11" "agi" "Adjusted gross income (AGI)" $
       l9 .-. l10
 
   -- Lines 12-14: Deductions
-  l12 <- interior "L12" "itemized_deductions" $ importForm "us_schedule_a" "L17"
+  l12 <- interior "L12" "itemized_deductions" $ importForm usScheduleAL17
 
   -- Additional standard deduction for blind/65+ (from 1040 line 12 worksheet)
   additionalStdDed <- keyInput "AddStdDed" "additional_std_ded" "Additional standard deduction for blind/65+"
@@ -84,7 +85,7 @@ us1040_2025 = form "us_1040" 2025 $ do
     interior "L15_pre_qbi" "taxable_income_before_qbi" $
       l11 `subtractNotBelowZero` l12Final
 
-  l13 <- interior "L13" "qbi_deduction" $ importForm "us_form_8995" "L16"
+  l13 <- interior "L13" "qbi_deduction" $ importForm usForm8995L16
 
   l14 <-
     interior "L14" "total_deductions" $
@@ -99,7 +100,7 @@ us1040_2025 = form "us_1040" 2025 $ do
 
   -- Qualified Dividends and Capital Gain Tax Worksheet
   -- See 2025 Instructions for Form 1040, Line 16.
-  l15SchedD <- interior "L15_sched_d_net_long_term" "Net long-term capital gain" $ importForm "us_schedule_d" "L15"
+  l15SchedD <- interior "L15_sched_d_net_long_term" "Net long-term capital gain" $ importForm usScheduleDL15
 
   let qcgws1 = l15
   let qcgws2 = l3a
@@ -154,16 +155,16 @@ us1040_2025 = form "us_1040" 2025 $ do
     keyOutput "L16" "tax" "Tax from tax tables or Schedule D" $
       ifPos hasPreferential qcgws25 qcgws24
 
-  l17 <- interior "L17" "schedule_2_tax" $ importForm "us_schedule_2" "L3"
+  l17 <- interior "L17" "schedule_2_tax" $ importForm usSchedule2L3
 
   l18 <-
     interior "L18" "total_tax_before_credits" $
       l16 .+. l17
 
   -- Lines 19-21: Credits
-  l19 <- interior "L19" "child_tax_credit" $ importForm "us_form_8812" "L14"
+  l19 <- interior "L19" "child_tax_credit" $ importForm usForm8812L14
 
-  l20 <- interior "L20" "schedule_3_credits" $ importForm "us_schedule_3" "L8"
+  l20 <- interior "L20" "schedule_3_credits" $ importForm usSchedule3L8
 
   l21 <-
     interior "L21" "total_credits" $
@@ -175,7 +176,7 @@ us1040_2025 = form "us_1040" 2025 $ do
       l18 `subtractNotBelowZero` l21
 
   -- Line 23-24: Other Taxes
-  l23 <- interior "L23" "other_taxes" $ importForm "us_schedule_2" "L21"
+  l23 <- interior "L23" "other_taxes" $ importForm usSchedule2L21
 
   l24 <-
     keyOutput "L24" "total_tax" "Total tax liability" $
@@ -192,10 +193,10 @@ us1040_2025 = form "us_1040" 2025 $ do
 
   l26 <- keyInput "L26" "estimated_payments" "Estimated tax payments for the year"
   l27 <- keyInput "L27" "eic" "Earned income credit"
-  l28 <- interior "L28" "additional_ctc" $ importForm "us_form_8812" "L27"
-  l29 <- interior "L29" "aotc" $ importForm "us_form_8863" "L9"
+  l28 <- interior "L28" "additional_ctc" $ importForm usForm8812L27
+  l29 <- interior "L29" "aotc" $ importForm usForm8863L9
   l30 <- keyInput "L30" "recovery_rebate" "Recovery rebate credit"
-  l31 <- interior "L31" "schedule_3_payments" $ importForm "us_schedule_3" "L15"
+  l31 <- interior "L31" "schedule_3_payments" $ importForm usSchedule3L15
   l32 <- keyInput "L32" "extension_payment" "Amount paid with extension request"
 
   l33 <-

--- a/tenforty-spec/forms/USForm2441_2024.hs
+++ b/tenforty-spec/forms/USForm2441_2024.hs
@@ -5,6 +5,7 @@ module USForm2441_2024
   )
 where
 
+import FormRefs
 import Tables2024
 import TenForty
 
@@ -49,7 +50,7 @@ usForm2441_2024 = form "us_form_2441" 2024 $ do
       smallerOf l4 (smallerOf l5 l6)
 
   -- Line 8: AGI from Form 1040, line 11
-  l8 <- interior "L8" "agi" $ importForm "us_1040" "L11"
+  l8 <- interior "L8" "agi" $ importForm us1040L11
 
   -- Line 9: Decimal amount (credit percentage based on AGI)
   -- Credit starts at 35% for AGI <= $15,000

--- a/tenforty-spec/forms/USForm2441_2025.hs
+++ b/tenforty-spec/forms/USForm2441_2025.hs
@@ -5,6 +5,7 @@ module USForm2441_2025
   )
 where
 
+import FormRefs
 import Tables2025
 import TenForty
 
@@ -49,7 +50,7 @@ usForm2441_2025 = form "us_form_2441" 2025 $ do
       smallerOf l4 (smallerOf l5 l6)
 
   -- Line 8: AGI from Form 1040, line 11
-  l8 <- interior "L8" "agi" $ importForm "us_1040" "L11"
+  l8 <- interior "L8" "agi" $ importForm us1040L11
 
   -- Line 9: Decimal amount (credit percentage based on AGI)
   -- Credit starts at 35% for AGI <= $15,000

--- a/tenforty-spec/forms/USForm6251_2024.hs
+++ b/tenforty-spec/forms/USForm6251_2024.hs
@@ -5,6 +5,7 @@ module USForm6251_2024
   )
 where
 
+import FormRefs
 import Tables2024
 import TenForty
 
@@ -13,7 +14,7 @@ usForm6251_2024 = form "us_form_6251" 2024 $ do
   -- Part I: Alternative Minimum Taxable Income (AMTI)
 
   -- Line 1: Enter taxable income from Form 1040, line 15
-  l1 <- interior "L1" "taxable_income" $ importForm "us_1040" "L15"
+  l1 <- interior "L1" "taxable_income" $ importForm us1040L15
 
   -- Line 2a: taxes added back. Form 6251 line 2a is the Schedule A taxes when
   -- itemizing, OR the standard deduction when not (IRC 56(b)(1)(E): the
@@ -41,7 +42,7 @@ usForm6251_2024 = form "us_form_6251" 2024 $ do
       byStatusE (fmap lit standardDeduction2024)
   deductionTaken <-
     interior "deduction_taken" "Deduction the 1040 used (greater of itemized and standard)" $
-      importForm "us_1040" "L12Final"
+      importForm us1040L12final
   itemizingExcess <-
     interior "amt_itemizing_excess" "By how much the 1040 deduction exceeds the standard deduction" $
       deductionTaken `subtractNotBelowZero` stdDeduction
@@ -199,10 +200,10 @@ usForm6251_2024 = form "us_form_6251" 2024 $ do
   -- Part III: Tax Computation Using Maximum Capital Gains Rates
   preferentialIncome <-
     interior "P3_pref_income" "preferential_income" $
-      importForm "us_1040" "qcgws_4"
+      importForm us1040Qcgws4
   ordinaryTaxableIncome <-
     interior "P3_ord_taxable" "ordinary_taxable_income" $
-      importForm "us_1040" "qcgws_5"
+      importForm us1040Qcgws5
 
   -- Split AMT taxable income into ordinary and preferential portions
   prefInAmt <-
@@ -294,7 +295,7 @@ usForm6251_2024 = form "us_form_6251" 2024 $ do
       l7 `subtractNotBelowZero` l8
 
   -- Line 10: Regular tax liability from Form 1040
-  l10 <- interior "L10" "regular_tax" $ importForm "us_1040" "L16"
+  l10 <- interior "L10" "regular_tax" $ importForm us1040L16
 
   -- Line 11: AMT. Subtract line 10 from line 9. If zero or less, enter -0-.
   _l11 <-

--- a/tenforty-spec/forms/USForm6251_2025.hs
+++ b/tenforty-spec/forms/USForm6251_2025.hs
@@ -5,6 +5,7 @@ module USForm6251_2025
   )
 where
 
+import FormRefs
 import Tables2025
 import TenForty
 
@@ -13,7 +14,7 @@ usForm6251_2025 = form "us_form_6251" 2025 $ do
   -- Part I: Alternative Minimum Taxable Income (AMTI)
 
   -- Line 1: Enter taxable income from Form 1040, line 15
-  l1 <- interior "L1" "taxable_income" $ importForm "us_1040" "L15"
+  l1 <- interior "L1" "taxable_income" $ importForm us1040L15
 
   -- Line 2a: taxes added back. Form 6251 line 2a is the Schedule A taxes when
   -- itemizing, OR the standard deduction when not (IRC 56(b)(1)(E): the
@@ -41,7 +42,7 @@ usForm6251_2025 = form "us_form_6251" 2025 $ do
       byStatusE (fmap lit standardDeduction2025)
   deductionTaken <-
     interior "deduction_taken" "Deduction the 1040 used (greater of itemized and standard)" $
-      importForm "us_1040" "L12Final"
+      importForm us1040L12final
   itemizingExcess <-
     interior "amt_itemizing_excess" "By how much the 1040 deduction exceeds the standard deduction" $
       deductionTaken `subtractNotBelowZero` stdDeduction
@@ -199,10 +200,10 @@ usForm6251_2025 = form "us_form_6251" 2025 $ do
   -- Part III: Tax Computation Using Maximum Capital Gains Rates
   preferentialIncome <-
     interior "P3_pref_income" "preferential_income" $
-      importForm "us_1040" "qcgws_4"
+      importForm us1040Qcgws4
   ordinaryTaxableIncome <-
     interior "P3_ord_taxable" "ordinary_taxable_income" $
-      importForm "us_1040" "qcgws_5"
+      importForm us1040Qcgws5
 
   -- Split AMT taxable income into ordinary and preferential portions
   prefInAmt <-
@@ -294,7 +295,7 @@ usForm6251_2025 = form "us_form_6251" 2025 $ do
       l7 `subtractNotBelowZero` l8
 
   -- Line 10: Regular tax liability from Form 1040
-  l10 <- interior "L10" "regular_tax" $ importForm "us_1040" "L16"
+  l10 <- interior "L10" "regular_tax" $ importForm us1040L16
 
   -- Line 11: AMT. Subtract line 10 from line 9. If zero or less, enter -0-.
   _l11 <-

--- a/tenforty-spec/forms/USForm8812_2024.hs
+++ b/tenforty-spec/forms/USForm8812_2024.hs
@@ -5,6 +5,7 @@ module USForm8812_2024
   )
 where
 
+import FormRefs
 import Tables2024
 import TenForty
 
@@ -36,7 +37,7 @@ usForm8812_2024 = form "us_form_8812" 2024 $ do
       l2 .+. l4
 
   -- Line 6: AGI from Form 1040, line 11
-  l6 <- interior "L6" "agi" $ importForm "us_1040" "L11"
+  l6 <- interior "L6" "agi" $ importForm us1040L11
 
   -- Line 7: Phase-out threshold
   l7 <-
@@ -68,7 +69,7 @@ usForm8812_2024 = form "us_form_8812" 2024 $ do
       l5 `subtractNotBelowZero` l10
 
   -- Line 12: Tax liability limit (from Form 1040, line 18)
-  l12 <- interior "L12" "tax_liability" $ importForm "us_1040" "L18"
+  l12 <- interior "L12" "tax_liability" $ importForm us1040L18
 
   -- Line 13: Credit for other dependents (limited to tax liability)
   -- This is the portion of credit attributable to other dependents (ODC)

--- a/tenforty-spec/forms/USForm8812_2025.hs
+++ b/tenforty-spec/forms/USForm8812_2025.hs
@@ -5,6 +5,7 @@ module USForm8812_2025
   )
 where
 
+import FormRefs
 import Tables2025
 import TenForty
 
@@ -36,7 +37,7 @@ usForm8812_2025 = form "us_form_8812" 2025 $ do
       l2 .+. l4
 
   -- Line 6: AGI from Form 1040, line 11
-  l6 <- interior "L6" "agi" $ importForm "us_1040" "L11"
+  l6 <- interior "L6" "agi" $ importForm us1040L11
 
   -- Line 7: Phase-out threshold
   l7 <-
@@ -68,7 +69,7 @@ usForm8812_2025 = form "us_form_8812" 2025 $ do
       l5 `subtractNotBelowZero` l10
 
   -- Line 12: Tax liability limit (from Form 1040, line 18)
-  l12 <- interior "L12" "tax_liability" $ importForm "us_1040" "L18"
+  l12 <- interior "L12" "tax_liability" $ importForm us1040L18
 
   -- Line 13: Credit for other dependents (limited to tax liability)
   -- This is the portion of credit attributable to other dependents (ODC)

--- a/tenforty-spec/forms/USForm8863_2024.hs
+++ b/tenforty-spec/forms/USForm8863_2024.hs
@@ -5,6 +5,7 @@ module USForm8863_2024
   )
 where
 
+import FormRefs
 import Tables2024
 import TenForty
 
@@ -18,7 +19,7 @@ usForm8863_2024 = form "us_form_8863" 2024 $ do
   l1 <- keyInput "L1" "aotc_total" "Total American opportunity credit from Part III"
 
   -- Line 2: MAGI from Form 1040 (used for phase-out calculation)
-  l2 <- interior "L2" "magi" $ importForm "us_1040" "L11"
+  l2 <- interior "L2" "magi" $ importForm us1040L11
 
   -- Line 3: Phase-out threshold
   l3 <-
@@ -61,7 +62,7 @@ usForm8863_2024 = form "us_form_8863" 2024 $ do
   l11 <- keyInput "L11" "llc_total" "Total lifetime learning credit from Part III"
 
   -- Line 12: MAGI for LLC phase-out
-  l12 <- interior "L12" "magi_llc" $ importForm "us_1040" "L11"
+  l12 <- interior "L12" "magi_llc" $ importForm us1040L11
 
   -- Line 13: LLC phase-out threshold
   l13 <-

--- a/tenforty-spec/forms/USForm8863_2025.hs
+++ b/tenforty-spec/forms/USForm8863_2025.hs
@@ -5,6 +5,7 @@ module USForm8863_2025
   )
 where
 
+import FormRefs
 import Tables2025
 import TenForty
 
@@ -18,7 +19,7 @@ usForm8863_2025 = form "us_form_8863" 2025 $ do
   l1 <- keyInput "L1" "aotc_total" "Total American opportunity credit from Part III"
 
   -- Line 2: MAGI from Form 1040 (used for phase-out calculation)
-  l2 <- interior "L2" "magi" $ importForm "us_1040" "L11"
+  l2 <- interior "L2" "magi" $ importForm us1040L11
 
   -- Line 3: Phase-out threshold
   l3 <-
@@ -61,7 +62,7 @@ usForm8863_2025 = form "us_form_8863" 2025 $ do
   l11 <- keyInput "L11" "llc_total" "Total lifetime learning credit from Part III"
 
   -- Line 12: MAGI for LLC phase-out
-  l12 <- interior "L12" "magi_llc" $ importForm "us_1040" "L11"
+  l12 <- interior "L12" "magi_llc" $ importForm us1040L11
 
   -- Line 13: LLC phase-out threshold
   l13 <-

--- a/tenforty-spec/forms/USForm8959_2024.hs
+++ b/tenforty-spec/forms/USForm8959_2024.hs
@@ -5,6 +5,7 @@ module USForm8959_2024
   )
 where
 
+import FormRefs
 import Tables2024
 import TenForty
 
@@ -32,7 +33,7 @@ usForm8959_2024 = form "us_form_8959" 2024 $ do
       l6 .*. lit 0.009
 
   -- Part II: Additional Medicare Tax on Self-Employment Income
-  l8 <- interior "L8" "se_income" $ importForm "us_schedule_se" "L4a"
+  l8 <- interior "L8" "se_income" $ importForm usScheduleSeL4a
 
   l9 <-
     interior "L9" "threshold_se" $

--- a/tenforty-spec/forms/USForm8959_2025.hs
+++ b/tenforty-spec/forms/USForm8959_2025.hs
@@ -5,6 +5,7 @@ module USForm8959_2025
   )
 where
 
+import FormRefs
 import Tables2025
 import TenForty
 
@@ -32,7 +33,7 @@ usForm8959_2025 = form "us_form_8959" 2025 $ do
       l6 .*. lit 0.009
 
   -- Part II: Additional Medicare Tax on Self-Employment Income
-  l8 <- interior "L8" "se_income" $ importForm "us_schedule_se" "L4a"
+  l8 <- interior "L8" "se_income" $ importForm usScheduleSeL4a
 
   l9 <-
     interior "L9" "threshold_se" $

--- a/tenforty-spec/forms/USForm8960_2024.hs
+++ b/tenforty-spec/forms/USForm8960_2024.hs
@@ -5,6 +5,7 @@ module USForm8960_2024
   )
 where
 
+import FormRefs
 import Tables2024
 import TenForty
 
@@ -20,7 +21,7 @@ usForm8960_2024 = form "us_form_8960" 2024 $ do
   l4b <- keyInput "L4b" "adjustment_active_business" "Adjustment for net income/loss from active trade/business"
   l4c <- interior "L4c" "net_rental_royalty" $ l4a .+. l4b
 
-  l5a <- interior "L5a" "net_gain_disposition" $ importForm "us_schedule_d" "L21"
+  l5a <- interior "L5a" "net_gain_disposition" $ importForm usScheduleDL21
   l5b <- keyInput "L5b" "adjustment_disposition" "Adjustments from disposition of partnership/S corp interest"
   l5c <- interior "L5c" "net_gain_adjusted" $ l5a .+. l5b
   l5d <- keyInput "L5d" "net_gain_estate_trust" "Net gain or loss from estate or trust"
@@ -48,7 +49,7 @@ usForm8960_2024 = form "us_form_8960" 2024 $ do
       l8 `subtractNotBelowZero` l11
 
   -- Modified AGI - for most taxpayers this equals AGI
-  l13 <- interior "L13" "modified_agi" $ importForm "us_1040" "L11"
+  l13 <- interior "L13" "modified_agi" $ importForm us1040L11
 
   l14 <-
     interior "L14" "niit_threshold" $

--- a/tenforty-spec/forms/USForm8960_2025.hs
+++ b/tenforty-spec/forms/USForm8960_2025.hs
@@ -5,6 +5,7 @@ module USForm8960_2025
   )
 where
 
+import FormRefs
 import Tables2025
 import TenForty
 
@@ -20,7 +21,7 @@ usForm8960_2025 = form "us_form_8960" 2025 $ do
   l4b <- keyInput "L4b" "adjustment_active_business" "Adjustment for net income/loss from active trade/business"
   l4c <- interior "L4c" "net_rental_royalty" $ l4a .+. l4b
 
-  l5a <- interior "L5a" "net_gain_disposition" $ importForm "us_schedule_d" "L21"
+  l5a <- interior "L5a" "net_gain_disposition" $ importForm usScheduleDL21
   l5b <- keyInput "L5b" "adjustment_disposition" "Adjustments from disposition of partnership/S corp interest"
   l5c <- interior "L5c" "net_gain_adjusted" $ l5a .+. l5b
   l5d <- keyInput "L5d" "net_gain_estate_trust" "Net gain or loss from estate or trust"
@@ -48,7 +49,7 @@ usForm8960_2025 = form "us_form_8960" 2025 $ do
       l8 `subtractNotBelowZero` l11
 
   -- Modified AGI - for most taxpayers this equals AGI
-  l13 <- interior "L13" "modified_agi" $ importForm "us_1040" "L11"
+  l13 <- interior "L13" "modified_agi" $ importForm us1040L11
 
   l14 <-
     interior "L14" "niit_threshold" $

--- a/tenforty-spec/forms/USForm8995_2024.hs
+++ b/tenforty-spec/forms/USForm8995_2024.hs
@@ -5,6 +5,7 @@ module USForm8995_2024
   )
 where
 
+import FormRefs
 import Tables2024
 import TenForty
 
@@ -30,7 +31,7 @@ usForm8995_2024 = form "us_form_8995" 2024 $ do
   -- the deductible part of SE tax — and net it out before the 20%.
   seHalfDeduction <-
     interior "se_half_deduction" "Deductible half of SE tax reducing QBI" $
-      importForm "us_schedule_se" "L11"
+      importForm usScheduleSeL11
 
   -- Line 5: Total qualified business income (net of the half-SE deduction)
   l5 <-
@@ -64,7 +65,7 @@ usForm8995_2024 = form "us_form_8995" 2024 $ do
       l6 .+. l10
 
   -- Line 12: Taxable income before QBI deduction
-  l12 <- interior "L12" "taxable_income_before" $ importForm "us_1040" "L15_pre_qbi"
+  l12 <- interior "L12" "taxable_income_before" $ importForm us1040L15PreQbi
 
   -- Line 13: Net capital gain (from Form 1040, lines 3a and 7, if applicable)
   l13 <- keyInput "L13" "net_capital_gain" "Net capital gain (qualified dividends + capital gain)"

--- a/tenforty-spec/forms/USForm8995_2025.hs
+++ b/tenforty-spec/forms/USForm8995_2025.hs
@@ -5,6 +5,7 @@ module USForm8995_2025
   )
 where
 
+import FormRefs
 import Tables2025
 import TenForty
 
@@ -30,7 +31,7 @@ usForm8995_2025 = form "us_form_8995" 2025 $ do
   -- the deductible part of SE tax — and net it out before the 20%.
   seHalfDeduction <-
     interior "se_half_deduction" "Deductible half of SE tax reducing QBI" $
-      importForm "us_schedule_se" "L11"
+      importForm usScheduleSeL11
 
   -- Line 5: Total qualified business income (net of the half-SE deduction)
   l5 <-
@@ -64,7 +65,7 @@ usForm8995_2025 = form "us_form_8995" 2025 $ do
       l6 .+. l10
 
   -- Line 12: Taxable income before QBI deduction
-  l12 <- interior "L12" "taxable_income_before" $ importForm "us_1040" "L15_pre_qbi"
+  l12 <- interior "L12" "taxable_income_before" $ importForm us1040L15PreQbi
 
   -- Line 13: Net capital gain (from Form 1040, lines 3a and 7, if applicable)
   l13 <- keyInput "L13" "net_capital_gain" "Net capital gain (qualified dividends + capital gain)"

--- a/tenforty-spec/forms/USSchedule1_2024.hs
+++ b/tenforty-spec/forms/USSchedule1_2024.hs
@@ -5,6 +5,7 @@ module USSchedule1_2024
   )
 where
 
+import FormRefs
 import TenForty
 
 usSchedule1_2024 :: Either FormError Form
@@ -73,7 +74,7 @@ usSchedule1_2024 = form "us_schedule_1" 2024 $ do
   l12 <- keyInput "L12" "business_expenses_reservists" "Certain business expenses of reservists"
   l13 <- keyInput "L13" "hsa_deduction" "Health savings account deduction"
   l14 <- keyInput "L14" "moving_expenses_military" "Moving expenses for armed forces"
-  l15 <- interior "L15" "self_employment_tax_deduction" $ importForm "us_schedule_se" "L11"
+  l15 <- interior "L15" "self_employment_tax_deduction" $ importForm usScheduleSeL11
   l16 <- keyInput "L16" "sep_simple_deduction" "Self-employed SEP, SIMPLE, and qualified plans"
   l17 <- keyInput "L17" "self_employed_health" "Self-employed health insurance deduction"
   l18 <- keyInput "L18" "early_withdrawal_penalty" "Penalty on early withdrawal of savings"

--- a/tenforty-spec/forms/USSchedule1_2025.hs
+++ b/tenforty-spec/forms/USSchedule1_2025.hs
@@ -5,6 +5,7 @@ module USSchedule1_2025
   )
 where
 
+import FormRefs
 import TenForty
 
 usSchedule1_2025 :: Either FormError Form
@@ -73,7 +74,7 @@ usSchedule1_2025 = form "us_schedule_1" 2025 $ do
   l12 <- keyInput "L12" "business_expenses_reservists" "Certain business expenses of reservists"
   l13 <- keyInput "L13" "hsa_deduction" "Health savings account deduction"
   l14 <- keyInput "L14" "moving_expenses_military" "Moving expenses for armed forces"
-  l15 <- interior "L15" "self_employment_tax_deduction" $ importForm "us_schedule_se" "L11"
+  l15 <- interior "L15" "self_employment_tax_deduction" $ importForm usScheduleSeL11
   l16 <- keyInput "L16" "sep_simple_deduction" "Self-employed SEP, SIMPLE, and qualified plans"
   l17 <- keyInput "L17" "self_employed_health" "Self-employed health insurance deduction"
   l18 <- keyInput "L18" "early_withdrawal_penalty" "Penalty on early withdrawal of savings"

--- a/tenforty-spec/forms/USSchedule2_2024.hs
+++ b/tenforty-spec/forms/USSchedule2_2024.hs
@@ -5,12 +5,13 @@ module USSchedule2_2024
   )
 where
 
+import FormRefs
 import TenForty
 
 usSchedule2_2024 :: Either FormError Form
 usSchedule2_2024 = form "us_schedule_2" 2024 $ do
   -- Part I: Tax
-  l1 <- interior "L1" "amt" $ importForm "us_form_6251" "L11"
+  l1 <- interior "L1" "amt" $ importForm usForm6251L11
   l2 <- keyInput "L2" "excess_aptc" "Excess advance premium tax credit repayment from Form 8962"
 
   _l3 <-
@@ -18,15 +19,15 @@ usSchedule2_2024 = form "us_schedule_2" 2024 $ do
       l1 .+. l2
 
   -- Part II: Other Taxes
-  l4 <- interior "L4" "self_employment_tax" $ importForm "us_schedule_se" "L10"
+  l4 <- interior "L4" "self_employment_tax" $ importForm usScheduleSeL10
   l5 <- keyInput "L5" "unreported_ss_medicare" "Social security and Medicare on unreported tip income from Form 4137"
   l6 <- keyInput "L6" "additional_tax_ira" "Additional tax on IRAs or other tax-favored accounts from Form 5329"
 
   l7a <- keyInput "L7a" "household_employment" "Household employment taxes from Schedule H"
   l7b <- keyInput "L7b" "first_time_homebuyer" "First-time homebuyer credit repayment from Form 5405"
 
-  l8_8959 <- interior "L8_8959" "additional_medicare" $ importForm "us_form_8959" "L18"
-  l8_8960 <- interior "L8_8960" "niit" $ importForm "us_form_8960" "L17"
+  l8_8959 <- interior "L8_8959" "additional_medicare" $ importForm usForm8959L18
+  l8_8960 <- interior "L8_8960" "niit" $ importForm usForm8960L17
   l8 <- interior "L8" "additional_medicare_niit" $ l8_8959 .+. l8_8960
 
   l9 <- keyInput "L9" "section_965" "Section 965 net tax liability installment from Form 965-A"

--- a/tenforty-spec/forms/USSchedule2_2025.hs
+++ b/tenforty-spec/forms/USSchedule2_2025.hs
@@ -5,12 +5,13 @@ module USSchedule2_2025
   )
 where
 
+import FormRefs
 import TenForty
 
 usSchedule2_2025 :: Either FormError Form
 usSchedule2_2025 = form "us_schedule_2" 2025 $ do
   -- Part I: Tax
-  l1 <- interior "L1" "amt" $ importForm "us_form_6251" "L11"
+  l1 <- interior "L1" "amt" $ importForm usForm6251L11
   l2 <- keyInput "L2" "excess_aptc" "Excess advance premium tax credit repayment from Form 8962"
 
   _l3 <-
@@ -18,15 +19,15 @@ usSchedule2_2025 = form "us_schedule_2" 2025 $ do
       l1 .+. l2
 
   -- Part II: Other Taxes
-  l4 <- interior "L4" "self_employment_tax" $ importForm "us_schedule_se" "L10"
+  l4 <- interior "L4" "self_employment_tax" $ importForm usScheduleSeL10
   l5 <- keyInput "L5" "unreported_ss_medicare" "Social security and Medicare on unreported tip income from Form 4137"
   l6 <- keyInput "L6" "additional_tax_ira" "Additional tax on IRAs or other tax-favored accounts from Form 5329"
 
   l7a <- keyInput "L7a" "household_employment" "Household employment taxes from Schedule H"
   l7b <- keyInput "L7b" "first_time_homebuyer" "First-time homebuyer credit repayment from Form 5405"
 
-  l8_8959 <- interior "L8_8959" "additional_medicare" $ importForm "us_form_8959" "L18"
-  l8_8960 <- interior "L8_8960" "niit" $ importForm "us_form_8960" "L17"
+  l8_8959 <- interior "L8_8959" "additional_medicare" $ importForm usForm8959L18
+  l8_8960 <- interior "L8_8960" "niit" $ importForm usForm8960L17
   l8 <- interior "L8" "additional_medicare_niit" $ l8_8959 .+. l8_8960
 
   l9 <- keyInput "L9" "section_965" "Section 965 net tax liability installment from Form 965-A"

--- a/tenforty-spec/forms/USSchedule3_2024.hs
+++ b/tenforty-spec/forms/USSchedule3_2024.hs
@@ -5,14 +5,15 @@ module USSchedule3_2024
   )
 where
 
+import FormRefs
 import TenForty
 
 usSchedule3_2024 :: Either FormError Form
 usSchedule3_2024 = form "us_schedule_3" 2024 $ do
   -- Part I: Nonrefundable Credits
   l1 <- keyInput "L1" "foreign_tax_credit" "Foreign tax credit from Form 1116"
-  l2 <- interior "L2" "child_dependent_care" $ importForm "us_form_2441" "L11"
-  l3 <- interior "L3" "education_credits" $ importForm "us_form_8863" "L19"
+  l2 <- interior "L2" "child_dependent_care" $ importForm usForm2441L11
+  l3 <- interior "L3" "education_credits" $ importForm usForm8863L19
   l4 <- keyInput "L4" "retirement_savings" "Retirement savings contributions credit from Form 8880"
   l5 <- keyInput "L5" "residential_energy" "Residential energy credits from Form 5695"
 

--- a/tenforty-spec/forms/USSchedule3_2025.hs
+++ b/tenforty-spec/forms/USSchedule3_2025.hs
@@ -5,14 +5,15 @@ module USSchedule3_2025
   )
 where
 
+import FormRefs
 import TenForty
 
 usSchedule3_2025 :: Either FormError Form
 usSchedule3_2025 = form "us_schedule_3" 2025 $ do
   -- Part I: Nonrefundable Credits
   l1 <- keyInput "L1" "foreign_tax_credit" "Foreign tax credit from Form 1116"
-  l2 <- interior "L2" "child_dependent_care" $ importForm "us_form_2441" "L11"
-  l3 <- interior "L3" "education_credits" $ importForm "us_form_8863" "L19"
+  l2 <- interior "L2" "child_dependent_care" $ importForm usForm2441L11
+  l3 <- interior "L3" "education_credits" $ importForm usForm8863L19
   l4 <- keyInput "L4" "retirement_savings" "Retirement savings contributions credit from Form 8880"
   l5 <- keyInput "L5" "residential_energy" "Residential energy credits from Form 5695"
 

--- a/tenforty-spec/forms/USScheduleA_2024.hs
+++ b/tenforty-spec/forms/USScheduleA_2024.hs
@@ -5,13 +5,14 @@ module USScheduleA_2024
   )
 where
 
+import FormRefs
 import TenForty
 
 usScheduleA_2024 :: Either FormError Form
 usScheduleA_2024 = form "us_schedule_a" 2024 $ do
   -- Medical and Dental Expenses
   l1 <- keyInput "L1" "medical_dental" "Medical and dental expenses"
-  l2 <- interior "L2" "agi_amount" $ importForm "us_1040" "L11"
+  l2 <- interior "L2" "agi_amount" $ importForm us1040L11
   l3 <- interior "L3" "medical_threshold" $ l2 .*. lit 0.075
   _l4 <-
     keyOutput "L4" "medical_deduction" "Subtract L3 from L1 (not below 0)" $

--- a/tenforty-spec/forms/USScheduleA_2025.hs
+++ b/tenforty-spec/forms/USScheduleA_2025.hs
@@ -5,13 +5,14 @@ module USScheduleA_2025
   )
 where
 
+import FormRefs
 import TenForty
 
 usScheduleA_2025 :: Either FormError Form
 usScheduleA_2025 = form "us_schedule_a" 2025 $ do
   -- Medical and Dental Expenses
   l1 <- keyInput "L1" "medical_dental" "Medical and dental expenses"
-  l2 <- interior "L2" "agi_amount" $ importForm "us_1040" "L11"
+  l2 <- interior "L2" "agi_amount" $ importForm us1040L11
   l3 <- interior "L3" "medical_threshold" $ l2 .*. lit 0.075
   _l4 <-
     keyOutput "L4" "medical_deduction" "Subtract L3 from L1 (not below 0)" $

--- a/tenforty-spec/forms/USScheduleEIC_2024.hs
+++ b/tenforty-spec/forms/USScheduleEIC_2024.hs
@@ -5,6 +5,7 @@ module USScheduleEIC_2024
   )
 where
 
+import FormRefs
 import Tables2024
 import TenForty
 
@@ -20,7 +21,7 @@ usScheduleEIC_2024 = form "us_schedule_eic" 2024 $ do
   investmentIncome <- keyInput "INVESTMENT_INCOME" "investment_income" "Investment income"
 
   -- Get AGI for phase-out calculation
-  agi <- interior "AGI" "agi" $ importForm "us_1040" "L11"
+  agi <- interior "AGI" "agi" $ importForm us1040L11
 
   -- Phase-out thresholds by status (varies by 0 vs 1+ qualifying children)
   phaseOutThreshold0QC <-

--- a/tenforty-spec/forms/USScheduleEIC_2025.hs
+++ b/tenforty-spec/forms/USScheduleEIC_2025.hs
@@ -5,6 +5,7 @@ module USScheduleEIC_2025
   )
 where
 
+import FormRefs
 import Tables2025
 import TenForty
 
@@ -20,7 +21,7 @@ usScheduleEIC_2025 = form "us_schedule_eic" 2025 $ do
   investmentIncome <- keyInput "INVESTMENT_INCOME" "investment_income" "Investment income"
 
   -- Get AGI for phase-out calculation
-  agi <- interior "AGI" "agi" $ importForm "us_1040" "L11"
+  agi <- interior "AGI" "agi" $ importForm us1040L11
 
   -- Phase-out thresholds by status (varies by 0 vs 1+ qualifying children)
   phaseOutThreshold0QC <-

--- a/tenforty-spec/forms/UTTC40_2024.hs
+++ b/tenforty-spec/forms/UTTC40_2024.hs
@@ -5,13 +5,14 @@ module UTTC40_2024
   )
 where
 
+import FormRefs
 import TablesUT2024
 import TenForty
 
 utTC40_2024 :: Either FormError Form
 utTC40_2024 = form "ut_tc40" 2024 $ do
   -- Line 4: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l4 <-
     keyOutput "L4" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0
@@ -46,7 +47,7 @@ utTC40_2024 = form "ut_tc40" 2024 $ do
   -- Line 12: Federal standard or itemized deductions (imported from US 1040)
   l12 <-
     interior "L12" "federal_deductions" $
-      importForm "us_1040" "L12Final"
+      importForm us1040L12final
 
   -- Line 13: Total exemptions and deductions
   l13 <-

--- a/tenforty-spec/forms/UTTC40_2025.hs
+++ b/tenforty-spec/forms/UTTC40_2025.hs
@@ -5,13 +5,14 @@ module UTTC40_2025
   )
 where
 
+import FormRefs
 import TablesUT2025
 import TenForty
 
 utTC40_2025 :: Either FormError Form
 utTC40_2025 = form "ut_tc40" 2025 $ do
   -- Line 4: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l4 <-
     keyOutput "L4" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0
@@ -46,7 +47,7 @@ utTC40_2025 = form "ut_tc40" 2025 $ do
   -- Line 12: Federal standard or itemized deductions (imported from US 1040)
   l12 <-
     interior "L12" "federal_deductions" $
-      importForm "us_1040" "L12Final"
+      importForm us1040L12final
 
   -- Line 13: Total exemptions and deductions
   l13 <-

--- a/tenforty-spec/forms/VAForm760_2024.hs
+++ b/tenforty-spec/forms/VAForm760_2024.hs
@@ -5,6 +5,7 @@ module VAForm760_2024
   )
 where
 
+import FormRefs
 import TablesVA2024
 import TenForty
 
@@ -13,7 +14,7 @@ vaForm760_2024 = form "va_760" 2024 $ do
   defineTable virginiaBracketsTable2024
 
   -- Line 1: Federal AGI (imported from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <-
     keyOutput "L1" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/VAForm760_2025.hs
+++ b/tenforty-spec/forms/VAForm760_2025.hs
@@ -5,6 +5,7 @@ module VAForm760_2025
   )
 where
 
+import FormRefs
 import TablesVA2025
 import TenForty
 
@@ -13,7 +14,7 @@ vaForm760_2025 = form "va_760" 2025 $ do
   defineTable virginiaBracketsTable2025
 
   -- Line 1: Federal AGI (imported from US 1040 Line 11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <-
     keyOutput "L1" "federal_agi" "Federal adjusted gross income" $
       federalAgi .+. dollars 0

--- a/tenforty-spec/forms/VTIN111_2024.hs
+++ b/tenforty-spec/forms/VTIN111_2024.hs
@@ -5,6 +5,7 @@ module VTIN111_2024
   )
 where
 
+import FormRefs
 import TablesVT2024
 import TenForty
 
@@ -13,7 +14,7 @@ vtIN111_2024 = form "vt_in111" 2024 $ do
   defineTable vtBracketsTable2024
 
   -- Line 1: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 2: Net additions to Federal AGI from Vermont Schedule IN-113

--- a/tenforty-spec/forms/VTIN111_2025.hs
+++ b/tenforty-spec/forms/VTIN111_2025.hs
@@ -5,6 +5,7 @@ module VTIN111_2025
   )
 where
 
+import FormRefs
 import TablesVT2025
 import TenForty
 
@@ -13,7 +14,7 @@ vtIN111_2025 = form "vt_in111" 2025 $ do
   defineTable vtBracketsTable2025
 
   -- Line 1: Federal AGI (imported from US 1040)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 2: Net additions to Federal AGI from Vermont Schedule IN-113

--- a/tenforty-spec/forms/WIForm1_2024.hs
+++ b/tenforty-spec/forms/WIForm1_2024.hs
@@ -5,6 +5,7 @@ module WIForm1_2024
   )
 where
 
+import FormRefs
 import TablesWI2024
 import TenForty
 
@@ -13,7 +14,7 @@ wiForm1_2024 = form "wi_form1" 2024 $ do
   defineTable wisconsinBracketsTable2024
 
   -- Line 1: Federal adjusted gross income (from US 1040 L11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Lines 2-8: Wisconsin additions to federal AGI (from Schedule I)

--- a/tenforty-spec/forms/WIForm1_2025.hs
+++ b/tenforty-spec/forms/WIForm1_2025.hs
@@ -5,6 +5,7 @@ module WIForm1_2025
   )
 where
 
+import FormRefs
 import TablesWI2025
 import TenForty
 
@@ -13,7 +14,7 @@ wiForm1_2025 = form "wi_form1" 2025 $ do
   defineTable wisconsinBracketsTable2025
 
   -- Line 1: Federal adjusted gross income (from US 1040 L11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Lines 2-8: Wisconsin additions to federal AGI (from Schedule I)

--- a/tenforty-spec/forms/WVIT140_2024.hs
+++ b/tenforty-spec/forms/WVIT140_2024.hs
@@ -5,6 +5,7 @@ module WVIT140_2024
   )
 where
 
+import FormRefs
 import TablesWV2024
 import TenForty
 
@@ -13,7 +14,7 @@ wvIT140_2024 = form "wv_it140" 2024 $ do
   defineTable westVirginiaBracketsTable2024
 
   -- Line 1: Federal Adjusted Gross Income (imported from US 1040 L11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 2: Additions to federal AGI (from Schedule M)

--- a/tenforty-spec/forms/WVIT140_2025.hs
+++ b/tenforty-spec/forms/WVIT140_2025.hs
@@ -5,6 +5,7 @@ module WVIT140_2025
   )
 where
 
+import FormRefs
 import TablesWV2025
 import TenForty
 
@@ -13,7 +14,7 @@ wvIT140_2025 = form "wv_it140" 2025 $ do
   defineTable westVirginiaBracketsTable2025
 
   -- Line 1: Federal Adjusted Gross Income (imported from US 1040 L11)
-  let federalAgi = importForm "us_1040" "L11"
+  let federalAgi = importForm us1040L11
   l1 <- keyOutput "L1" "federal_agi" "Federal adjusted gross income" federalAgi
 
   -- Line 2: Additions to federal AGI (from Schedule M)

--- a/tenforty-spec/src/TenForty/Compile/JSON.hs
+++ b/tenforty-spec/src/TenForty/Compile/JSON.hs
@@ -352,7 +352,10 @@ unresolvedImports cgs =
     Map.notMember (tf, tl) resKeys
   ]
   where
-    -- (formId, key) present, key = full name and lid base (matches resolveForms)
+    -- (formId, key) present, key = full name and lid base (matches resolveForms).
+    -- Only OUTPUT nodes register keys: a cross-form import may target a declared
+    -- output and nothing else (tenforty-9yh.2). An import of an interior line is
+    -- therefore "unresolved" and fails the build.
     resKeys :: Map (Text, Text) ()
     resKeys =
       Map.fromList $
@@ -361,7 +364,8 @@ unresolvedImports cgs =
               Nothing -> []
               Just nm -> [((gmFormId (cgMeta cg), nm), ()), ((gmFormId (cgMeta cg), T.takeWhile (/= '_') nm), ())]
           | cg <- cgs,
-            n <- Map.elems (cgNodes cg)
+            oid <- cgOutputs cg,
+            Just n <- [Map.lookup oid (cgNodes cg)]
           ]
 
 -- | Resolve a set of per-form compiled graphs into ONE graph (tenforty-ovz,
@@ -402,8 +406,11 @@ resolveForms cgs@(cg0 : _) =
     outputNodes =
       [(formOf cg, n) | cg <- cgs, oid <- cgOutputs cg, Just n <- [Map.lookup oid (cgNodes cg)]]
 
+    -- Only OUTPUT nodes are resolution targets: a cross-form import may bind to
+    -- a declared output and nothing else (tenforty-9yh.2). Interior lines are
+    -- unreachable across forms, so an import can never silently land on one.
     resMap :: Map (Text, Text) Int
-    resMap = foldl' ins Map.empty (outputNodes ++ flat)
+    resMap = foldl' ins Map.empty outputNodes
       where
         ins m (f, n) = case nodeName n of
           Nothing -> m

--- a/tenforty-spec/src/TenForty/DSL.hs
+++ b/tenforty-spec/src/TenForty/DSL.hs
@@ -51,6 +51,7 @@ module TenForty.DSL
     line,
     importLine,
     importForm,
+    lineRef,
 
     -- * Tax Operations
     bracketTax,
@@ -131,8 +132,20 @@ interior lid name = F.compute lid name "" Interior
 max0 :: Expr Dollars -> Expr Dollars
 max0 = maxE (dollars 0)
 
-importForm :: FormId -> LineId -> Expr Dollars
-importForm = Import
+-- | Mint a typed cross-form output handle. Handles live in a dependency-free
+-- module (see @FormRefs@) so importers never depend on the exporter's form
+-- module — the form graph stays acyclic even where two forms reference each
+-- other's lines. The unit is fixed at the handle's declaration site.
+lineRef :: FormId -> LineId -> LineRef u
+lineRef = LineRef
+
+-- | Import another form's output through its typed handle. A mistyped or
+-- since-renamed reference is a compile-time \"not in scope\" error, and a unit
+-- mismatch is a type error — neither can slip through to the resolver. This is
+-- the only way a form definition refers across form boundaries; the raw
+-- string-keyed 'importLine' is reserved for the resolver's own tests.
+importForm :: LineRef u -> Expr u
+importForm (LineRef fid lid) = Import fid lid
 
 bracketTax :: TableId -> Expr Dollars -> Expr Dollars
 bracketTax = BracketTax

--- a/tenforty-spec/src/TenForty/Expr.hs
+++ b/tenforty-spec/src/TenForty/Expr.hs
@@ -45,7 +45,7 @@ type Expr :: Type -> Type
 data Expr u where
   Lit :: Amount u -> Expr u
   Line :: LineId -> Expr Dollars
-  Import :: FormId -> LineId -> Expr Dollars
+  Import :: FormId -> LineId -> Expr u
   Add :: Expr u -> Expr u -> Expr u
   Sub :: Expr u -> Expr u -> Expr u
   Mul :: Expr Dollars -> Expr Rate -> Expr Dollars

--- a/tenforty-spec/src/TenForty/Form.hs
+++ b/tenforty-spec/src/TenForty/Form.hs
@@ -318,7 +318,11 @@ validateFormSet forms =
 validateFormSetYear :: Int -> [Form] -> [FormSetError]
 validateFormSetYear year forms =
   let formMap = Map.fromList [(formId f, f) | f <- forms]
-      availableExports = Map.map (Map.keysSet . formLineMap) formMap
+      -- A form may import only another form's declared OUTPUTS, never its
+      -- interior lines (tenforty-9yh.2). This is what makes a typed handle a
+      -- promise about the exporter's public surface rather than a peek at any
+      -- line that happens to exist.
+      availableExports = Map.map formOutputIds formMap
    in concatMap (checkFormImports year availableExports) forms
 
 checkFormImports :: Int -> Map FormId (Set LineId) -> Form -> [FormSetError]

--- a/tenforty-spec/src/TenForty/Types.hs
+++ b/tenforty-spec/src/TenForty/Types.hs
@@ -23,6 +23,9 @@ module TenForty.Types
     FormId (..),
     TableId (..),
     NodeId (..),
+
+    -- * Typed Cross-Form Output References
+    LineRef (..),
   )
 where
 
@@ -119,3 +122,15 @@ instance IsString TableId where
 newtype NodeId = NodeId {unNodeId :: Int}
   deriving stock (Show, Read)
   deriving newtype (Eq, Ord, Num, Enum)
+
+-- | A typed, cross-form reference to a form's output line: it carries the
+-- target form, the target line, and the line's unit as a phantom.
+--
+-- A 'LineRef' is minted only by 'TenForty.Form.export', from the very 'Expr'
+-- the line's own @keyOutput@/@compute@ returned — so the handle cannot name a
+-- line that does not exist, and its unit is the line's unit. Importers
+-- reference the handle instead of a @(form, line)@ string pair, which turns a
+-- mistyped or since-renamed reference into a compile-time \"not in scope\"
+-- error and a unit mismatch into a type error.
+data LineRef (u :: Type) = LineRef FormId LineId
+  deriving stock (Show)

--- a/tenforty-spec/src/TenForty/Types.hs
+++ b/tenforty-spec/src/TenForty/Types.hs
@@ -126,11 +126,16 @@ newtype NodeId = NodeId {unNodeId :: Int}
 -- | A typed, cross-form reference to a form's output line: it carries the
 -- target form, the target line, and the line's unit as a phantom.
 --
--- A 'LineRef' is minted only by 'TenForty.Form.export', from the very 'Expr'
--- the line's own @keyOutput@/@compute@ returned — so the handle cannot name a
--- line that does not exist, and its unit is the line's unit. Importers
--- reference the handle instead of a @(form, line)@ string pair, which turns a
--- mistyped or since-renamed reference into a compile-time \"not in scope\"
--- error and a unit mismatch into a type error.
+-- Handles are minted by 'TenForty.DSL.lineRef' from a @(form, line)@ pair, with
+-- the unit fixed at the declaration site, and all live in one dependency-free
+-- module (@FormRefs@). This consolidates every cross-form reference to a single
+-- named handle: importers write @importForm us1040L11@ rather than the string
+-- pair, so a mistyped or since-renamed reference is a compile-time \"not in
+-- scope\" error at the reference site, and a unit mismatch is a type error.
+--
+-- The @(form, line)@ strings still live inside each handle, so a handle whose
+-- strings name no real line — or name a line that is not a declared output — is
+-- not a type error; it is caught at graph-resolution time by
+-- 'TenForty.Compile.JSON.unresolvedImports', which fails the build.
 data LineRef (u :: Type) = LineRef FormId LineId
   deriving stock (Show)

--- a/tenforty-spec/tenforty-spec.cabal
+++ b/tenforty-spec/tenforty-spec.cabal
@@ -85,6 +85,7 @@ executable tenforty-compile
     DEFormPITRES_2025
     FLNoTax_2024
     FLNoTax_2025
+    FormRefs
     GAForm500_2024
     GAForm500_2025
     HIHIN11_2024
@@ -370,6 +371,7 @@ test-suite tenforty-spec-test
     ExprProperties
     FLNoTax_2024
     FLNoTax_2025
+    FormRefs
     GAForm500_2024
     GAForm500_2025
     HIHIN11_2024

--- a/tenforty-spec/test/Spec.hs
+++ b/tenforty-spec/test/Spec.hs
@@ -233,7 +233,7 @@ spec n = do
           case form
             (fid "source")
             2024
-            (void (compute (lid "L2") "Source Line" "" Interior (importForm (fid "target") (lid "L9")))) of
+            (void (compute (lid "L2") "Source Line" "" Interior (importLine (fid "target") (lid "L9")))) of
             Left err -> expectationFailure $ show err
             Right sourceForm -> do
               let errors = validateFormSet [sourceForm, targetForm]


### PR DESCRIPTION
## The problem

Cross-form references in the Haskell spec were **stringly-typed**: `importForm "us_1040" "L11"`. A typo, a since-renamed line, or an import of a line that isn't an output all sailed past GHC and surfaced only later, in the resolver (or, pre-#314, at runtime). The `Expr` GADT is otherwise carefully typed — this was a stringly-typed hole punched through every form boundary.

This PR closes that hole (bead **tenforty-9yh**, ideas .1 and .2).

## The fix

**.1 — typed handles.** `importForm :: LineRef u -> Expr u`. Forms reference a typed handle instead of two strings, so a mistyped reference is a compile-time `not in scope` error *at the reference site*, and the `L15`/`L15_pre_qbi` base-name ambiguity can't arise — a handle names an exact line.

**Option A (dependency-free handles module).** The 37 handles live in `FormRefs`, which imports **no form module**. That matters: the federal forms are mutually referential at the module level (`us_1040` imports `us_form_8995`'s QBI line; `us_form_8995` imports `us_1040`'s `L15_pre_qbi`), so "importer imports the exporter's module" would create GHC module cycles requiring `.hs-boot` files. Routing through a leaf handles module keeps the form-module graph acyclic with no boot files and no hub special-case.

**.2 — outputs-only.** Cross-form imports now resolve and validate against a form's **declared outputs**, not any line. Importing an interior scratch line fails the build. Every existing import already targets an output, so this is a pure tightening.

## Proof

- **All 142 generated graphs byte-identical** to `main` — this changes the *type discipline*, not a single computed number.
- A mistyped reference → GHC `Variable not in scope`, with a fix suggestion.
- An import of an interior line (`us_1040 L13`) → build fails with `UnresolvedImport` (previously resolved silently).
- Haskell suite **189/0**; Python **703 passed / 0 failed** with the CI hypothesis profile (500 examples), OTS regression + parity, and the **taxcalc differential** vs Tax-Calculator 6.7.2.
- `ormolu` + `hlint --strict` clean.

## Scope

- Core: `LineRef` type + `lineRef` ctor (Types), `Import` generalized to `Expr u` (Expr), typed `importForm` (DSL), outputs-only `validateFormSet` (Form) and `resolveForms`/`unresolvedImports` (Compile.JSON).
- `FormRefs.hs` (new) + **180 call sites across 114 forms** converted.
- Raw string constructor `importLine` retained solely for the resolver's own test.

## Dropped from the original plan

The third idea — filing-status coherence via a `perStatus` tag — is **dropped** as type-astronomy for this DSL: status-varying constants are *designed* to mix with scalar arithmetic (109 `byStatusE` sites), the evaluator always has the filing status, and the one real bug class (transposed `byStatus` args) is a wrong-number the taxcalc differential catches, not something a type can. Recorded in bead tenforty-9yh.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)