### PR TITLE
fix(autodiff): follow derived naturals in the gradient (tenforty-hrp)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ freeze rather than rolling the whole tree back.
 - `pytest` — Run tests (uses dev profile by default)
 - `pytest --hypothesis-profile=ci` — Run with CI profile (500 examples)
 - `pytest --hypothesis-profile=deep` — Deep property sweep (10,000 examples; ad hoc)
+- `pytest --hypothesis-profile=soak` — Soak (100,000 examples; ad hoc, ~2 hours)
 - `python ots/amalgamate.py ots/ots-releases/*.tgz` — Regenerate OTS bindings
 - `make graph-build` — Build graph library (interpreter only)
 - `make spec-graphs` — Generate JSON graphs from Haskell specs
@@ -121,9 +122,10 @@ spec/graph — not docs, tests, or tooling), run all three deeper sweeps and not
 the result in the PR:
 
 - **Deep hypothesis sweep** — `uv run pytest --hypothesis-profile=deep` (10,000
-  examples). Catches obscure-threshold conjunctions the 500-example gate clears
-  only intermittently. Targeted boundary-straddling strategies (tenforty-g79)
-  are the higher-leverage complement; reps are the safety net under them.
+  examples, ~11 minutes). Catches obscure-threshold conjunctions the 500-example
+  gate clears only intermittently. Targeted boundary-straddling strategies
+  (tenforty-g79) are the higher-leverage complement; reps are the safety net
+  under them.
 - **OTS regression + cross-backend parity** — the `tests/parity/` suite, so the
   OTS and graph backends still agree.
 - **taxcalc differential** — `TENFORTY_TAXCALC=1 uv run pytest tests/taxcalc/`
@@ -135,13 +137,23 @@ These are complementary nets: the differential pins **numbers**, parity pins
 two are blind to. None runs in the per-PR gate; they are the author's
 responsibility on an engine change.
 
+Above those sits an ad-hoc fourth, expected of nothing: **`--hypothesis-profile=soak`**
+(100,000 examples, ~2 hours). Reach for it when a change is large enough that `deep`
+is not reassurance, because `deep` is a coin flip on the rarest defects rather than a
+net — the float-boundary drop in `derived_chain_factor` sat at a per-example hit rate
+near 2e-5, which `deep` clears about one run in five, and it was found by luck. But
+reps are the instrument of last resort. Once a corner is **characterized**, write a
+strategy that lands on it (`_BINADE_EDGE` in `tests/graph_autodiff_properties_test.py`)
+rather than buying it with reps: the defect `deep` took eleven minutes to hit falls out
+of the 500-example `ci` gate in fifteen seconds once the strategy aims there.
+
 For the deep sweep to reach a property, that property must **inherit** the
 profile's example count:
 
 - **Invariant / corner-hunting property tests** (monotonicity, continuity,
   wiring, gradients — cheap, one or two evaluations per example) omit
-  `max_examples` and use `@settings(deadline=None)`, so they run 500 under `ci`
-  and 10,000 under `deep`.
+  `max_examples` and use `@settings(deadline=None)`, so they run 500 under `ci`,
+  10,000 under `deep`, and 100,000 under `soak`.
 - **Oracle / expensive tests** (parity across both backends, the taxcalc
   differential, the Newton solver) pin an explicit, bounded `max_examples` with a
   one-line reason — 10k of a slow example is prohibitive and adds nothing to a

--- a/src/tenforty/backends/graph.py
+++ b/src/tenforty/backends/graph.py
@@ -8,6 +8,7 @@ import pathlib
 from functools import lru_cache
 
 from ..mappings import (
+    DERIVED_NATURAL_SOURCES,
     FILING_STATUS_MAP,
     LINE_TO_NATURAL,
     NATURAL_TO_NODE,
@@ -16,6 +17,7 @@ from ..mappings import (
     STATE_GRAPH_CONFIGS,
     STATE_NATURAL_TO_NODE,
     STATE_OUTPUT_LINES,
+    derived_chain_factor,
 )
 from ..models import STATE_TO_FORM, InterpretedTaxReturn, OTSState, TaxReturnInput
 
@@ -495,6 +497,15 @@ class GraphBackend:
         influence the requested output simply contributes a zero partial, so
         there is no need to guess which namespace the caller meant.
 
+        DERIVED naturals count as well. `schedule_se_ss_wages` is computed from
+        `w2_income`, so evaluation writes the filer's wages to Schedule SE line 5a
+        and the shared social security wage base couples W2 to SE tax — but the
+        node is filed under the derived natural's own key, so a gradient that
+        consulted only `NATURAL_TO_NODES[var]` dropped that coupling entirely
+        (tenforty-hrp). Only derivations with a unit slope contribute: an adjoint
+        sum is unweighted, so a factor other than 0 or 1 could not be represented
+        here and is left out rather than counted wrong.
+
         The result is deduplicated. Evaluation is idempotent to a repeated
         node — assigning it twice leaves the same value — but `gradient_sum`
         adds one adjoint per name, so a node named twice would have its
@@ -508,6 +519,13 @@ class GraphBackend:
         state_node = STATE_NATURAL_TO_NODE.get(tax_input.state, {}).get(var)
         if state_node:
             nodes.append(state_node)
+
+        for derived, source in DERIVED_NATURAL_SOURCES.items():
+            if (
+                source == var
+                and derived_chain_factor(tax_input, derived, source) == 1.0
+            ):
+                nodes.extend(NATURAL_TO_NODES.get(derived, []))
 
         if nodes:
             return list(dict.fromkeys(nodes))

--- a/src/tenforty/backends/graph.py
+++ b/src/tenforty/backends/graph.py
@@ -504,7 +504,13 @@ class GraphBackend:
         consulted only `NATURAL_TO_NODES[var]` dropped that coupling entirely
         (tenforty-hrp). Only derivations with a unit slope contribute: an adjoint
         sum is unweighted, so a factor other than 0 or 1 could not be represented
-        here and is left out rather than counted wrong.
+        here — `derived_chain_factor` raises on one rather than let it be counted
+        wrong or dropped in silence.
+
+        This reaches `solve` as well, which names the same nodes and assigns the
+        candidate to every one of them. Omitting the derived node left the solver
+        searching a function the library does not compute, and converging on a
+        point that is not a root.
 
         The result is deduplicated. Evaluation is idempotent to a repeated
         node — assigning it twice leaves the same value — but `gradient_sum`

--- a/src/tenforty/mappings.py
+++ b/src/tenforty/mappings.py
@@ -67,6 +67,12 @@ for name, nodes in _SUBORDINATE_NODES.items():
 # (`derived_chain_factor`), so this table cannot drift from the derivation in
 # models.py. Only identity derivations can be expressed downstream, because
 # `gradient_sum` adds one unweighted adjoint per node.
+#
+# COMPUTED FIELDS ONLY. A derivation applied by a `model_validator` rather than a
+# computed field cannot be entered here: `derived_chain_factor` probes with
+# `model_copy`, which does not re-run validators, so the entry would read as a
+# constant zero and be skipped in silence. `ensure_ordinary_includes_qualified` is
+# exactly that shape and is tracked separately (tenforty-3gt).
 DERIVED_NATURAL_SOURCES: dict[str, str] = {
     "schedule_se_ss_wages": "w2_income",
 }
@@ -82,12 +88,33 @@ def derived_chain_factor(tax_input: TaxReturnInput, derived: str, source: str) -
     self-employment income) because a copy of that rule here could fall out of step
     with `models.py` without anything failing.
 
