### PR TITLE
fix(graph): include state tax in total-tax autodiff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@
   `.link()`. The `tenforty` public tax API (`evaluate_return[s]`) is unaffected.
 
 ### Changed
+- **`marginal_rate` and `solve_for_income` now read `total_tax` as federal plus the
+  selected state's tax**, matching what `evaluate_return(...).total_tax` has always
+  returned. Both previously resolved the default `output="total_tax"` to the federal
+  1040 line alone, so with a state selected they answered a different question than
+  the one the field name names: for 2024 CA Single at $100,000 of wages,
+  `marginal_rate` returned `0.22` where the derivative of the public total is `0.313`,
+  and `solve_for_income(target_tax=20_000)` returned an income producing $27,792 of
+  total tax. Callers who calibrated against the old federal-only number will see it
+  move; pass `output="federal_total_tax"` to keep the previous meaning. `output` also
+  now accepts `federal_total_tax` and `state_total_tax`, which previously raised
+  `ValueError: Node not found`. Evaluation is unchanged. (#328)
 - Graph backend: an unset graph input now reads as `0.0` instead of raising.
   The resolved per-year graph carries every state's inputs (~800); a given return
   sets only the handful it uses. Mapping typos are still rejected at `set()` (an

--- a/crates/tenforty-graph/src/autodiff.rs
+++ b/crates/tenforty-graph/src/autodiff.rs
@@ -63,6 +63,19 @@ pub fn gradient_sum(
         .sum())
 }
 
+/// Compute the derivative of the sum of several outputs with respect to a
+/// quantity written into several input nodes.
+pub fn gradient_sum_outputs(
+    runtime: &mut Runtime,
+    outputs: &[NodeId],
+    inputs: &[NodeId],
+) -> Result<f64, EvalError> {
+    outputs
+        .iter()
+        .map(|output| gradient_sum(runtime, *output, inputs))
+        .sum()
+}
+
 fn backprop(
     op: &Op,
     _node_id: NodeId,
@@ -313,6 +326,16 @@ mod tests {
 
         let grad = gradient(&mut runtime, 2, 0).unwrap();
         assert_eq!(grad, 2.0);
+    }
+
+    #[test]
+    fn test_gradient_sum_outputs() {
+        let graph = simple_arithmetic_graph();
+        let mut runtime = Runtime::new(&graph, FilingStatus::Single);
+        runtime.set_by_id(0, 5.0);
+
+        let grad = gradient_sum_outputs(&mut runtime, &[0, 2], &[0]).unwrap();
+        assert_eq!(grad, 3.0);
     }
 
     #[test]

--- a/crates/tenforty-graph/src/python.rs
+++ b/crates/tenforty-graph/src/python.rs
@@ -653,6 +653,43 @@ impl Runtime {
         })
     }
 
+    /// Total derivative of the sum of `outputs` with respect to a quantity
+    /// written into several input nodes.
+    fn gradient_multi_output(
+        &mut self,
+        outputs: Vec<String>,
+        inputs: Vec<String>,
+    ) -> PyResult<f64> {
+        self.inner.with_runtime_mut(|rt| {
+            if outputs.is_empty() {
+                return Err(PyValueError::new_err(
+                    "At least one output node is required",
+                ));
+            }
+            let output_ids = outputs
+                .iter()
+                .map(|name| {
+                    rt.graph()
+                        .node_id_by_name(name)
+                        .ok_or_else(|| PyValueError::new_err(format!("Node not found: {}", name)))
+                })
+                .collect::<PyResult<Vec<_>>>()?;
+            let input_ids: Vec<_> = inputs
+                .iter()
+                .filter_map(|name| rt.graph().node_id_by_name(name))
+                .collect();
+            if input_ids.is_empty() {
+                return Err(PyValueError::new_err(format!(
+                    "None of the input nodes were found: {}",
+                    inputs.join(", ")
+                )));
+            }
+
+            autodiff::gradient_sum_outputs(rt, &output_ids, &input_ids)
+                .map_err(|e| PyValueError::new_err(format!("{}", e)))
+        })
+    }
+
     /// Solve for the value of a quantity written into several input nodes.
     ///
     /// Each Newton step assigns the trial value to every named node and steps
