### PR TITLE
fix(test): carry itemized aggregate through uncapped taxcalc field

### DIFF
--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -211,11 +211,11 @@ itemized). All three engines take the same deduction and agree on taxable
 income — but OTS reports $1,634.46 of AMT where graph and taxcalc report
 none. Cause: the aggregate rides in a different Schedule A category per
 engine — OTS maps it to A6 ("other taxes", added back on Form 6251), graph
-to L16 ("other deductions", not added back), the taxcalc adapter to charity
-(not added back). None is wrong; the input model cannot say which kind of
-deduction it is. This is the categorized-deductions API gap made concrete,
-resolved by input model v2; until then the divergence is a documented
-assumption, excused by signature.
+to L16 ("other deductions", not added back), and the taxcalc adapter to
+interest paid through e19200 (not added back). None is wrong; the input model
+cannot say which kind of deduction it is. This is the categorized-deductions
+API gap made concrete, resolved by input model v2; until then the divergence
+is a documented assumption, excused by signature.
 
 ### F13. NEW — graph 2025 Married/Sep long-term-gain thresholds diverge
 

--- a/scripts/taxcalc_audit.py
+++ b/scripts/taxcalc_audit.py
@@ -15,8 +15,8 @@ Scope notes:
 - Federal only (taxcalc has no state model).
 - No dependents, no ISO gains, no rental/schedule-1 income (taxcalc mapping
   for those is ambiguous or absent).
-- Itemized deductions are mapped to taxcalc cash charity (e19800): no AGI
-  floor below 60%, so it's the cleanest single-aggregate carrier.
+- Itemized deductions are mapped to taxcalc interest paid (e19200), an
+  uncapped carrier for tenforty's uncategorized aggregate.
 - MFJ wage attribution: taxcalc requires per-spouse wages; tenforty's
   w2_income is a household aggregate. taxcalc runs under both attributions
   (all wages on the self-employed primary / all on the other spouse); a
@@ -277,7 +277,7 @@ def run_taxcalc(cases, wage_attribution="primary"):
                     "e00650": qd,
                     "p22250": c["stcg"],
                     "p23250": c["ltcg"],
-                    "e19800": c["itemized"],
+                    "e19200": c["itemized"],
                     "cmbtp": c["iso"],
                 }
             )

--- a/tests/taxcalc/adapter_conformance_test.py
+++ b/tests/taxcalc/adapter_conformance_test.py
@@ -131,3 +131,20 @@ def test_ots_matches_form_6251_on_the_same_case():
     assert evaluate_components(F14_CASE, "ots")["amt"] == pytest.approx(
         43_813.50, abs=1.0
     )
+
+
+def test_itemized_aggregate_is_not_charity_capped():
+    """The generic aggregate must survive taxcalc without a charitable ceiling."""
+    case = {
+        **F14_CASE,
+        "status": "Widow(er)",
+        "w2": 0.0,
+        "stcg": 74_196.0,
+        "itemized": 58_661.0,
+        "iso": 0.0,
+    }
+
+    result = taxcalc_batch([case])[0]
+
+    assert result["taxable_income"] == pytest.approx(15_535.0, abs=0.01)
+    assert result["income_tax"] == pytest.approx(1_553.5, abs=0.01)

--- a/tests/taxcalc/taxcalc_differential_test.py
+++ b/tests/taxcalc/taxcalc_differential_test.py
@@ -152,7 +152,10 @@ def taxcalc_batch(cases, wage_attribution="primary"):
                     "e00650": c["qual_div"],
                     "p22250": c["stcg"],
                     "p23250": c["ltcg"],
-                    "e19800": c["itemized"],
+                    # Carry the uncategorized aggregate through an uncapped
+                    # itemized field. Cash charity (e19800) would impose a
+                    # 60%-of-AGI ceiling that tenforty's aggregate does not have.
+                    "e19200": c["itemized"],
                     # AMT preference income (ISO exercise spread). Without this
                     # taxcalc is handed no preference at all and reports zero
                     # AMT, so every AMT case would compare tenforty with the