+    That guarantee covers pydantic COMPUTED FIELDS, which recompute on attribute
+    access. It does not extend to derivations applied by a `model_validator`:
+    `model_copy` does not re-run validators, so the probe reads a slope of zero and
+    the caller skips the edge without complaint. See the note on
+    `DERIVED_NATURAL_SOURCES` and tenforty-3gt.
+
     Note this is deliberately not `getattr(tax_input, derived) != 0`: with
     `w2_income` at zero the derived value is zero while the slope is still 1, and
     that is a live gradient, not a dead one.
+
+    Raises NotImplementedError for any other slope. Downstream can only express 0
+    or 1 — `gradient_sum` adds one unweighted adjoint per node — and an entry in
+    `DERIVED_NATURAL_SOURCES` is a deliberate opt-in, so a factor it cannot carry is
+    a mapping defect to surface rather than a coupling to drop in silence.
     """
     bumped = tax_input.model_copy(update={source: getattr(tax_input, source) + 1.0})
-    return getattr(bumped, derived) - getattr(tax_input, derived)
+    factor = getattr(bumped, derived) - getattr(tax_input, derived)
+
+    if factor not in (0.0, 1.0):
+        raise NotImplementedError(
+            f"d({derived})/d({source}) = {factor}, but only 0 or 1 can be carried: "
+            f"`gradient_sum` adds one unweighted adjoint per node, so a scaled "
+            f"derivation cannot be expressed by naming nodes. Give {derived} its own "
+            f"weighted edge instead of an entry in DERIVED_NATURAL_SOURCES."
+        )
+
+    return factor
 
 
 CAPITAL_GAINS_FIELDS = {"short_term_capital_gains", "long_term_capital_gains"}

--- a/src/tenforty/mappings.py
+++ b/src/tenforty/mappings.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .models import STATE_TO_FORM, OTSFilingStatus, OTSState
+from .models import STATE_TO_FORM, OTSFilingStatus, OTSState, TaxReturnInput
 
 NATURAL_TO_NODE = {
     # Federal (1040)
@@ -55,6 +55,40 @@ NATURAL_TO_NODES: dict[str, list[str]] = {
 for name, nodes in _SUBORDINATE_NODES.items():
     if name not in NATURAL_TO_NODES:
         NATURAL_TO_NODES[name] = list(nodes)
+
+# Naturals that are COMPUTED from another natural rather than supplied by the
+# caller (pydantic computed fields on TaxReturnInput), mapped to the natural they
+# derive from. Evaluation reaches their nodes on its own, but a derivative with
+# respect to the SOURCE natural has to follow the derived natural's nodes too, or
+# it silently drops the coupling those nodes carry — d(se_tax)/d(w2_income) losing
+# the shared social security wage base is exactly that (tenforty-hrp).
+#
+# The chain factor is not stored here: it is read off the model at call time
+# (`derived_chain_factor`), so this table cannot drift from the derivation in
+# models.py. Only identity derivations can be expressed downstream, because
+# `gradient_sum` adds one unweighted adjoint per node.
+DERIVED_NATURAL_SOURCES: dict[str, str] = {
+    "schedule_se_ss_wages": "w2_income",
+}
+
+
+def derived_chain_factor(tax_input: TaxReturnInput, derived: str, source: str) -> float:
+    """d(derived natural)/d(source natural), read off the model itself.
+
+    The derivations are piecewise linear in their source and every one of them is
+    currently either identity or a constant zero, so a unit bump recovers the exact
+    slope — no step-size choice to get wrong. Probing beats restating the condition
+    (`schedule_se_ss_wages` is zero for Married/Joint and when there is no
+    self-employment income) because a copy of that rule here could fall out of step
+    with `models.py` without anything failing.
+
+    Note this is deliberately not `getattr(tax_input, derived) != 0`: with
+    `w2_income` at zero the derived value is zero while the slope is still 1, and
+    that is a live gradient, not a dead one.
+    """
+    bumped = tax_input.model_copy(update={source: getattr(tax_input, source) + 1.0})
+    return getattr(bumped, derived) - getattr(tax_input, derived)
+
 
 CAPITAL_GAINS_FIELDS = {"short_term_capital_gains", "long_term_capital_gains"}
 

--- a/src/tenforty/mappings.py
+++ b/src/tenforty/mappings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
 from .models import STATE_TO_FORM, OTSFilingStatus, OTSState, TaxReturnInput
@@ -82,11 +83,18 @@ def derived_chain_factor(tax_input: TaxReturnInput, derived: str, source: str) -
     """d(derived natural)/d(source natural), read off the model itself.
 
     The derivations are piecewise linear in their source and every one of them is
-    currently either identity or a constant zero, so a unit bump recovers the exact
-    slope — no step-size choice to get wrong. Probing beats restating the condition
-    (`schedule_se_ss_wages` is zero for Married/Joint and when there is no
-    self-employment income) because a copy of that rule here could fall out of step
-    with `models.py` without anything failing.
+    currently either identity or a constant zero, so a single bump recovers the exact
+    slope. Probing beats restating the condition (`schedule_se_ss_wages` is zero for
+    Married/Joint and when there is no self-employment income) because a copy of that
+    rule here could fall out of step with `models.py` without anything failing.
+
+    The slope is taken against the bump that SURVIVED rounding, not the one requested,
+    and that is what makes it EXACT: an identity derivation moves the derived value by
+    precisely the amount the source moved, so the ratio is 1.0 with no tolerance to
+    choose. Dividing by the requested bump instead reads 1.0000000000009095 whenever
+    `source + bump` crosses a power of two, and 0.0 above 2**53 where a unit bump
+    rounds away to nothing — both of which used to read as "not 1" and drop the
+    coupling in silence. The bump is at least one ulp wide so it can never vanish.
 
     That guarantee covers pydantic COMPUTED FIELDS, which recompute on attribute
     access. It does not extend to derivations applied by a `model_validator`:
