### PR TITLE
fix(graph): follow qualified-dividend validation in autodiff

### DIFF
--- a/src/tenforty/mappings.py
+++ b/src/tenforty/mappings.py
@@ -91,6 +91,14 @@ def derived_chain_factor(tax_input: TaxReturnInput, derived: str, source: str) -
     pydantic validation, which exposes the local slope of validator-mediated
     derivations without stepping across a nearby inactive clamp.
 
+    THE `model_copy` BRANCH STILL CANNOT SEE A VALIDATOR. It is reached only when the
+    derived natural is not a concrete field, so nothing entered here today needs it to
+    — a computed field recomputes on attribute access. But a computed field that reads
+    a concrete field some `model_validator` adjusts would have its coupling probed as a
+    constant zero and dropped in silence, which is the shape that cost us tenforty-3gt.
+    Reconstructing through validation on both branches would close it; that is a change
+    to the `schedule_se_ss_wages` path and wants its own commit, not this note.
+
     Note this is deliberately not `getattr(tax_input, derived) != 0`: with
     `w2_income` at zero the derived value is zero while the slope is still 1, and
     that is a live gradient, not a dead one.

--- a/src/tenforty/mappings.py
+++ b/src/tenforty/mappings.py
@@ -57,25 +57,21 @@ for name, nodes in _SUBORDINATE_NODES.items():
     if name not in NATURAL_TO_NODES:
         NATURAL_TO_NODES[name] = list(nodes)
 
-# Naturals that are COMPUTED from another natural rather than supplied by the
-# caller (pydantic computed fields on TaxReturnInput), mapped to the natural they
-# derive from. Evaluation reaches their nodes on its own, but a derivative with
-# respect to the SOURCE natural has to follow the derived natural's nodes too, or
-# it silently drops the coupling those nodes carry — d(se_tax)/d(w2_income) losing
-# the shared social security wage base is exactly that (tenforty-hrp).
+# Naturals that are derived from another natural rather than supplied independently
+# by the caller, mapped to the natural they derive from. Evaluation reaches their
+# nodes on its own, but a derivative with respect to the SOURCE natural has to follow
+# the derived natural's nodes too, or it silently drops the coupling those nodes carry
+# — d(se_tax)/d(w2_income) losing the shared social security wage base is exactly that
+# (tenforty-hrp).
 #
 # The chain factor is not stored here: it is read off the model at call time
 # (`derived_chain_factor`), so this table cannot drift from the derivation in
 # models.py. Only identity derivations can be expressed downstream, because
 # `gradient_sum` adds one unweighted adjoint per node.
 #
-# COMPUTED FIELDS ONLY. A derivation applied by a `model_validator` rather than a
-# computed field cannot be entered here: `derived_chain_factor` probes with
-# `model_copy`, which does not re-run validators, so the entry would read as a
-# constant zero and be skipped in silence. `ensure_ordinary_includes_qualified` is
-# exactly that shape and is tracked separately (tenforty-3gt).
 DERIVED_NATURAL_SOURCES: dict[str, str] = {
     "schedule_se_ss_wages": "w2_income",
+    "ordinary_dividends": "qualified_dividends",
 }
 
 
@@ -89,18 +85,11 @@ def derived_chain_factor(tax_input: TaxReturnInput, derived: str, source: str) -
     rule here could fall out of step with `models.py` without anything failing.
 
     The slope is taken against the bump that SURVIVED rounding, not the one requested,
-    and that is what makes it EXACT: an identity derivation moves the derived value by
-    precisely the amount the source moved, so the ratio is 1.0 with no tolerance to
-    choose. Dividing by the requested bump instead reads 1.0000000000009095 whenever
-    `source + bump` crosses a power of two, and 0.0 above 2**53 where a unit bump
-    rounds away to nothing — both of which used to read as "not 1" and drop the
-    coupling in silence. The bump is at least one ulp wide so it can never vanish.
-
-    That guarantee covers pydantic COMPUTED FIELDS, which recompute on attribute
-    access. It does not extend to derivations applied by a `model_validator`:
-    `model_copy` does not re-run validators, so the probe reads a slope of zero and
-    the caller skips the edge without complaint. See the note on
-    `DERIVED_NATURAL_SOURCES` and tenforty-3gt.
+    and that is what makes an identity derivation exact with no tolerance to choose.
+    Computed fields and properties use a stable bump of at least one dollar. Concrete
+    model fields use the next representable source value and reconstruct through
+    pydantic validation, which exposes the local slope of validator-mediated
+    derivations without stepping across a nearby inactive clamp.
 
     Note this is deliberately not `getattr(tax_input, derived) != 0`: with
     `w2_income` at zero the derived value is zero while the slope is still 1, and