--- a/tests/taxcalc/taxcalc_policy.py
+++ b/tests/taxcalc/taxcalc_policy.py
@@ -73,10 +73,10 @@ def _f15_ots_itemized_taxable_income(backend: str, case: dict) -> set[str]:
     """F15: OTS applies itemized deductions the caller did not ask for.
 
     With a nonzero itemized aggregate, OTS deducts it whatever
-    `standard_or_itemized` says, while the taxcalc adapter carries the amount as
-    charity and so meets the 60%-of-AGI charitable ceiling. Taxable income
-    therefore diverges in both directions, and the deduction quantities
-    downstream of it follow.
+    `standard_or_itemized` says, while taxcalc takes the greater of the standard
+    deduction and the uncapped aggregate carried through e19200. Taxable income
+    therefore diverges when the caller requests standard treatment but the
+    aggregate exceeds it, and the downstream tax quantities follow.
 
     The same category mismatch as F12, surfacing on taxable income rather than
     AMT. Blocked on the Itemized-semantics decision (tenforty-ddj); tracked as
@@ -101,9 +101,9 @@ def _f12_itemized_category_amt(backend: str, case: dict) -> set[str]:
     """F12: per-engine Schedule A category for the itemized aggregate.
 
     OTS carries it as A6 "other taxes" (AMT add-back); graph as L16 "other
-    deductions"; the taxcalc adapter as charity. AMT legitimately diverges
-    whenever the amount is nonzero. API decision needed (categorized
-    deductions, input model v2).
+    deductions"; the taxcalc adapter as interest paid through e19200. AMT
+    legitimately diverges whenever the amount is nonzero. API decision needed
+    (categorized deductions, input model v2).
     """
     if backend == "ots" and case.get("itemized", 0):
         return {"amt", "income_tax", "total_tax"}

--- a/tests/taxcalc/taxcalc_policy.py
+++ b/tests/taxcalc/taxcalc_policy.py
@@ -70,17 +70,32 @@ def _f11_ots_hoh_bracket(backend: str, case: dict) -> set[str]:
 
 
 def _f15_ots_itemized_taxable_income(backend: str, case: dict) -> set[str]:
-    """F15: OTS applies itemized deductions the caller did not ask for.
+    """F15: OTS taxable income, excused wherever an itemized aggregate is present.
 
-    With a nonzero itemized aggregate, OTS deducts it whatever
-    `standard_or_itemized` says, while taxcalc takes the greater of the standard
-    deduction and the uncapped aggregate carried through e19200. Taxable income
-    therefore diverges when the caller requests standard treatment but the
-    aggregate exceeds it, and the downstream tax quantities follow.
+    WIDER THAN ANY DIVERGENCE WE CAN NOW REPRODUCE. The finding this signature
+    was written for was the charitable ceiling: the aggregate rode to taxcalc as
+    cash charity (e19800), which caps at 60% of AGI, so taxable income diverged
+    whenever the aggregate cleared that ceiling. Carrying it through the uncapped
+    e19200 instead (tenforty-pus) removed the cap, and with it the divergence.
+    All three engines now take the greater of the standard deduction and the
+    aggregate: checked three ways on Standard-flag cases with the aggregate above
+    the standard deduction, and OTS against graph over 1,500 randomized cases
+    with no self-employment income, where nothing disagreed.
 
-    The same category mismatch as F12, surfacing on taxable income rather than
-    AMT. Blocked on the Itemized-semantics decision (tenforty-ddj); tracked as
-    tenforty-z31.
+    What is left is F7's case and not this one — the caller asks for Itemized
+    with an aggregate BELOW the standard deduction, OTS itemizes anyway, and the
+    other two take the standard deduction. F7 already excuses the same three
+    quantities under that narrower condition.
+
+    So the predicate below is a blanket. It fires on a nonzero aggregate whatever
+    `standard_or_itemized` says, which means it also forgives OTS taxable-income
+    gaps that have nothing to do with deductions — the self-employment-deduction
+    difference, say — for any case that happens to carry one. Narrow it to F7's
+    condition or delete it and let F7 and F12 carry the ground, once the
+    differential has been run to confirm the gate stays green without it. That
+    check has not been done; until it is, this stays as-is rather than trading a
+    documented blanket for a red gate. Blocked on the Itemized-semantics decision
+    (tenforty-ddj); tracked as tenforty-z31.
     """
     if backend == "ots" and case.get("itemized", 0):
         return {"taxable_income", "income_tax", "total_tax"}


### PR DESCRIPTION
## Summary
- map the generic itemized-deduction aggregate to taxcalc e19200 instead of cash charity e19800
- pin the over-60%-of-AGI regression that previously made the differential gate red
- align the audit script, known-defect policy, and differential-audit documentation

Tracks tenforty-pus.

## Validation
- `make run-hooks-all-files`
- `uv run pytest tests/ -q --tb=line` — 874 passed, 12 skipped, 23 xfailed
- `TENFORTY_TAXCALC=1 uv run pytest tests/taxcalc/ -q --tb=line` — 13 passed, 1 xfailed