### PR TITLE
test(hypothesis): add ad-hoc 'deep' profile + document engine-change sweep policy (tenforty-g79)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,18 @@ These are complementary nets: the differential pins **numbers**, parity pins
 two are blind to. None runs in the per-PR gate; they are the author's
 responsibility on an engine change.
 
+For the deep sweep to reach a property, that property must **inherit** the
+profile's example count:
+
+- **Invariant / corner-hunting property tests** (monotonicity, continuity,
+  wiring, gradients — cheap, one or two evaluations per example) omit
+  `max_examples` and use `@settings(deadline=None)`, so they run 500 under `ci`
+  and 10,000 under `deep`.
+- **Oracle / expensive tests** (parity across both backends, the taxcalc
+  differential, the Newton solver) pin an explicit, bounded `max_examples` with a
+  one-line reason — 10k of a slow example is prohibitive and adds nothing to a
+  value/agreement oracle, so these deliberately do **not** scale.
+
 ## Python Style
 
 - Use modern type hints (PEP 604 unions with `|`, generics without `typing` module)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ freeze rather than rolling the whole tree back.
 - `pip install -e ".[dev]"` — Install in dev mode
 - `pytest` — Run tests (uses dev profile by default)
 - `pytest --hypothesis-profile=ci` — Run with CI profile (500 examples)
+- `pytest --hypothesis-profile=deep` — Deep property sweep (10,000 examples; ad hoc)
 - `python ots/amalgamate.py ots/ots-releases/*.tgz` — Regenerate OTS bindings
 - `make graph-build` — Build graph library (interpreter only)
 - `make spec-graphs` — Generate JSON graphs from Haskell specs
@@ -110,6 +111,29 @@ If the graph backend tests in `tests/backends_test.py` fail to load the compiled
 module (or `evaluate` raises on a fresh graph), the `.so` is out of sync — run
 `make env-full`.
 Never bypass pre-commit hooks with `--no-verify`; fix the underlying issue instead.
+
+### Sweeps expected for substantive engine changes
+
+The per-PR suite runs the `ci` hypothesis profile (500 examples) — enough to
+gate a change, not to hunt rare corners. For a **substantive change to a compute
+engine** (the Rust graph runtime, the OTS mapping/orchestration, or the Haskell
+spec/graph — not docs, tests, or tooling), run all three deeper sweeps and note
+the result in the PR:
+
+- **Deep hypothesis sweep** — `uv run pytest --hypothesis-profile=deep` (10,000
+  examples). Catches obscure-threshold conjunctions the 500-example gate clears
+  only intermittently. Targeted boundary-straddling strategies (tenforty-g79)
+  are the higher-leverage complement; reps are the safety net under them.
+- **OTS regression + cross-backend parity** — the `tests/parity/` suite, so the
+  OTS and graph backends still agree.
+- **taxcalc differential** — `TENFORTY_TAXCALC=1 uv run pytest tests/taxcalc/`
+  (install with `uv sync --group taxcalc`), the value oracle against
+  Tax-Calculator.
+
+These are complementary nets: the differential pins **numbers**, parity pins
+**backend agreement**, and the property sweep pins **shape/structure** the other
+two are blind to. None runs in the per-PR gate; they are the author's
+responsibility on an engine change.
 
 ## Python Style
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,4 +33,15 @@ settings.register_profile(
     max_examples=50,
     suppress_health_check=[HealthCheck.too_slow],
 )
+# Ad-hoc deep sweep: `uv run pytest --hypothesis-profile=deep`. Reaches rare
+# corners the 500-example ci profile clears only ~40% of the time (bugs with a
+# per-example hit rate in ~[1e-4, 2e-3] — obscure-threshold conjunctions). Only
+# tests that do NOT pin their own @settings(max_examples=...) inherit this; a
+# property meant for the deep sweep should leave max_examples to the profile.
+settings.register_profile(
+    "deep",
+    max_examples=10_000,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
 settings.load_profile("dev")  # Default for local dev


### PR DESCRIPTION
## What

A third hypothesis profile beside `dev` (50) and `ci` (500): **`deep` (10,000)**, run on demand — `uv run pytest --hypothesis-profile=deep`. No nightly job; ad hoc for now, per request.

Plus an AGENTS.md policy: for a **substantive change to a compute engine** (Rust runtime, OTS mapping, Haskell spec/graph), the deep sweep is expected **alongside** the OTS/parity regression and the taxcalc differential — three complementary nets:

- **deep hypothesis** → *shape/structure* (monotonicity, continuity, wiring, gradients)
- **parity** → *backend agreement* (OTS vs graph)
- **taxcalc differential** → *numbers* (value oracle)

None runs in the per-PR gate; they're the author's responsibility on an engine change.

## Why 10k, and the one caveat

Per-example, a bug is missed after `N` examples with probability `~e^(−pN)`, so the reliably-caught floor is `p ≳ 1/N`: `ci`=500 clears `p ≳ 0.2%`, `deep`=10k clears `p ≳ 0.01%`. The delta is the narrow band `p ∈ [1e-4, 2e-3]` — rare obscure-threshold conjunctions. hrp (found by kug) was `p ≈ 3%`, so 500 already nailed it; `deep` is for the residue below that.

**Caveat, documented in both the profile and AGENTS.md:** only tests that do **not** pin their own `@settings(max_examples=...)` inherit the profile. A property meant for the deep sweep must leave `max_examples` to the profile. The targeted boundary-straddling strategies planned in **tenforty-g79** are the intended consumers, where the extra reps actually earn their runtime — reps are the safety net *under* targeting and sharper properties, not a substitute (targeting a known threshold raises that bug's `p` from ~1e-4 to ~1e-1, beating brute-force reps by orders of magnitude).

## Note

The existing pinned property tests (dct, kug) won't deepen under this profile as-is — that's intentional for now (their pinned counts keep the normal suite fast/deterministic). Retrofitting them to inherit the profile is a possible follow-up; g79's new tests will inherit it from the start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)