@@ -683,6 +720,46 @@ impl Runtime {
             }
 
             solver::solve_multi(rt, output_id, target, &input_ids, guess)
+                .map_err(|e| PyValueError::new_err(format!("{}", e)))
+        })
+    }
+
+    /// Solve for an input quantity against the sum of several output nodes.
+    #[pyo3(signature = (outputs, target, for_inputs, initial_guess=None))]
+    fn solve_multi_output(
+        &mut self,
+        outputs: Vec<String>,
+        target: f64,
+        for_inputs: Vec<String>,
+        initial_guess: Option<f64>,
+    ) -> PyResult<f64> {
+        let guess = initial_guess.unwrap_or(target);
+        self.inner.with_runtime_mut(|rt| {
+            if outputs.is_empty() {
+                return Err(PyValueError::new_err(
+                    "At least one output node is required",
+                ));
+            }
+            let output_ids = outputs
+                .iter()
+                .map(|name| {
+                    rt.graph()
+                        .node_id_by_name(name)
+                        .ok_or_else(|| PyValueError::new_err(format!("Node not found: {}", name)))
+                })
+                .collect::<PyResult<Vec<_>>>()?;
+            let input_ids: Vec<_> = for_inputs
+                .iter()
+                .filter_map(|name| rt.graph().node_id_by_name(name))
+                .collect();
+            if input_ids.is_empty() {
+                return Err(PyValueError::new_err(format!(
+                    "None of the input nodes were found: {}",
+                    for_inputs.join(", ")
+                )));
+            }
+
+            solver::solve_multi_output(rt, &output_ids, target, &input_ids, guess)
                 .map_err(|e| PyValueError::new_err(format!("{}", e)))
         })
     }

--- a/crates/tenforty-graph/src/solver.rs
+++ b/crates/tenforty-graph/src/solver.rs
@@ -1,4 +1,4 @@
-use crate::autodiff::gradient_sum;
+use crate::autodiff::gradient_sum_outputs;
 use crate::eval::{EvalError, Runtime};
 use crate::graph::NodeId;
 use thiserror::Error;