@@ -103,8 +111,12 @@ def derived_chain_factor(tax_input: TaxReturnInput, derived: str, source: str) -
     `DERIVED_NATURAL_SOURCES` is a deliberate opt-in, so a factor it cannot carry is
     a mapping defect to surface rather than a coupling to drop in silence.
     """
-    bumped = tax_input.model_copy(update={source: getattr(tax_input, source) + 1.0})
-    factor = getattr(bumped, derived) - getattr(tax_input, derived)
+    current = float(getattr(tax_input, source))
+    bump = max(1.0, math.ulp(current))
+    bumped = tax_input.model_copy(update={source: current + bump})
+
+    realized = float(getattr(bumped, source)) - current
+    factor = (getattr(bumped, derived) - getattr(tax_input, derived)) / realized
 
     if factor not in (0.0, 1.0):
         raise NotImplementedError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,4 +44,23 @@ settings.register_profile(
     deadline=None,
     suppress_health_check=[HealthCheck.too_slow],
 )
+# Ad-hoc soak: `uv run pytest --hypothesis-profile=soak`, roughly two hours for the
+# suite against deep's eleven minutes. The rung exists because deep is a COIN FLIP on
+# the rarest defects rather than a net: the float-boundary drop in
+# `derived_chain_factor` had a per-example hit rate near 2e-5, which deep clears about
+# one run in five — it was found by luck, not by budget. A hundred thousand examples
+# turns that into a near-certainty.
+#
+# Reach for this the way you reach for deep — deliberately, on an engine change, when
+# the change is large enough that a one-in-five detection rate is not reassurance.
+# Nothing schedules it and nothing gates on it; a targeted strategy that lands ON the
+# corner (see `_BINADE_EDGE` in graph_autodiff_properties_test.py) beats buying the
+# same corner with reps by four orders of magnitude, so prefer writing one of those
+# when the corner is known. This is for the corners nobody has characterized yet.
+settings.register_profile(
+    "soak",
+    max_examples=100_000,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
 settings.load_profile("dev")  # Default for local dev

--- a/tests/graph_autodiff_fanout_test.py
+++ b/tests/graph_autodiff_fanout_test.py
@@ -313,3 +313,40 @@ def test_derived_chain_factor_rejects_a_slope_it_cannot_carry():
 
     with pytest.raises(NotImplementedError, match=r"only 0 or 1 can be carried"):
         derived_chain_factor(tax_input, "scaled_wages", "w2_income")
+
+
+@pytest.mark.parametrize(
+    "w2_income",
+    [
+        8191.969842312686,
+        4095.1460934553484,
+        2**53 - 0.5,
+        1e16,
+        1e17,
+    ],
+    ids=["binade-8192", "binade-4096", "at-2**53", "above-2**53", "far-above-2**53"],
+)
+def test_derived_chain_factor_is_exact_where_a_unit_bump_is_not(w2_income):
+    """An identity derivation reads as slope 1 even where `w + 1.0` misbehaves.
+
+    Two ways a nominal unit bump lies about the slope. Below 2**53, `w + 1.0` can
+    cross a power of two and land 1.0000000000009095 away; above it, the bump rounds
+    off entirely and the probe sees no movement at all. Both used to read as "not 1"
+    and drop the schedule_se_ss_wages coupling in silence — the deep sweep caught the
+    first one through `test_marginal_rate_within_bounds`.
+
+    Taking the slope against the bump that survived rounding makes it exact rather
+    than merely close, so `_input_nodes` can keep comparing to 1.0 outright.
+    """
+    from tenforty.mappings import derived_chain_factor
+
+    tax_input = TaxReturnInput(
+        year=2024,
+        filing_status="Single",
+        w2_income=w2_income,
+        self_employment_income=50_000.0,
+    )
+
+    assert (
+        derived_chain_factor(tax_input, "schedule_se_ss_wages", "w2_income") == 1.0
+    ), "identity derivation must read as exactly 1.0, not approximately"

--- a/tests/graph_autodiff_fanout_test.py
+++ b/tests/graph_autodiff_fanout_test.py
@@ -221,12 +221,6 @@ def test_solve_through_derived_input_is_wrong():
     assert solved == pytest.approx(60_000.0, rel=1e-3)
 
 
-@pytest.mark.xfail(
-    reason="tenforty-gxk: schedule_se_ss_wages is a Python computed field derived "
-    "from w2_income, so it is invisible to the graph's dependency structure and "
-    "the wage-base path is missing from the derivative",
-    strict=True,
-)
 @skip_if_graph_unavailable
 def test_w2_gradient_includes_schedule_se_wage_base():
     """Wages displace self-employment earnings from the OASDI base.
@@ -236,10 +230,12 @@ def test_w2_gradient_includes_schedule_se_wage_base():
     earnings together exceed that base, another dollar of wages pushes a dollar
     of SE earnings out of the 12.4% charge. Here 2024's $168,600 base leaves
     $28,600 of room against $46,175 of SE earnings, so the true marginal rate
-    is 0.130880 while the derivative reports 0.240000 — nearly double.
+    is 0.130880 — the derivative used to report 0.240000, nearly double.
 