@@ -112,8 +101,14 @@ def derived_chain_factor(tax_input: TaxReturnInput, derived: str, source: str) -
     a mapping defect to surface rather than a coupling to drop in silence.
     """
     current = float(getattr(tax_input, source))
-    bump = max(1.0, math.ulp(current))
-    bumped = tax_input.model_copy(update={source: current + bump})
+    if derived in type(tax_input).model_fields:
+        bump = math.ulp(current)
+        bumped_values = tax_input.model_dump(round_trip=True)
+        bumped_values[source] = current + bump
+        bumped = type(tax_input).model_validate(bumped_values)
+    else:
+        bump = max(1.0, math.ulp(current))
+        bumped = tax_input.model_copy(update={source: current + bump})
 
     realized = float(getattr(bumped, source)) - current
     factor = (getattr(bumped, derived) - getattr(tax_input, derived)) / realized

--- a/tests/graph_autodiff_fanout_test.py
+++ b/tests/graph_autodiff_fanout_test.py
@@ -293,6 +293,59 @@ def test_w2_gradient_includes_schedule_se_wage_base():
     )
 
 
+@skip_if_graph_unavailable
+@pytest.mark.parametrize("year", [2024, 2025])
+def test_qualified_dividend_gradient_follows_ordinary_dividend_clamp(year):
+    """Qualified dividends feed ordinary income when line 3b is omitted."""
+    case = dict(
+        year=year,
+        filing_status="Single",
+        w2_income=120_000.0,
+        qualified_dividends=20_000.0,
+    )
+
+    gradient = _gradient("qualified_dividends", **case)
+
+    assert gradient == pytest.approx(
+        _finite_difference("qualified_dividends", **case), abs=1e-6
+    )
+    assert gradient == pytest.approx(0.15, abs=1e-6)
+
+
+@skip_if_graph_unavailable
+def test_qualified_dividend_gradient_leaves_larger_ordinary_dividend_fixed():
+    """The derived edge is inactive when line 3b already exceeds line 3a."""
+    case = dict(
+        year=2024,
+        filing_status="Single",
+        w2_income=120_000.0,
+        qualified_dividends=20_000.0,
+        ordinary_dividends=30_000.0,
+    )
+
+    gradient = _gradient("qualified_dividends", **case)
+
+    assert gradient == pytest.approx(
+        _finite_difference("qualified_dividends", **case), abs=1e-6
+    )
+    assert gradient == pytest.approx(-0.09, abs=1e-6)
+
+
+@skip_if_graph_unavailable
+def test_solve_recovers_qualified_dividends_through_ordinary_dividend_clamp():
+    """Solving varies both dividend lines when line 3b is derived from line 3a."""
+    known = dict(
+        year=2024,
+        filing_status="Single",
+        w2_income=120_000.0,
+        qualified_dividends=20_000.0,
+    )
+
+    solved = _solve_for("qualified_dividends", **known)
+
+    assert solved == pytest.approx(known["qualified_dividends"], abs=0.01)
+
+
 def test_derived_chain_factor_rejects_a_slope_it_cannot_carry():
     """A derivation the adjoint sum cannot express must raise, not be skipped.
 
@@ -313,6 +366,27 @@ def test_derived_chain_factor_rejects_a_slope_it_cannot_carry():
 
     with pytest.raises(NotImplementedError, match=r"only 0 or 1 can be carried"):
         derived_chain_factor(tax_input, "scaled_wages", "w2_income")