@@ -61,9 +61,20 @@ pub fn solve_multi(
     inputs: &[NodeId],
     initial_guess: f64,
 ) -> Result<f64, SolveError> {
-    solve_with_config(
+    solve_multi_output(runtime, &[output], target, inputs, initial_guess)
+}
+
+/// Solve for an input quantity against the sum of several output nodes.
+pub fn solve_multi_output(
+    runtime: &mut Runtime,
+    outputs: &[NodeId],
+    target: f64,
+    inputs: &[NodeId],
+    initial_guess: f64,
+) -> Result<f64, SolveError> {
+    solve_multi_output_with_config(
         runtime,
-        output,
+        outputs,
         target,
         inputs,
         initial_guess,
@@ -71,9 +82,9 @@ pub fn solve_multi(
     )
 }
 
-pub fn solve_with_config(
+pub fn solve_multi_output_with_config(
     runtime: &mut Runtime,
-    output: NodeId,
+    outputs: &[NodeId],
     target: f64,
     inputs: &[NodeId],
     initial_guess: f64,
@@ -85,14 +96,16 @@ pub fn solve_with_config(
         for &input in inputs {
             runtime.set_by_id(input, x);
         }
-        let y = runtime.eval_node(output)?;
+        let y = outputs.iter().try_fold(0.0, |sum, output| {
+            runtime.eval_node(*output).map(|value| sum + value)
+        })?;
         let error = y - target;
 
         if error.abs() < config.tolerance {
             return Ok(x);
         }
 
-        let grad = gradient_sum(runtime, output, inputs)?;
+        let grad = gradient_sum_outputs(runtime, outputs, inputs)?;
 
         if grad.abs() < config.min_step {
             return Err(SolveError::ZeroGradient);
@@ -102,7 +115,6 @@ pub fn solve_with_config(
         let clamped_step = step.clamp(-config.max_step, config.max_step);
         x -= clamped_step;
 
-        // Clamp to bounds
         if let Some(lb) = config.lower_bound {
             x = x.max(lb);
         }
@@ -112,6 +124,17 @@ pub fn solve_with_config(
     }
 
     Err(SolveError::NoConvergence(config.max_iterations))
+}
+
+pub fn solve_with_config(
+    runtime: &mut Runtime,
+    output: NodeId,
+    target: f64,
+    inputs: &[NodeId],
+    initial_guess: f64,
+    config: &SolverConfig,
+) -> Result<f64, SolveError> {
+    solve_multi_output_with_config(runtime, &[output], target, inputs, initial_guess, config)
 }
 
 /// Binary search fallback for non-smooth regions.
@@ -271,6 +294,15 @@ mod tests {
 
         let x = solve(&mut runtime, 4, 100.0, 0, 0.0).unwrap();
         assert!((x - 45.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_solve_multi_output() {
+        let graph = linear_graph();
+        let mut runtime = Runtime::new(&graph, FilingStatus::Single);
+
+        let x = solve_multi_output(&mut runtime, &[2, 4], 100.0, &[0], 0.0).unwrap();
+        assert!((x - 22.5).abs() < 1e-6);
     }
 
     #[test]

--- a/src/tenforty/backends/graph.py
+++ b/src/tenforty/backends/graph.py
@@ -47,6 +47,7 @@ FEDERAL_OUTPUT_NODES: dict[str, str] = {
     "us_form_8960_L17_niit": "federal_niit",
     "us_form_8959_L18_total_additional_medicare": "federal_additional_medicare_tax",
 }
+_FEDERAL_FIELD_TO_NODE = {field: node for node, field in FEDERAL_OUTPUT_NODES.items()}
 
 _STATE_ZERO_FIELDS = (
     "state_adjusted_gross_income",
@@ -69,6 +70,19 @@ def _state_output_node(form_name: str, line_name: str) -> str:
     if "_" in line_name and not line_name.startswith("L"):
         return line_name
     return f"{form_name}_{line_name}"
+
+
+def _state_output_node_for_field(state: OTSState, field: str) -> str:
+    """Resolve a public state output field to its selected state's graph node."""
+    form_name = STATE_FORM_NAMES.get(state)
+    if form_name is None:
+        raise ValueError(f"Graph backend does not support state: {state.value}")
+
+    for line_name, result_field in STATE_OUTPUT_LINES.get(state, {}).items():
+        if result_field == field:
+            return _state_output_node(form_name, line_name)
+
+    raise ValueError(f"State {state.value} does not provide output field {field!r}")
 
 
 def _federal_effective_tax_rate(total_tax: float, agi: float) -> float:
@@ -538,6 +552,35 @@ class GraphBackend:
 
         return [self._resolve_input_node(tax_input, var, output_node)]
 
+    def _output_nodes(self, tax_input: TaxReturnInput, output: str) -> list[str]:
+        """Resolve a public output to the graph nodes whose sum it denotes."""
+        if output.startswith(_ALL_KNOWN_PREFIXES):
+            return [output]
+
+        has_state = bool(tax_input.state and tax_input.state != OTSState.NONE)
+        if output == "total_tax":
+            nodes = [_FEDERAL_FIELD_TO_NODE["federal_total_tax"]]
+            if has_state:
+                nodes.append(
+                    _state_output_node_for_field(tax_input.state, "state_total_tax")
+                )
+            return nodes
+
+        federal_node = _FEDERAL_FIELD_TO_NODE.get(output)
+        if federal_node:
+            return [federal_node]
+
+        if output.startswith("state_"):
+            if not has_state:
+                raise ValueError(f"Output {output!r} requires a state return")
+            return [_state_output_node_for_field(tax_input.state, output)]
+
+        for line, natural in LINE_TO_NATURAL.items():
+            if natural == output:
+                return [f"us_1040_{line}"]
+
+        return [f"us_1040_{output}"]
+
     def gradient(
         self, tax_input: TaxReturnInput, output: str, wrt: str
     ) -> float | None:
@@ -546,23 +589,10 @@ class GraphBackend:
             return None
 
         evaluator, _ = self._create_evaluator(tax_input)
+        output_nodes = self._output_nodes(tax_input, output)
+        input_nodes = self._input_nodes(tax_input, wrt, output_nodes[0])
 
-        if output.startswith(_ALL_KNOWN_PREFIXES):
-            output_node = output
-        else:
-            output_node = None
-            for line, natural in LINE_TO_NATURAL.items():
-                if natural == output:
-                    output_node = line
-                    break
-            if output_node is None:
-                output_node = f"us_1040_{output}"
-            else:
-                output_node = f"us_1040_{output_node}"
-
-        input_nodes = self._input_nodes(tax_input, wrt, output_node)
-
-        return evaluator.gradient_multi(output_node, input_nodes)
+        return evaluator.gradient_multi_output(output_nodes, input_nodes)
 
     def solve(
         self, tax_input: TaxReturnInput, output: str, target: float, var: str
@@ -583,21 +613,8 @@ class GraphBackend:
             return None
 
         evaluator, _ = self._create_evaluator(tax_input)
-
-        if output.startswith(_ALL_KNOWN_PREFIXES):
-            output_node = output
-        else:
-            output_node = None
-            for line, natural in LINE_TO_NATURAL.items():
-                if natural == output:
-                    output_node = line
-                    break
-            if output_node is None:
-                output_node = f"us_1040_{output}"
-            else:
-                output_node = f"us_1040_{output_node}"
-
-        input_nodes = self._input_nodes(tax_input, var, output_node)
+        output_nodes = self._output_nodes(tax_input, output)
+        input_nodes = self._input_nodes(tax_input, var, output_nodes[0])
 
         natural_values = tax_input.model_dump(
             exclude={"year", "state", "filing_status", "standard_or_itemized"}
@@ -621,8 +638,8 @@ class GraphBackend:
             initial_guess = tax_estimate
 
         try:
-            return evaluator.solve_multi(
-                output_node, target, input_nodes, initial_guess
+            return evaluator.solve_multi_output(
+                output_nodes, target, input_nodes, initial_guess
             )
         except Exception as exc:
             msg = str(exc)

--- a/tests/state_total_autodiff_test.py
+++ b/tests/state_total_autodiff_test.py
@@ -1,0 +1,88 @@
+"""State-aware total-tax autodiff and solver contract."""
+
+import pytest
+
+from tenforty import evaluate_return, marginal_rate, solve_for_income
+
+
+def _total_tax_at_wages(state: str, wages: float) -> float:
+    return evaluate_return(
+        year=2024,
+        state=state,
+        filing_status="Single",
+        w2_income=wages,
+        backend="graph",
+    ).total_tax
+
+
+def test_state_total_marginal_matches_finite_difference():
+    """The default marginal rate includes the selected state's tax."""
+    wages = 100_000.0
+    step = 1.0
+    finite_difference = (
+        _total_tax_at_wages("CA", wages + step)
+        - _total_tax_at_wages("CA", wages - step)
+    ) / (2 * step)
+
+    rate = marginal_rate(
+        year=2024,
+        state="CA",
+        filing_status="Single",
+        w2_income=wages,
+    )
+
+    assert rate == pytest.approx(finite_difference, abs=1e-9)
+    assert rate == pytest.approx(0.313, abs=1e-9)
+
+
+def test_explicit_federal_output_excludes_state_tax():
+    """Explicit federal outputs preserve their federal-only meaning."""
+    kwargs = {
+        "year": 2024,
+        "state": "CA",
+        "filing_status": "Single",
+        "w2_income": 100_000.0,
+    }
+
+    federal_field = marginal_rate(**kwargs, output="federal_total_tax")
+    federal_node = marginal_rate(**kwargs, output="us_1040_L24_total_tax")
+
+    assert federal_field == pytest.approx(0.22, abs=1e-9)
+    assert federal_node == pytest.approx(federal_field, abs=1e-9)
+
+
+def test_no_tax_state_total_matches_federal():
+    """A no-income-tax state contributes zero to the total derivative."""
+    kwargs = {
+        "year": 2024,
+        "state": "FL",
+        "filing_status": "Single",
+        "w2_income": 100_000.0,
+    }
+
+    total_rate = marginal_rate(**kwargs)
+    federal_rate = marginal_rate(**kwargs, output="federal_total_tax")
+
+    assert total_rate == pytest.approx(federal_rate, abs=1e-9)
+
+
+def test_state_total_solver_roundtrips_public_total():
+    """Income solving targets the public federal-plus-state total."""
+    target = 20_000.0
+    solved_wages = solve_for_income(
+        target_tax=target,
+        year=2024,
+        state="CA",
+        filing_status="Single",
+    )
+
+    result = evaluate_return(
+        year=2024,
+        state="CA",
+        filing_status="Single",
+        w2_income=solved_wages,
+        backend="graph",
+    )
+
+    assert result.total_tax == pytest.approx(target, abs=0.01)
+    assert result.federal_total_tax < target

--- a/tests/state_total_autodiff_test.py
+++ b/tests/state_total_autodiff_test.py
@@ -3,6 +3,9 @@
 import pytest
 
 from tenforty import evaluate_return, marginal_rate, solve_for_income
+from tenforty.mappings import STATE_GRAPH_CONFIGS
+
+GRAPH_STATES = sorted(state.value for state in STATE_GRAPH_CONFIGS if state.value)
 
 
 def _total_tax_at_wages(state: str, wages: float) -> float:
@@ -86,3 +89,52 @@ def test_state_total_solver_roundtrips_public_total():
 
     assert result.total_tax == pytest.approx(target, abs=0.01)
     assert result.federal_total_tax < target
+
+
+@pytest.mark.parametrize("state", GRAPH_STATES)
+def test_total_marginal_decomposes_into_federal_plus_state(state):
+    """Every state's total-tax derivative is its two parts, and nothing else.
+
+    `total_tax` is now resolved in two places that must not drift: `evaluate`
+    adds the federal and state totals in Python, and `_output_nodes` names the
+    two graph nodes for the derivative and the solver. This pins the second to
+    the first for EVERY state in `STATE_GRAPH_CONFIGS`, so a state added or
+    rewired without a matching output line cannot slip through unguarded.
+
+    Deliberately not a finite difference. Several state graphs are genuinely
+    non-differentiable at round wage figures — CT's bracket edge at $30,000 of
+    wages, NY's standard-deduction crossover — where autodiff takes one side and
+    a central difference straddles both. A test built on finite differences is
+    hostage to those points forever; this identity holds at every one of them,
+    because `gradient_sum_outputs` sums exactly the two partials taken here.
+    """
+    kwargs = {
+        "year": 2024,
+        "state": state,
+        "filing_status": "Single",
+        "w2_income": 100_000.0,
+    }
+
+    total = marginal_rate(**kwargs)
+    federal = marginal_rate(**kwargs, output="federal_total_tax")
+    state_rate = marginal_rate(**kwargs, output="state_total_tax")
+
+    assert total == pytest.approx(federal + state_rate, abs=1e-12)
+
+
+@pytest.mark.parametrize("state", GRAPH_STATES)
+def test_solver_targets_the_public_total_in_every_state(state):
+    """Solving for income lands on the total the caller can actually observe.
+
+    The failure this pins is not a rounding one: resolving `total_tax` to the
+    federal line alone made the solver converge on a root of a function the
+    library does not expose. For 2024 CA Single it returned the income for
+    $20,000 of FEDERAL tax, whose public total is $27,792 -- off by 39%.
+    """
+    target = 20_000.0
+
+    wages = solve_for_income(
+        target_tax=target, year=2024, state=state, filing_status="Single"
+    )
+
+    assert _total_tax_at_wages(state, wages) == pytest.approx(target, abs=0.01)


### PR DESCRIPTION
## Summary
- resolve public `total_tax` as federal plus selected-state tax for marginal rates and income solving
- add summed-output autodiff and Newton solver support through Rust and Python bindings
- preserve explicit federal-node behavior and cover California plus no-income-tax states

## Validation
- `cd crates/tenforty-graph && cargo test` — 26 passed
- targeted graph/autodiff suite — 44 passed, 2 skipped, 1 xfailed
- `make test-deep` — 878 passed, 12 skipped, 23 xfailed
- `make run-hooks-all-files` — passed
- strict ad-hoc Clippy remains blocked by nine pre-existing warnings in untouched PyO3/WASM code

## Merge order
Please merge #327 first. The state-total diff is independent, but #327 clears the existing Tax-Calculator adapter failure on `main`.

Tracks tenforty-nnq.