-    Fan-out summing cannot reach this: the wage-base node is written from a
-    computed field rather than from any node w2_income is mapped to.
+    Fan-out summing over NATURAL_TO_NODES alone cannot reach this: the wage-base
+    node is written from a computed field rather than from any node w2_income is
+    mapped to. Following DERIVED_NATURAL_SOURCES is what closes it (tenforty-hrp,
+    and the gradient half of tenforty-gxk).
     """
     case = dict(
         year=2024,

--- a/tests/graph_autodiff_fanout_test.py
+++ b/tests/graph_autodiff_fanout_test.py
@@ -194,6 +194,51 @@ def test_solve_recovers_input_through_fanout(natural, true_value, extra):
     )
 
 
+@skip_if_graph_unavailable
+def test_solve_recovers_wages_through_the_derived_schedule_se_node():
+    """Solving must vary the DERIVED natural's nodes too, not only the mapped ones.
+
+    `_input_nodes` serves `solve` as well as `gradient`, and the solver assigns its
+    candidate to every node it names. The cases above were picked so that
+    `schedule_se_ss_wages` is unaffected by hiding the unknown; this one is the
+    opposite, and is the case the derived fan-out repairs. Self-employment income
+    stays visible, so the derivation is live at a unit slope throughout the search
+    while the wage-base coupling is the thing being solved through.
+
+    Without the derived node the solver leaves Schedule SE line 5a at zero, so it
+    searches a function the library does not compute: it reports convergence at
+    $127,478 for a true $140,000, a point whose total tax is $1,601.62 short of the
+    target it claims to have hit. The residual is asserted alongside the recovered
+    input so the failure reads as "not a root", not merely "not the number we chose".
+    """
+    known = dict(
+        year=2024,
+        filing_status="Single",
+        w2_income=140_000.0,
+        self_employment_income=60_000.0,
+    )
+    target = evaluate_return(backend="graph", **known).federal_total_tax
+
+    solved = _solve_for("w2_income", **known)
+
+    assert solved is not None, "solver failed to converge"
+    assert solved == pytest.approx(known["w2_income"], rel=1e-3), (
+        f"solved w2_income={solved:,.2f} but the true value was 140,000.00; the "
+        f"search likely left us_schedule_se_L5_w2_ss_wages at zero"
+    )
+
+    residual = (
+        evaluate_return(
+            backend="graph", **{**known, "w2_income": solved}
+        ).federal_total_tax
+        - target
+    )
+    assert residual == pytest.approx(0.0, abs=1.0), (
+        f"solver converged on a point that is not a root: total tax there misses "
+        f"the target by ${residual:,.2f}"
+    )
+
+
 @pytest.mark.xfail(
     reason="tenforty-gxk: solve freezes computed input fields at construction, "
     "so hiding the unknown collapses schedule_se_ss_wages and the solver "
@@ -246,3 +291,25 @@ def test_w2_gradient_includes_schedule_se_wage_base():
     assert _gradient("w2_income", **case) == pytest.approx(
         _finite_difference("w2_income", **case), abs=1e-6
     )
+
+
+def test_derived_chain_factor_rejects_a_slope_it_cannot_carry():
+    """A derivation the adjoint sum cannot express must raise, not be skipped.
+
+    `_input_nodes` extends across a derived natural by NAMING its nodes, and
+    `gradient_sum` adds one unweighted adjoint per name — so the only slopes the
+    mechanism can carry are 0 and 1. Dropping anything else would be silently
+    correct-looking: the table entry sits there reading as wired while the coupling
+    goes missing, which is the failure mode that hid tenforty-3gt.
+    """
+    from tenforty.mappings import derived_chain_factor
+
+    class ScaledInput(TaxReturnInput):
+        @property
+        def scaled_wages(self) -> float:
+            return 0.9235 * self.w2_income
+
+    tax_input = ScaledInput(year=2024, filing_status="Single", w2_income=100_000.0)
+
+    with pytest.raises(NotImplementedError, match=r"only 0 or 1 can be carried"):
+        derived_chain_factor(tax_input, "scaled_wages", "w2_income")

--- a/tests/graph_autodiff_properties_test.py
+++ b/tests/graph_autodiff_properties_test.py
@@ -75,8 +75,19 @@ _STEP = 10.0
 
 # 2024 Social Security wage base. Below it, W2 wages and self-employment income
 # share the 12.4% SS ceiling, coupling the two — the region where the autodiff
-# currently drops the derived w2 -> Schedule SE edge (tenforty-hrp).
+# used to drop the derived w2 -> Schedule SE edge (tenforty-hrp).
 _SS_WAGE_BASE_2024 = 168_600.0
+
+# 2024 Additional Medicare Tax thresholds (IRC 3101(b)(2)). Form 8959 hangs two
+# max0 branches off these, so wages landing exactly on one put both on a kink at
+# the same time — see tenforty-dhi.
+_ADDITIONAL_MEDICARE_THRESHOLDS = {
+    "Single": 200_000.0,
+    "Head_of_House": 200_000.0,
+    "Widow(er)": 200_000.0,
+    "Married/Joint": 250_000.0,
+    "Married/Sep": 125_000.0,
+}
 
 
 def _total_tax(case: dict) -> float:
@@ -102,16 +113,18 @@ def test_autodiff_matches_finite_difference(filing_status, wrt, incomes):
     # Leave room for a symmetric step without pushing the input negative.
     case[wrt] = max(case[wrt], _STEP)
 
-    # Skip the W2 gradient in the SS wage-base sharing region: there the autodiff
-    # omits the derived w2 -> Schedule SE SS-wages edge and disagrees with the
-    # evaluation path. This is a real, tracked bug (tenforty-hrp), pinned by the
-    # strict-xfail tests below; scope it out here rather than hide it by loosening
-    # the tolerance. Remove this assume when hrp lands.
+    # Skip wages landing EXACTLY on the Additional Medicare threshold. Form 8959
+    # charges two max0 branches off that one threshold, so both sit on their kinks
+    # at once and autodiff takes the subgradient 0 for each — but the kinks cancel
+    # and the sum is differentiable, so the true slope is 0.009 and the gradient
+    # reads 0. A real, tracked defect (tenforty-dhi), pinned by the strict xfail
+    # below. The kink filter underneath cannot catch it: it watches the composed
+    # function, which is smooth here, not the interior nodes. Remove when dhi lands.
     assume(
         not (
             wrt == "w2_income"
             and incomes["self_employment_income"] > 0.0
-            and case["w2_income"] < _SS_WAGE_BASE_2024
+            and case["w2_income"] == _ADDITIONAL_MEDICARE_THRESHOLDS[filing_status]
         )
     )
 
@@ -145,6 +158,20 @@ def test_marginal_rate_within_bounds(filing_status, wrt, incomes):
     # Monotone region: total income clear of the EIC phase-in, where more income
     # buys more refundable credit and the marginal rate can dip below zero.
     assume(sum(incomes.values()) >= 50_000.0)
+
+    # Skip the long-term capital gain rate where a QBI deduction is live: Form 8995
+    # line 13 (net capital gain) is an unfed input, so the line 15 taxable-income
+    # limit is computed on taxable income INCLUDING the gain, and another dollar of
+    # gain buys $0.20 of QBI deduction it should not. The marginal goes to -0.024.
+    # A real, tracked defect (tenforty-345), pinned by the strict xfail below;
+    # scoped out here rather than hidden by widening the bound. Remove when 345
+    # lands. Only this pair misbehaves — short-term gains, dividends, interest,
+    # schedule-1 and wages all stay positive with the same QBI deduction live.
+    assume(
+        not (
+            wrt == "long_term_capital_gains" and incomes["self_employment_income"] > 0.0
+        )
+    )
     case = dict(year=2024, filing_status=filing_status, **incomes)
 
     marginal = _gradient(wrt, case)
@@ -153,12 +180,80 @@ def test_marginal_rate_within_bounds(filing_status, wrt, incomes):
     )
 
 
-# Durable record of tenforty-hrp: the graph autodiff omits the derived
-# w2_income -> us_schedule_se_L5_w2_ss_wages edge, so d(*)/d(w2_income) drops the
-# Social Security wage-base coupling. These assert the CORRECT behavior and are
-# strict xfails, so the day hrp is fixed they xpass and force their own removal.
-# The coupling is live here: W2 ($101,237) sits below the wage base and
-# W2 + 0.9235 * SE (~$67,373) exceeds it, so SE income is partially SS-capped.
+# Durable record of tenforty-345: Form 8995 line 13 (net capital gain) is declared
+# as a graph input and never written, so the line 15 limit does not subtract the
+# gain and the QBI deduction grows with it. Asserts the CORRECT behavior and is a
+# strict xfail, so the day 345 is fixed it xpasses and forces its own removal --
+# along with the `assume` above, which nothing else would flag.
+_QBI_GAIN_CASE = dict(
+    year=2024,
+    filing_status="Single",
+    self_employment_income=35_401.0,
+    rental_income=14_598.0,
+    long_term_capital_gains=1.0,
+)
+
+
+# Durable record of tenforty-dhi: at wages exactly on the Additional Medicare
+# threshold, Form 8959's two max0 branches are both at their kink and autodiff
+# zeroes each, losing a derivative that survives in their sum. Strict xfail, so
+# the fix forces this and the `assume` above out together.
+_KINK_CASE = dict(
+    year=2024,
+    filing_status="Single",
+    w2_income=200_000.0,
+    self_employment_income=11.0,
+)
+
+
+@skip_if_graph_unavailable
+@pytest.mark.xfail(
+    reason="tenforty-dhi: coincident max0 kinks at the Additional Medicare "
+    "threshold zero the adjoint, so d(*)/d(w2_income) loses the 0.9%",
+    strict=True,
+)
+def test_gradient_survives_coincident_kinks_at_the_medicare_threshold():
+    """The sum is differentiable at the threshold even though each branch kinks."""
+    from tenforty.backends import GraphBackend
+
+    analytical = GraphBackend().gradient(
+        TaxReturnInput(**_KINK_CASE),
+        "us_form_8959_L18_total_additional_medicare",
+        "w2_income",
+    )
+
+    def additional_medicare(value):
+        return evaluate_return(
+            backend="graph", **{**_KINK_CASE, "w2_income": value}
+        ).federal_additional_medicare_tax
+
+    w2 = _KINK_CASE["w2_income"]
+    left = (additional_medicare(w2) - additional_medicare(w2 - 1.0)) / 1.0
+    right = (additional_medicare(w2 + 1.0) - additional_medicare(w2)) / 1.0
+    assert left == pytest.approx(right, abs=1e-9), "guard: the point must be smooth"
+    assert analytical == pytest.approx(right, abs=1e-6)
+
+
+@skip_if_graph_unavailable
+@pytest.mark.xfail(
+    reason="tenforty-345: Form 8995 L13 net_capital_gain is an unfed input, so the "
+    "QBI taxable-income limit omits the gain and d(total_tax)/d(LTCG) goes negative",
+    strict=True,
+)
+def test_long_term_gain_marginal_is_not_negative_under_qbi():
+    """A dollar of long-term gain must never REDUCE total tax."""
+    marginal = _gradient("long_term_capital_gains", _QBI_GAIN_CASE)
+    assert marginal >= -1e-6, (
+        f"d(total_tax)/d(long_term_capital_gains) = {marginal:.6f}: the gain is "
+        f"buying QBI deduction through the unsubtracted line 15 limit"
+    )
+
+
+# Regression pins for tenforty-hrp: the graph autodiff used to omit the derived
+# w2_income -> us_schedule_se_L5_w2_ss_wages edge, so d(*)/d(w2_income) dropped the
+# Social Security wage-base coupling entirely. The coupling is live here: W2
+# ($101,237) sits below the wage base and W2 + 0.9235 * SE (~$67,373) exceeds it,
+# so SE income is partially SS-capped.
 _COUPLING_CASE = dict(
     year=2024,
     filing_status="Single",
@@ -168,11 +263,6 @@ _COUPLING_CASE = dict(
 
 
 @skip_if_graph_unavailable
-@pytest.mark.xfail(
-    reason="tenforty-hrp: autodiff omits the derived w2 -> Schedule SE SS-wages "
-    "edge, so d(se_tax)/d(w2_income) misses the wage-base coupling",
-    strict=True,
-)
 def test_se_tax_gradient_carries_w2_wage_base_coupling():
     """More W2 wages crowd SE income out of the 12.4% SS portion, cutting SE tax."""
     from tenforty.backends import GraphBackend
@@ -192,11 +282,6 @@ def test_se_tax_gradient_carries_w2_wage_base_coupling():
 
 
 @skip_if_graph_unavailable
-@pytest.mark.xfail(
-    reason="tenforty-hrp: the dropped w2 -> Schedule SE edge inflates "
-    "d(total_tax)/d(w2_income) above the SS wage base (~0.24 vs ~0.128 truth)",
-    strict=True,
-)
 def test_total_tax_gradient_matches_finite_difference_at_wage_base_coupling():
     """The total-tax w2 gradient must include the (negative) SE-tax reduction."""
     w2 = _COUPLING_CASE["w2_income"]
@@ -206,3 +291,66 @@ def test_total_tax_gradient_matches_finite_difference_at_wage_base_coupling():
         - _total_tax({**_COUPLING_CASE, "w2_income": w2 - 1.0})
     ) / 2.0
     assert analytical == pytest.approx(central, abs=1e-3)
+
+
+# The coupling is live only where the wage base actually binds. With SE income of
+# $72,954, net earnings are 0.9235 * 72,954 = $67,373, so wages start crowding SE
+# income out of the 12.4% portion once w2 clears 168,600 - 67,373 = ~$101,227 (and
+# the SE OASDI charge is gone entirely above the base). Below that band the zero
+# gradient is CORRECT -- nothing is being displaced -- which makes it the honest
+# control for the coupled samples.
+_COUPLING_SE_INCOME = 72_954.0
+_COUPLING_BAND_FLOOR = _SS_WAGE_BASE_2024 - 0.9235 * _COUPLING_SE_INCOME
+
+
+@skip_if_graph_unavailable
+@pytest.mark.parametrize(
+    ("w2", "coupled"),
+    [
+        (40_000.0, False),
+        (90_000.0, False),
+        (105_000.0, True),
+        (130_000.0, True),
+        (_SS_WAGE_BASE_2024 - 5_000.0, True),
+    ],
+    ids=lambda v: f"w2-{int(v)}" if isinstance(v, float) else f"coupled-{v}",
+)
+def test_se_tax_gradient_tracks_wage_base_across_the_region(w2: float, coupled: bool):
+    """The w2 -> SE coupling holds across the band it lives in, not at one point.
+
+    A single sample can be matched by a wrong gradient that happens to agree there;
+    the coupling has to survive a walk across its whole region. Reverting the
+    derived-fan-out fix flattens every coupled sample here to 0.0.
+    """
+    from tenforty.backends import GraphBackend
+
+    case = dict(
+        year=2024,
+        filing_status="Single",
+        w2_income=w2,
+        self_employment_income=_COUPLING_SE_INCOME,
+    )
+    analytical = GraphBackend().gradient(
+        TaxReturnInput(**case), "us_schedule_se_L10_se_tax", "w2_income"
+    )
+
+    def se_tax(value):
+        return evaluate_return(
+            backend="graph", **{**case, "w2_income": value}
+        ).federal_se_tax
+
+    central = (se_tax(w2 + 1.0) - se_tax(w2 - 1.0)) / 2.0
+    assert analytical == pytest.approx(central, abs=1e-3)
+
+    assert (w2 > _COUPLING_BAND_FLOOR) is coupled, (
+        f"test data drift: w2={w2} sits on the wrong side of the "
+        f"${_COUPLING_BAND_FLOOR:,.0f} wage-base band floor"
+    )
+    if coupled:
+        assert analytical < 0.0, (
+            f"more W2 wages must crowd SE income out of the 12.4% SS portion at w2={w2}"
+        )
+    else:
+        assert analytical == pytest.approx(0.0, abs=1e-9), (
+            f"the wage base does not bind at w2={w2}; nothing is displaced"
+        )

--- a/tests/graph_autodiff_properties_test.py
+++ b/tests/graph_autodiff_properties_test.py
@@ -24,6 +24,8 @@ pins the finite-difference agreement on the runtime directly.
   marginal negative at very low income).
 """
 