+
+
+@pytest.mark.parametrize(
+    ("ordinary_dividends", "expected"),
+    [(20_000.0, 1.0), (20_000.5, 0.0)],
+)
+def test_derived_chain_factor_revalidates_dividend_clamp(ordinary_dividends, expected):
+    """The probe follows the validator without crossing a nearby inactive clamp."""
+    from tenforty.mappings import derived_chain_factor
+
+    tax_input = TaxReturnInput(
+        year=2024,
+        filing_status="Single",
+        qualified_dividends=20_000.0,
+        ordinary_dividends=ordinary_dividends,
+    )
+
+    assert (
+        derived_chain_factor(tax_input, "ordinary_dividends", "qualified_dividends")
+        == expected
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/graph_autodiff_properties_test.py
+++ b/tests/graph_autodiff_properties_test.py
@@ -113,6 +113,22 @@ _INCOME_VECTOR = st.fixed_dictionaries(
 
 _STEP = 10.0
 
+# The one marginal rate that may be negative. When line 3b already exceeds line 3a,
+# a dollar added to line 3a RECLASSIFIES a dollar of ordinary dividend income as
+# preferential rather than adding any, so the tax can only fall. The most it can fall
+# by is the widest gap between an ordinary bracket and the preferential rate that
+# applies at the same taxable income: 35% against 15%, which is 2024 Single between
+# $243,725 and $518,900 of taxable income. QBI pushes the other way (a larger net
+# capital gain tightens the line 15 limit) and NIIT is neutral to the reclassification,
+# so neither widens it.
+#
+# A structured search over statuses, years, wage levels and dividend splits lands
+# exactly on -0.20 and never below, so the derivation above IS the extremum and a bound
+# of -0.20 would pass with zero float headroom. The extra cent buys margin against an
+# adjoint sum that rounds the wrong way under `soak`, without admitting any slope the
+# tax law can produce.
+_RECLASSIFICATION_FLOOR = -0.21
+
 # 2024 Social Security wage base. Below it, W2 wages and self-employment income
 # share the 12.4% SS ceiling, coupling the two — the region where the autodiff
 # used to drop the derived w2 -> Schedule SE edge (tenforty-hrp).
@@ -202,10 +218,8 @@ def test_marginal_rate_within_bounds(filing_status, wrt, incomes):
     case = dict(year=2024, filing_status=filing_status, **incomes)
 
     marginal = _gradient(wrt, case)
-    # When line 3b is already larger, increasing line 3a reclassifies rather than
-    # adds income, so the preferential-rate delta can legitimately be negative.
     lower_bound = (
-        -0.2
+        _RECLASSIFICATION_FLOOR
         if wrt == "qualified_dividends"
         and case["ordinary_dividends"] > case["qualified_dividends"]
         else -1e-6

--- a/tests/graph_autodiff_properties_test.py
+++ b/tests/graph_autodiff_properties_test.py
@@ -55,6 +55,7 @@ INCOME_NATURALS = [
     "w2_income",
     "self_employment_income",
     "taxable_interest",
+    "qualified_dividends",
     "ordinary_dividends",
     "long_term_capital_gains",
     "short_term_capital_gains",
@@ -95,9 +96,20 @@ _INCOME = st.one_of(
     _BINADE_EDGE,
 )
 
+
+def _normalize_dividend_boxes(incomes: dict[str, float]) -> dict[str, float]:
+    """Keep generated Form 1040 line 3b inclusive of line 3a."""
+    return {
+        **incomes,
+        "ordinary_dividends": max(
+            incomes["ordinary_dividends"], incomes["qualified_dividends"]
+        ),
+    }
+
+
 _INCOME_VECTOR = st.fixed_dictionaries(
     {natural: _INCOME for natural in INCOME_NATURALS}
-)
+).map(_normalize_dividend_boxes)
 
 _STEP = 10.0
 
@@ -190,8 +202,17 @@ def test_marginal_rate_within_bounds(filing_status, wrt, incomes):
     case = dict(year=2024, filing_status=filing_status, **incomes)
 
     marginal = _gradient(wrt, case)
-    assert -1e-6 <= marginal <= 0.5, (
-        f"marginal d(total_tax)/d({wrt}) = {marginal:.6f} is outside [0, 0.5] at {case}"
+    # When line 3b is already larger, increasing line 3a reclassifies rather than
+    # adds income, so the preferential-rate delta can legitimately be negative.
+    lower_bound = (
+        -0.2
+        if wrt == "qualified_dividends"
+        and case["ordinary_dividends"] > case["qualified_dividends"]
+        else -1e-6
+    )
+    assert lower_bound <= marginal <= 0.5, (
+        f"marginal d(total_tax)/d({wrt}) = {marginal:.6f} is outside "
+        f"[{lower_bound}, 0.5] at {case}"
     )
 
 


### PR DESCRIPTION
## Summary
- revalidate concrete derived fields when probing local chain factors, so model validators participate in autodiff
- carry qualified dividends through the ordinary-dividend nodes only while the line 3b inclusion clamp is active
- cover 2024/2025 gradients, the independently larger line 3b case, income solving, and qualified dividends in the deep property matrix

## Validation
- targeted autodiff/fanout suite — 42 passed, 2 xfailed
- `make test-deep` — 880 passed, 12 skipped, 23 xfailed
- `make run-hooks-all-files` — passed
- parity is included in the deep suite; the Tax-Calculator value oracle is not affected because this changes derivative/solver routing, not return evaluation

## Merge order
This is independently based on `main`; intended to follow #327 and #328.

Tracks tenforty-3gt.