+import math
+
 import pytest
 from hypothesis import assume, given, settings
 from hypothesis import strategies as st
@@ -60,15 +62,41 @@ INCOME_NATURALS = [
     "rental_income",
 ]
 
+# Incomes landing in the last unit before a power of two, where float spacing
+# DOUBLES on the way across. A derivative probed as `f(x + 1) - f(x)` reads a slope
+# of 1.0000000000009095 rather than 1.0 there, because the exact sum is no longer
+# representable in the wider binade above; `derived_chain_factor` compared that to
+# 1.0 outright and dropped the w2 -> Schedule SE coupling in silence.
+#
+# Uniform sampling reaches this by accident: the windows are one unit wide, so about
+# 2e-5 of [0, 200_000) lies in one, and the deep sweep needed 10,000 examples to trip
+# over it once. Landing ON the window instead makes it a per-example event, which is
+# the whole argument for a targeted strategy over more reps — same corner, four
+# orders of magnitude cheaper. Sampling the exponent rather than hard-coding 2**13
+# keeps it a statement about float structure and not about the one value that failed.
+_BINADE_EDGE = st.builds(
+    lambda exponent, offset: math.ldexp(1.0, exponent) - offset,
+    st.sampled_from(range(1, 18)),  # 2 .. 131072, inside the 200_000 cap
+    st.floats(
+        min_value=0.0,
+        max_value=1.0,
+        exclude_min=True,
+        allow_nan=False,
+        allow_infinity=False,
+    ),
+)
+
 # A random income for every source, so the gradient is exercised with the
 # subordinate forms (Schedule SE, 8959, 8960) live and fanning out.
+_INCOME = st.one_of(
+    st.floats(
+        min_value=0.0, max_value=200_000.0, allow_nan=False, allow_infinity=False
+    ),
+    _BINADE_EDGE,
+)
+
 _INCOME_VECTOR = st.fixed_dictionaries(
-    {
-        natural: st.floats(
-            min_value=0.0, max_value=200_000.0, allow_nan=False, allow_infinity=False
-        )
-        for natural in INCOME_NATURALS
-    }
+    {natural: _INCOME for natural in INCOME_NATURALS}
 )
 
 _STEP = 10.0
@@ -101,7 +129,7 @@ def _gradient(wrt: str, case: dict) -> float:
 
 
 @skip_if_graph_unavailable
-@settings(deadline=None)  # inherit profile example count (ci=500, deep=10k)
+@settings(deadline=None)  # inherit profile count (ci=500, deep=10k, soak=100k)
 @given(
     filing_status=st.sampled_from(FEDERAL_STATUSES),
     wrt=st.sampled_from(INCOME_NATURALS),
@@ -147,7 +175,7 @@ def test_autodiff_matches_finite_difference(filing_status, wrt, incomes):
 
 
 @skip_if_graph_unavailable
-@settings(deadline=None)  # inherit profile example count (ci=500, deep=10k)
+@settings(deadline=None)  # inherit profile count (ci=500, deep=10k, soak=100k)
 @given(
     filing_status=st.sampled_from(FEDERAL_STATUSES),
     wrt=st.sampled_from(INCOME_NATURALS),


### PR DESCRIPTION
## The problem

`GraphBackend._input_nodes` resolved a natural to `NATURAL_TO_NODES[var]` and stopped there — the nodes the caller's own input is written to, and nothing else.

`schedule_se_ss_wages` is a pydantic computed field derived from `w2_income`, and it is filed under its **own** key. So evaluation wrote the filer's wages to Schedule SE line 5a and correctly shared the social security wage base between W2 and self-employment earnings, while the gradient walked straight past that edge.

Not a rounding error. 2024/Single, `w2_income=$101,237`, `self_employment_income=$72,954` — chosen so W2 + 0.9235 × SE straddles the $168,600 wage base:

| derivative | finite difference | autodiff (before) |
|---|---:|---:|
| `d(se_tax)/d(w2)` | −0.12400 | 0.00000 |
| `d(total_tax)/d(w2)` | +0.12790 | +0.24000 |

The entire coupling was dropped, and the headline marginal rate came out near double the true one.

## The fix

`DERIVED_NATURAL_SOURCES` names the derivation; `_input_nodes` extends the node list across it.

Two decisions worth flagging for review, since both are places where an easier version would be quietly wrong:

**The chain factor is not stored in the table.** `derived_chain_factor` probes the model at call time, so the rule cannot drift from `models.py`. `schedule_se_ss_wages` is zero for Married/Joint and when there is no self-employment income — restating that condition in the mapping layer is exactly the kind of copy that goes stale with nothing failing.

**The probe is not `getattr(tax_input, derived) != 0`.** At `w2_income=0` the derived value is zero while the slope is still 1. That is a live gradient, not a dead one, and a value-based liveness test gets it backwards.

Only unit-slope derivations can be followed. `gradient_sum` adds one **unweighted** adjoint per node, so a factor other than 0 or 1 cannot be represented by naming nodes — `derived_chain_factor` raises `NotImplementedError` on one rather than drop the coupling in silence. An entry in the table is a deliberate opt-in, so a slope it cannot carry is a mapping defect to surface, not a runtime condition to skip.

## The solver

`_input_nodes` serves `solve` as well as `gradient`, and `solve_with_config` assigns its candidate to **every** node named — so following the derived natural repairs the solver too, not just the derivative.

The existing `SOLVE_CASES` were deliberately chosen so `schedule_se_ss_wages` is *unaffected* by hiding the unknown, which is why nothing caught this. With wages as the unknown and self-employment income live, Schedule SE line 5a stayed at zero throughout the search, so the solver was searching a function the library does not compute:

| | solved `w2_income` | total tax there | target |
|---|---:|---:|---:|
| before | 127,477.94 | 37,715.45 | 39,317.07 |
| after | 140,000.00 | 39,317.07 | 39,317.07 |

It reported **convergence** on a point $1,601.62 short of the target it claimed to have hit.

## Relationship to tenforty-gxk

This is also the gradient half of **tenforty-gxk**, filed separately before the two were recognized as the same defect.

The solver half splits. With `w2_income` as the unknown it is fixed here, as above. With `self_employment_income` as the unknown the mechanism is different — the evaluator is built once with computed fields frozen, so hiding the unknown collapses the derived value — and that case correctly still xfails. gxk stays open for it.

## Tests

Three strict xfails become plain passing tests (two hrp, one gxk fan-out), and the `assume()` carve-out comes out of `test_autodiff_matches_finite_difference`.

The new regional test walks the coupling across the band it actually lives in rather than pinning one point. Below w2 ≈ $101,227 the wage base does not bind and a **zero gradient is correct** — nothing is being displaced — which makes those samples the honest control rather than padding. A data-drift guard asserts each sample sits on the side of the band floor the parametrization claims.

Two more, in the follow-up commit:

- `test_solve_recovers_wages_through_the_derived_schedule_se_node` pins the solver repair. It asserts the residual alongside the recovered input, so a failure reads as "not a root" rather than "not the number we chose".
- `test_derived_chain_factor_rejects_a_slope_it_cannot_carry` pins the raise, on a synthetic `0.9235 ×` derivation.

Both were confirmed to fail with their subject removed: the solver test lands on $127,478, and the guard test reports DID NOT RAISE. Reverting the fix itself flattens every coupled sample to 0.0 and turns 7 tests red (6 under the `dev` profile — the seventh is `test_autodiff_matches_finite_difference`, which needs `ci` to reach the region).

## Found but not fixed here

Three further defects, each filed and pinned so it forces its own removal when fixed:

- **tenforty-345** — Form 8995 L13 `net_capital_gain` is declared as a graph input and never written, so the §199A(a) taxable-income limit omits the net-capital-gain subtraction. `d(total_tax)/d(LTCG)` goes to −0.024 and qualified dividends to −0.120; both 2024 and 2025. Strict xfail. Note this is a **value** defect, not only a gradient one — autodiff and the finite difference agree here, so the computed tax function itself is wrong.
- **tenforty-dhi** — at wages landing exactly on the Additional Medicare threshold, Form 8959's two max0 branches are both at a kink; autodiff takes subgradient 0 for each, but the kinks cancel and the sum is differentiable. Returning 0.0 is outside `[left, right]`, so it is not a defensible subgradient. The existing kink filter cannot catch it — it watches the composed function, which is smooth here, not the interior nodes. Strict xfail.
- **tenforty-3gt** — the same *family* as this defect, different mechanism. `ensure_ordinary_includes_qualified` is a `model_validator`, not a computed field, so a caller who supplies only `qualified_dividends` gets both 1040 lines fed while the gradient sees only L3a: `d(total_tax)/d(qualified_dividends)` reads −0.090 against a true +0.150, wrong in sign. Pre-existing and independent — it reproduces with `DERIVED_NATURAL_SOURCES` cleared.

  **It cannot be fixed by adding a row to the table.** `derived_chain_factor` probes with `model_copy`, which does not re-run validators, so the entry would read as a constant zero and be skipped silently. The table comment and the docstring now say so and point at the bead. That silent-skip is also why the `NotImplementedError` above earns its place.

The first two were surfaced by the deep sweep; each is scoped out of the property tests by a narrow `assume()` tied to its xfail, rather than hidden by widening a bound. 3gt is not scoped out because nothing generates it — `qualified_dividends` is absent from `INCOME_NATURALS`, which is why 10,000 examples never found it. Adding it is the cheapest part of that bead.

## The deep sweep broke this PR, twice over

The whole-suite deep sweep on the follow-up commit failed:

```
tests/graph_autodiff_properties_test.py::test_marginal_rate_within_bounds
src/tenforty/mappings.py:110: NotImplementedError:
d(schedule_se_ss_wages)/d(w2_income) = 0.9999999999999999,
but only 0 or 1 can be carried
```

**That is a retraction.** An earlier revision of this description claimed the new `NotImplementedError` sat on "a path the current single-entry table cannot reach (the factor is exactly 0.0 or 1.0 for every filing status)". It is not exactly 0.0 or 1.0 for every input, and 10,000 examples proved it. I had probed float precision only at round magnitudes (1e10–1e17) and pronounced the behaviour benign; it was benign right up until `3fc807b` added a guard that raises on it.

The guard was mine and it was wrong. But it exposed something that was not mine. `derived_chain_factor` probed the slope as `derived(source + 1.0) - derived(source)` and `_input_nodes` compared that to `1.0` exactly. A nominal unit bump misreports an identity derivation in two ways:

| `w2_income` | probed slope | old `== 1.0` |
|---|---|---|
| `8191.969842312686` — `w2 + 1` crosses a power of two | `1.0000000000009095` | **False** |
| `1e16` — the bump rounds away entirely | `0.0` | **False** |

Both made `_input_nodes` **drop the `schedule_se_ss_wages` coupling in silence**, reinstating on a thin set of inputs precisely the defect `bd8ec2f` exists to remove. Roughly 1 in 50,000 random incomes in `[0, 500k)` lands in the first case. It reaches gradients and `solve`, never computed tax. So `3fc807b`'s guard did its job — it converted a silent wrong gradient into a crash, which is the only reason the sweep could see it.

**`83b584f`** takes the slope against the bump that *survived rounding* rather than the one requested:

```python
current = float(getattr(tax_input, source))
bump = max(1.0, math.ulp(current))
bumped = tax_input.model_copy(update={source: current + bump})

realized = float(getattr(bumped, source)) - current
factor = (getattr(bumped, derived) - getattr(tax_input, derived)) / realized
```

`schedule_se_ss_wages` returns `float(self.w2_income)`, so the derived value moves by exactly the amount the source moved. The rounding error is common-mode and the ratio cancels it to exactly `1.0` — no tolerance to choose, `_input_nodes` keeps comparing to `1.0` outright, and a genuinely scaled slope such as `0.9235` still raises. The ulp-wide floor stops the bump vanishing above 2^53. This is platform-independent for a stronger reason than IEEE-754 conformance: numerator and denominator are the *same* subtraction on the *same* operands, so they agree bitwise whatever the platform does, and `x / x` is exactly `1.0` under any rounding mode.

Verified exactly `1.0` at both binade cases, `1e16`, `1e17`, `0.0` and `140000.0`; still `0.0` for Married/Joint and for no-SE-income.

## Aiming at the corner instead of buying it

**`49f1e3b`** adds `_BINADE_EDGE`, which generates incomes in the last unit before a power of two, sampling the *exponent* rather than hard-coding the value that failed:

```python
_BINADE_EDGE = st.builds(
    lambda exponent, offset: math.ldexp(1.0, exponent) - offset,
    st.sampled_from(range(1, 18)),
    st.floats(min_value=0.0, max_value=1.0, exclude_min=True, ...),
)
```

Reverting `83b584f` with this in place fails **both** autodiff properties in **15 seconds under the 500-example `ci` profile**, on a freshly emptied hypothesis database, at a *different* binade (`1.0000000000000002`) than the one originally reported — so it aims at the structure rather than replaying a stored example. Without it, the same defect cost the 10,000-example sweep 11 minutes and hit one property, once.

This is a distinct axis from tenforty-g79: g79 straddles **tax** thresholds (the SS wage base, NIIT and Additional Medicare, the LTCG breakpoints), which are facts about the code under test. Binade edges are facts about binary64 and apply to any probe-based derivative. Extending them past this one income vector is filed as **tenforty-e06**.

Also adds the **`soak`** profile (100,000 examples, ~2 hours), ad hoc like `deep`. `deep` clears a 2e-5 defect about one run in five — a coin flip, not a net, and this PR's own bug was found by luck. Soak is deliberately the instrument of last resort; once a corner is characterized, a strategy that lands on it beats reps by four orders of magnitude.

## Gates

Engine change, so the full discipline in CLAUDE.md. All three re-run on the final tree (`49f1e3b`):

| Gate | Result | |
|---|---|---|
| Deep hypothesis sweep, whole suite (10,000 examples) | 870 passed, 12 skipped, 24 xfailed — 12m04s | ✅ |
| OTS regression + cross-backend parity | 44 passed, 8 skipped, 11 xfailed — 20.7s | ✅ |
| taxcalc differential | **1 failed**, 11 passed, 1 xfailed — 3m53s | ❌ |
| `make run-hooks` | clean | ✅ |

**The taxcalc failure is not this PR's**, and I checked rather than assumed:

- Both backends produce *identical* taxable income (15,535.00) on the failing case. An engine divergence would show them disagreeing with each other, not agreeing against taxcalc.
- `git diff main...HEAD -- src/` is two files, `_input_nodes` and `derived_chain_factor`. Both are reached only from `graph.py:563` (`gradient`) and `graph.py:600` (`solve`). The differential calls `evaluate_return` → `evaluate`, which never touches either.

The harness maps our generic `itemized_deductions` onto taxcalc's `e19800` — **charitable cash contributions**, carrying the §170(b)(1)(G) 60%-of-AGI ceiling — while we map it to an uncapped Schedule A "other deductions" line. Confirmed by sweeping the ratio at fixed AGI: taxcalc *pins* at the ceiling rather than scaling, and below the cap the two agree to `0.00`. Filed as **tenforty-729.1**, a child of the existing F12 category-ambiguity bead.

It surfaced now because it needs `itemized > 0.60 × AGI`, which the strategy reaches rarely and the test's `target()` steers toward. The earlier clean taxcalc runs on `bd8ec2f` and `3fc807b` differ by hypothesis exploration, not by code.

## What I could not check

There is currently exactly one derived natural, so a derivation with a **non-unit constant slope** is unexercised by the real mapping tables. The guard test constructs a synthetic one to prove the rejection fires, but no real derivation demonstrates the *rejection being the right call* rather than a limitation worth lifting — that has to wait for a second derived natural to exist.

I have not verified that a `soak` run is as productive per example at 100,000 as `deep` is at 10,000; hypothesis re-treads its corpus and spends budget on shrinking, and I did not measure where that curve flattens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
