### PR TITLE
fix(graph): take composed right derivatives at active kinks

### DIFF
--- a/crates/tenforty-graph/src/autodiff.rs
+++ b/crates/tenforty-graph/src/autodiff.rs
@@ -36,7 +36,7 @@ pub fn adjoints(runtime: &mut Runtime, output: NodeId) -> Result<HashMap<NodeId,
 
 /// Compute the gradient of an output node with respect to an input node.
 /// Uses reverse-mode automatic differentiation in smooth regions and the
-/// composed function's symmetric numerical derivative at an active max tie.
+/// composed function's right-hand numerical derivative at an active kink.
 pub fn gradient(runtime: &mut Runtime, output: NodeId, input: NodeId) -> Result<f64, EvalError> {
     gradient_sum(runtime, output, &[input])
 }
@@ -58,17 +58,19 @@ pub fn gradient_sum(
     inputs: &[NodeId],
 ) -> Result<f64, EvalError> {
     let adjoints = adjoints(runtime, output)?;
-    if has_active_max_tie(runtime, &adjoints, inputs)? {
-        return numerical_gradient_sum(runtime, output, inputs);
-    }
-
-    Ok(inputs
+    let reverse_gradient = inputs
         .iter()
         .map(|input| adjoints.get(input).copied().unwrap_or(0.0))
-        .sum())
+        .sum();
+
+    if has_active_kink(runtime, &adjoints, inputs)? {
+        return forward_gradient(runtime, output, inputs);
+    }
+
+    Ok(reverse_gradient)
 }
 
-fn has_active_max_tie(
+fn has_active_kink(
     runtime: &Runtime,
     adjoints: &HashMap<NodeId, f64>,
     inputs: &[NodeId],
@@ -89,13 +91,46 @@ fn has_active_max_tie(
             reachable.insert(node_id);
         }
 
-        let Op::Max { left, right } = &node.op else {
+        if !reachable.contains(&node_id) || adjoints.get(&node_id).copied().unwrap_or(0.0) == 0.0 {
             continue;
+        }
+
+        let is_tie = match &node.op {
+            Op::Max { left, right } | Op::Min { left, right } => {
+                values.get(left).copied().unwrap_or(0.0)
+                    == values.get(right).copied().unwrap_or(0.0)
+            }
+            Op::Abs { arg } => values.get(arg).copied().unwrap_or(0.0) == 0.0,
+            Op::Clamp { arg, min, max } => {
+                let value = values.get(arg).copied().unwrap_or(0.0);
+                value == *min || value == *max
+            }
+            Op::BracketTax { table, income } => {
+                let income = values.get(income).copied().unwrap_or(0.0);
+                runtime.graph().tables.get(table).is_some_and(|table| {
+                    table
+                        .brackets
+                        .get(runtime.filing_status())
+                        .iter()
+                        .any(|bracket| bracket.threshold.is_finite() && income == bracket.threshold)
+                })
+            }
+            Op::PhaseOut {
+                base,
+                threshold,
+                rate,
+                agi,
+            } => {
+                let agi = values.get(agi).copied().unwrap_or(0.0);
+                let threshold = *threshold.get(runtime.filing_status());
+                agi == threshold || (*rate != 0.0 && agi == threshold + base / rate)
+            }
+            Op::IfPositive { cond, .. } => {
+                reachable.contains(cond) && values.get(cond).copied().unwrap_or(0.0) == 0.0
+            }
+            _ => false,
         };
-        if reachable.contains(&node_id)
-            && adjoints.get(&node_id).copied().unwrap_or(0.0) != 0.0
-            && values.get(left).copied().unwrap_or(0.0) == values.get(right).copied().unwrap_or(0.0)
-        {
+        if is_tie {
             return Ok(true);
         }
     }
@@ -103,7 +138,7 @@ fn has_active_max_tie(
     Ok(false)
 }
 
-fn numerical_gradient_sum(
+fn forward_gradient(
     runtime: &mut Runtime,
     output: NodeId,
     inputs: &[NodeId],
@@ -129,19 +164,13 @@ fn numerical_gradient_sum(
     let f_plus = runtime.eval_node(output);
 
     for (input, original) in &originals {
-        runtime.set_by_id(*input, original - epsilon);
-    }
-    let f_minus = runtime.eval_node(output);
-
-    for (input, original) in &originals {
         runtime.set_by_id(*input, *original);
     }
-    let restored = runtime.eval_node(output);
+    let f_original = runtime.eval_node(output);
 
     let f_plus = f_plus?;
-    let f_minus = f_minus?;
-    restored?;
-    Ok((f_plus - f_minus) / (2.0 * epsilon))
+    let f_original = f_original?;
+    Ok((f_plus - f_original) / epsilon)
 }
 
 /// Compute the derivative of the sum of several outputs with respect to a
@@ -431,6 +460,36 @@ mod tests {
         }
     }
 
+    fn minimum_graph() -> Graph {
+        let nodes = [
+            (0, Op::Input, Some("x")),
+            (1, Op::Literal { value: 0.0 }, Some("zero")),
+            (2, Op::Min { left: 0, right: 1 }, Some("nonpositive_x")),
+        ]
+        .into_iter()
+        .map(|(id, op, name)| {
+            (
+                id,
+                Node {
+                    id,
+                    op,
+                    name: name.map(str::to_string),
+                },
+            )
+        })
+        .collect();
+
+        Graph {
+            meta: None,
+            nodes,
+            imports: vec![],
+            tables: HashMap::new(),
+            inputs: vec![0],
+            outputs: vec![2],
+            invariants: vec![],
+        }
+    }
+
     fn tax_graph() -> Graph {
         let mut nodes = HashMap::new();
         nodes.insert(
@@ -517,13 +576,23 @@ mod tests {
     }
 
     #[test]
-    fn test_gradient_splits_max_tie_between_operands() {
+    fn test_gradient_uses_composed_right_derivative_at_a_max_kink() {
         let graph = coincident_max_graph();
         let mut runtime = Runtime::new(&graph, FilingStatus::Single);
         runtime.set_by_id(0, 0.0);
 
         let grad = gradient(&mut runtime, 3, 0).unwrap();
-        assert_eq!(grad, 0.5);
+        assert_eq!(grad, 1.0);
+    }
+
+    #[test]
+    fn test_gradient_uses_composed_right_derivative_at_a_min_kink() {
+        let graph = minimum_graph();
+        let mut runtime = Runtime::new(&graph, FilingStatus::Single);
+        runtime.set_by_id(0, 0.0);
+
+        let grad = gradient(&mut runtime, 2, 0).unwrap();
+        assert_eq!(grad, 0.0);
     }
 
     #[test]

--- a/crates/tenforty-graph/src/autodiff.rs
+++ b/crates/tenforty-graph/src/autodiff.rs
@@ -1,7 +1,7 @@
 use crate::eval::{EvalError, Runtime};
 use crate::graph::{NodeId, Op};
 use crate::primitives;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Compute the adjoint of every node with respect to an output node.
 ///
@@ -35,9 +35,10 @@ pub fn adjoints(runtime: &mut Runtime, output: NodeId) -> Result<HashMap<NodeId,
 }
 
 /// Compute the gradient of an output node with respect to an input node.
-/// Uses reverse-mode automatic differentiation (backpropagation).
+/// Uses reverse-mode automatic differentiation in smooth regions and the
+/// composed function's symmetric numerical derivative at an active max tie.
 pub fn gradient(runtime: &mut Runtime, output: NodeId, input: NodeId) -> Result<f64, EvalError> {
-    Ok(*adjoints(runtime, output)?.get(&input).unwrap_or(&0.0))
+    gradient_sum(runtime, output, &[input])
 }
 
 /// Compute the total derivative of an output with respect to a quantity that
@@ -57,10 +58,90 @@ pub fn gradient_sum(
     inputs: &[NodeId],
 ) -> Result<f64, EvalError> {
     let adjoints = adjoints(runtime, output)?;
+    if has_active_max_tie(runtime, &adjoints, inputs)? {
+        return numerical_gradient_sum(runtime, output, inputs);
+    }
+
     Ok(inputs
         .iter()
         .map(|input| adjoints.get(input).copied().unwrap_or(0.0))
         .sum())
+}
+
+fn has_active_max_tie(
+    runtime: &Runtime,
+    adjoints: &HashMap<NodeId, f64>,
+    inputs: &[NodeId],
+) -> Result<bool, EvalError> {
+    let mut reachable: HashSet<NodeId> = inputs.iter().copied().collect();
+    let values = runtime.get_all_values();
+
+    for node_id in runtime.graph().topological_order()? {
+        let Some(node) = runtime.graph().nodes.get(&node_id) else {
+            continue;
+        };
+        if node
+            .op
+            .dependencies()
+            .iter()
+            .any(|dependency| reachable.contains(dependency))
+        {
+            reachable.insert(node_id);
+        }
+
+        let Op::Max { left, right } = &node.op else {
+            continue;
+        };
+        if reachable.contains(&node_id)
+            && adjoints.get(&node_id).copied().unwrap_or(0.0) != 0.0
+            && values.get(left).copied().unwrap_or(0.0) == values.get(right).copied().unwrap_or(0.0)
+        {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+fn numerical_gradient_sum(
+    runtime: &mut Runtime,
+    output: NodeId,
+    inputs: &[NodeId],
+) -> Result<f64, EvalError> {
+    let originals: Vec<_> = inputs
+        .iter()
+        .map(|input| {
+            (
+                *input,
+                runtime.get_all_values().get(input).copied().unwrap_or(0.0),
+            )
+        })
+        .collect();
+    let scale = originals
+        .iter()
+        .map(|(_, value)| value.abs())
+        .fold(1.0, f64::max);
+    let epsilon = (scale * f64::EPSILON.sqrt()).max(1e-4);
+
+    for (input, original) in &originals {
+        runtime.set_by_id(*input, original + epsilon);
+    }
+    let f_plus = runtime.eval_node(output);
+
+    for (input, original) in &originals {
+        runtime.set_by_id(*input, original - epsilon);
+    }
+    let f_minus = runtime.eval_node(output);
+
+    for (input, original) in &originals {
+        runtime.set_by_id(*input, *original);
+    }
+    let restored = runtime.eval_node(output);
+
+    let f_plus = f_plus?;
+    let f_minus = f_minus?;
+    restored?;
+    Ok((f_plus - f_minus) / (2.0 * epsilon))
 }
 
 /// Compute the derivative of the sum of several outputs with respect to a
@@ -116,10 +197,7 @@ fn backprop(
         Op::Max { left, right } => {
             let l = values.get(left).copied().unwrap_or(0.0);
             let r = values.get(right).copied().unwrap_or(0.0);
-            if l == r {
-                *adjoints.entry(*left).or_insert(0.0) += adj * 0.5;
-                *adjoints.entry(*right).or_insert(0.0) += adj * 0.5;
-            } else if l > r {
+            if l >= r {
                 *adjoints.entry(*left).or_insert(0.0) += adj;
             } else {
                 *adjoints.entry(*right).or_insert(0.0) += adj;
@@ -315,6 +393,44 @@ mod tests {
         }
     }
 
+    fn limited_max_graph() -> Graph {
+        let nodes = [
+            (0, Op::Input, Some("x")),
+            (1, Op::Literal { value: 0.0 }, Some("zero")),
+            (2, Op::Max { left: 1, right: 0 }, Some("positive_x")),
+            (3, Op::Literal { value: 10.0 }, Some("threshold")),
+            (4, Op::Sub { left: 0, right: 3 }, Some("above_threshold")),
+            (
+                5,
+                Op::Max { left: 1, right: 4 },
+                Some("positive_above_threshold"),
+            ),
+            (6, Op::Min { left: 2, right: 5 }, Some("limited_amount")),
+        ]
+        .into_iter()
+        .map(|(id, op, name)| {
+            (
+                id,
+                Node {
+                    id,
+                    op,
+                    name: name.map(str::to_string),
+                },
+            )
+        })
+        .collect();
+
+        Graph {
+            meta: None,
+            nodes,
+            imports: vec![],
+            tables: HashMap::new(),
+            inputs: vec![0],
+            outputs: vec![6],
+            invariants: vec![],
+        }
+    }
+
     fn tax_graph() -> Graph {
         let mut nodes = HashMap::new();
         nodes.insert(
@@ -418,8 +534,20 @@ mod tests {
 
         let analytical = gradient(&mut runtime, 8, 0).unwrap();
         let numerical = numerical_gradient(&mut runtime, 8, 0, 1e-6).unwrap();
-        assert!((analytical - 1.0).abs() < 1e-12);
+        assert!((analytical - 1.0).abs() < 1e-8);
         assert!((analytical - numerical).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_gradient_does_not_leak_through_limited_max_tie() {
+        let graph = limited_max_graph();
+        let mut runtime = Runtime::new(&graph, FilingStatus::Single);
+        runtime.set_by_id(0, 0.0);
+
+        let analytical = gradient(&mut runtime, 6, 0).unwrap();
+        let numerical = numerical_gradient(&mut runtime, 6, 0, 1e-6).unwrap();
+        assert_eq!(analytical, 0.0);
+        assert_eq!(analytical, numerical);
     }
 
     #[test]

--- a/crates/tenforty-graph/src/autodiff.rs
+++ b/crates/tenforty-graph/src/autodiff.rs
@@ -6,12 +6,23 @@ use std::collections::{HashMap, HashSet};
 /// Compute the adjoint of every node with respect to an output node.
 ///
 /// One reverse-mode pass produces the partial derivative of `output` with
-/// respect to *every* node in the graph, so callers wanting several partials
-/// should take this map rather than calling [`gradient`] repeatedly.
+/// respect to every node on its active dependency path, so callers wanting
+/// several partials should take this map rather than calling [`gradient`]
+/// repeatedly.
 pub fn adjoints(runtime: &mut Runtime, output: NodeId) -> Result<HashMap<NodeId, f64>, EvalError> {
+    let (adjoints, _) = adjoints_with_order(runtime, output)?;
+    Ok(adjoints)
+}
+
+fn adjoints_with_order(
+    runtime: &mut Runtime,
+    output: NodeId,
+) -> Result<(HashMap<NodeId, f64>, Vec<NodeId>), EvalError> {
     runtime.eval_node(output)?;
 
-    let order = runtime.graph().topological_order()?;
+    let order = runtime
+        .graph()
+        .reachable_topological_order(&[output], runtime.filing_status())?;
     let values = runtime.get_all_values();
 
     let mut adjoints: HashMap<NodeId, f64> = HashMap::new();
@@ -31,7 +42,7 @@ pub fn adjoints(runtime: &mut Runtime, output: NodeId) -> Result<HashMap<NodeId,
         backprop(&node.op, node_id, adj, values, runtime, &mut adjoints)?;
     }
 
-    Ok(adjoints)
+    Ok((adjoints, order))
 }
 
 /// Compute the gradient of an output node with respect to an input node.
@@ -57,13 +68,13 @@ pub fn gradient_sum(
     output: NodeId,
     inputs: &[NodeId],
 ) -> Result<f64, EvalError> {
-    let adjoints = adjoints(runtime, output)?;
+    let (adjoints, order) = adjoints_with_order(runtime, output)?;
     let reverse_gradient = inputs
         .iter()
         .map(|input| adjoints.get(input).copied().unwrap_or(0.0))
         .sum();
 
-    if has_active_kink(runtime, &adjoints, inputs)? {
+    if has_active_kink(runtime, &adjoints, inputs, &order) {
         return forward_gradient(runtime, output, inputs);
     }
 
@@ -74,11 +85,17 @@ fn has_active_kink(
     runtime: &Runtime,
     adjoints: &HashMap<NodeId, f64>,
     inputs: &[NodeId],
-) -> Result<bool, EvalError> {
-    let mut reachable: HashSet<NodeId> = inputs.iter().copied().collect();
+    order: &[NodeId],
+) -> bool {
+    let active_nodes: HashSet<NodeId> = order.iter().copied().collect();
+    let mut reachable: HashSet<NodeId> = inputs
+        .iter()
+        .copied()
+        .filter(|input| active_nodes.contains(input))
+        .collect();
     let values = runtime.get_all_values();
 
-    for node_id in runtime.graph().topological_order()? {
+    for &node_id in order {
         let Some(node) = runtime.graph().nodes.get(&node_id) else {
             continue;
         };
@@ -131,11 +148,11 @@ fn has_active_kink(
             _ => false,
         };
         if is_tie {
-            return Ok(true);
+            return true;
         }
     }
 
-    Ok(false)
+    false
 }
 
 fn forward_gradient(
@@ -145,12 +162,7 @@ fn forward_gradient(
 ) -> Result<f64, EvalError> {
     let originals: Vec<_> = inputs
         .iter()
-        .map(|input| {
-            (
-                *input,
-                runtime.get_all_values().get(input).copied().unwrap_or(0.0),
-            )
-        })
+        .map(|input| (*input, original_value(runtime, *input)))
         .collect();
     let scale = originals
         .iter()
@@ -171,6 +183,13 @@ fn forward_gradient(
     let f_plus = f_plus?;
     let f_original = f_original?;
     Ok((f_plus - f_original) / epsilon)
+}
+
+fn original_value(runtime: &Runtime, node_id: NodeId) -> f64 {
+    runtime
+        .input_value(node_id)
+        .or_else(|| runtime.get_all_values().get(&node_id).copied())
+        .unwrap_or(0.0)
 }
 
 /// Compute the derivative of the sum of several outputs with respect to a
@@ -316,7 +335,8 @@ pub fn numerical_gradient(
     input: NodeId,
     epsilon: f64,
 ) -> Result<f64, EvalError> {
-    let original = runtime.get_all_values().get(&input).copied().unwrap_or(0.0);
+    runtime.eval_node(output)?;
+    let original = original_value(runtime, input);
 
     runtime.set_by_id(input, original + epsilon);
     let f_plus = runtime.eval_node(output)?;
@@ -460,6 +480,44 @@ mod tests {
         }
     }
 
+    fn disjoint_fanout_graph() -> Graph {
+        let nodes = [
+            (0, Op::Input, Some("federal_input")),
+            (1, Op::Input, Some("state_input")),
+            (2, Op::Literal { value: 0.0 }, Some("zero")),
+            (3, Op::Max { left: 2, right: 0 }, Some("federal_output")),
+            (4, Op::Literal { value: 10.0 }, Some("state_deduction")),
+            (
+                5,
+                Op::Sub { left: 1, right: 4 },
+                Some("state_taxable_income"),
+            ),
+            (6, Op::Max { left: 2, right: 5 }, Some("state_output")),
+        ]
+        .into_iter()
+        .map(|(id, op, name)| {
+            (
+                id,
+                Node {
+                    id,
+                    op,
+                    name: name.map(str::to_string),
+                },
+            )
+        })
+        .collect();
+
+        Graph {
+            meta: None,
+            nodes,
+            imports: vec![],
+            tables: HashMap::new(),
+            inputs: vec![0, 1],
+            outputs: vec![3, 6],
+            invariants: vec![],
+        }
+    }
+
     fn minimum_graph() -> Graph {
         let nodes = [
             (0, Op::Input, Some("x")),
@@ -565,6 +623,21 @@ mod tests {
     }
 
     #[test]
+    fn test_gradient_sum_outputs_preserves_inputs_outside_each_output_path() {
+        let graph = disjoint_fanout_graph();
+        let mut runtime = Runtime::new(&graph, FilingStatus::Single);
+        runtime.set_by_id(0, 0.0);
+        runtime.set_by_id(1, 50.0);
+
+        let grad = gradient_sum_outputs(&mut runtime, &[3, 6], &[0, 1]).unwrap();
+
+        assert_eq!(grad, 2.0);
+        assert_eq!(runtime.input_value(0), Some(0.0));
+        assert_eq!(runtime.input_value(1), Some(50.0));
+        assert_eq!(runtime.eval_node(6).unwrap(), 40.0);
+    }
+
+    #[test]
     fn test_gradient_vs_numerical() {
         let graph = simple_arithmetic_graph();
         let mut runtime = Runtime::new(&graph, FilingStatus::Single);
@@ -573,6 +646,19 @@ mod tests {
         let analytical = gradient(&mut runtime, 2, 0).unwrap();
         let numerical = numerical_gradient(&mut runtime, 2, 0, 1e-6).unwrap();
         assert!((analytical - numerical).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_numerical_gradient_restores_an_uncached_input() {
+        let graph = simple_arithmetic_graph();
+        let mut runtime = Runtime::new(&graph, FilingStatus::Single);
+        runtime.set_by_id(0, 5.0);
+
+        let numerical = numerical_gradient(&mut runtime, 2, 0, 1e-6).unwrap();
+
+        assert!((numerical - 2.0).abs() < 1e-6);
+        assert_eq!(runtime.input_value(0), Some(5.0));
+        assert_eq!(runtime.eval_node(2).unwrap(), 10.0);
     }
 
     #[test]

--- a/crates/tenforty-graph/src/autodiff.rs
+++ b/crates/tenforty-graph/src/autodiff.rs
@@ -116,7 +116,10 @@ fn backprop(
         Op::Max { left, right } => {
             let l = values.get(left).copied().unwrap_or(0.0);
             let r = values.get(right).copied().unwrap_or(0.0);
-            if l >= r {
+            if l == r {
+                *adjoints.entry(*left).or_insert(0.0) += adj * 0.5;
+                *adjoints.entry(*right).or_insert(0.0) += adj * 0.5;
+            } else if l > r {
                 *adjoints.entry(*left).or_insert(0.0) += adj;
             } else {
                 *adjoints.entry(*right).or_insert(0.0) += adj;
@@ -264,6 +267,54 @@ mod tests {
         }
     }
 
+    fn coincident_max_graph() -> Graph {
+        let nodes = [
+            (0, Op::Input, Some("x")),
+            (1, Op::Literal { value: 0.0 }, Some("zero")),
+            (2, Op::Neg { arg: 0 }, Some("negative_x")),
+            (3, Op::Max { left: 1, right: 0 }, Some("positive_x")),
+            (
+                4,
+                Op::Max { left: 1, right: 2 },
+                Some("positive_negative_x"),
+            ),
+            (5, Op::Literal { value: 11.0 }, Some("other_income")),
+            (
+                6,
+                Op::Sub { left: 5, right: 4 },
+                Some("income_above_remaining_threshold"),
+            ),
+            (
+                7,
+                Op::Max { left: 1, right: 6 },
+                Some("positive_other_income"),
+            ),
+            (8, Op::Add { left: 3, right: 7 }, Some("combined")),
+        ]
+        .into_iter()
+        .map(|(id, op, name)| {
+            (
+                id,
+                Node {
+                    id,
+                    op,
+                    name: name.map(str::to_string),
+                },
+            )
+        })
+        .collect();
+
+        Graph {
+            meta: None,
+            nodes,
+            imports: vec![],
+            tables: HashMap::new(),
+            inputs: vec![0],
+            outputs: vec![8],
+            invariants: vec![],
+        }
+    }
+
     fn tax_graph() -> Graph {
         let mut nodes = HashMap::new();
         nodes.insert(
@@ -347,6 +398,28 @@ mod tests {
         let analytical = gradient(&mut runtime, 2, 0).unwrap();
         let numerical = numerical_gradient(&mut runtime, 2, 0, 1e-6).unwrap();
         assert!((analytical - numerical).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_gradient_splits_max_tie_between_operands() {
+        let graph = coincident_max_graph();
+        let mut runtime = Runtime::new(&graph, FilingStatus::Single);
+        runtime.set_by_id(0, 0.0);
+
+        let grad = gradient(&mut runtime, 3, 0).unwrap();
+        assert_eq!(grad, 0.5);
+    }
+
+    #[test]
+    fn test_gradient_survives_coincident_max_ties() {
+        let graph = coincident_max_graph();
+        let mut runtime = Runtime::new(&graph, FilingStatus::Single);
+        runtime.set_by_id(0, 0.0);
+
+        let analytical = gradient(&mut runtime, 8, 0).unwrap();
+        let numerical = numerical_gradient(&mut runtime, 8, 0, 1e-6).unwrap();
+        assert!((analytical - 1.0).abs() < 1e-12);
+        assert!((analytical - numerical).abs() < 1e-6);
     }
 
     #[test]

--- a/crates/tenforty-graph/src/eval.rs
+++ b/crates/tenforty-graph/src/eval.rs
@@ -227,6 +227,10 @@ impl<'g> Runtime<'g> {
         &self.cache
     }
 
+    pub fn input_value(&self, node_id: NodeId) -> Option<f64> {
+        self.inputs.get(&node_id).copied()
+    }
+
     pub fn filing_status(&self) -> FilingStatus {
         self.filing_status
     }

--- a/tests/graph_autodiff_properties_test.py
+++ b/tests/graph_autodiff_properties_test.py
@@ -134,17 +134,6 @@ _RECLASSIFICATION_FLOOR = -0.21
 # used to drop the derived w2 -> Schedule SE edge (tenforty-hrp).
 _SS_WAGE_BASE_2024 = 168_600.0
 
-# 2024 Additional Medicare Tax thresholds (IRC 3101(b)(2)). Form 8959 hangs two
-# max0 branches off these, so wages landing exactly on one put both on a kink at
-# the same time — see tenforty-dhi.
-_ADDITIONAL_MEDICARE_THRESHOLDS = {
-    "Single": 200_000.0,
-    "Head_of_House": 200_000.0,
-    "Widow(er)": 200_000.0,
-    "Married/Joint": 250_000.0,
-    "Married/Sep": 125_000.0,
-}
-
 
 def _total_tax(case: dict) -> float:
     return evaluate_return(backend="graph", **case).federal_total_tax
@@ -168,21 +157,6 @@ def test_autodiff_matches_finite_difference(filing_status, wrt, incomes):
     case = dict(year=2024, filing_status=filing_status, **incomes)
     # Leave room for a symmetric step without pushing the input negative.
     case[wrt] = max(case[wrt], _STEP)
-
-    # Skip wages landing EXACTLY on the Additional Medicare threshold. Form 8959
-    # charges two max0 branches off that one threshold, so both sit on their kinks
-    # at once and autodiff takes the subgradient 0 for each — but the kinks cancel
-    # and the sum is differentiable, so the true slope is 0.009 and the gradient
-    # reads 0. A real, tracked defect (tenforty-dhi), pinned by the strict xfail
-    # below. The kink filter underneath cannot catch it: it watches the composed
-    # function, which is smooth here, not the interior nodes. Remove when dhi lands.
-    assume(
-        not (
-            wrt == "w2_income"
-            and incomes["self_employment_income"] > 0.0
-            and case["w2_income"] == _ADDITIONAL_MEDICARE_THRESHOLDS[filing_status]
-        )
-    )
 
     f0 = _total_tax(case)
     f_plus = _total_tax({**case, wrt: case[wrt] + _STEP})
@@ -245,10 +219,8 @@ _QBI_GAIN_CASE = dict(
 )
 
 
-# Durable record of tenforty-dhi: at wages exactly on the Additional Medicare
-# threshold, Form 8959's two max0 branches are both at their kink and autodiff
-# zeroes each, losing a derivative that survives in their sum. Strict xfail, so
-# the fix forces this and the `assume` above out together.
+# At wages exactly on the Additional Medicare threshold, Form 8959's two max0
+# branches kink in opposite directions while their sum remains differentiable.
 _KINK_CASE = dict(
     year=2024,
     filing_status="Single",
@@ -258,11 +230,6 @@ _KINK_CASE = dict(
 
 
 @skip_if_graph_unavailable
-@pytest.mark.xfail(
-    reason="tenforty-dhi: coincident max0 kinks at the Additional Medicare "
-    "threshold zero the adjoint, so d(*)/d(w2_income) loses the 0.9%",
-    strict=True,
-)
 def test_gradient_survives_coincident_kinks_at_the_medicare_threshold():
     """The sum is differentiable at the threshold even though each branch kinks."""
     from tenforty.backends import GraphBackend

--- a/tests/state_total_autodiff_test.py
+++ b/tests/state_total_autodiff_test.py
@@ -69,6 +69,35 @@ def test_no_tax_state_total_matches_federal():
     assert total_rate == pytest.approx(federal_rate, abs=1e-9)
 
 
+def test_state_mapped_interest_survives_federal_kink_probe():
+    """A federal right-derivative probe preserves a state-side input fan-out."""
+    kwargs = {
+        "year": 2024,
+        "state": "NH",
+        "filing_status": "Single",
+        "w2_income": 150_000.0,
+        "taxable_interest": 50_000.0,
+    }
+    step = 0.01
+
+    total_rate = marginal_rate(**kwargs, wrt="taxable_interest")
+    federal_rate = marginal_rate(
+        **kwargs, output="federal_total_tax", wrt="taxable_interest"
+    )
+    state_rate = marginal_rate(
+        **kwargs, output="state_total_tax", wrt="taxable_interest"
+    )
+    base_tax = evaluate_return(**kwargs, backend="graph").total_tax
+    right_tax = evaluate_return(
+        **(kwargs | {"taxable_interest": kwargs["taxable_interest"] + step}),
+        backend="graph",
+    ).total_tax
+
+    assert total_rate == pytest.approx(federal_rate + state_rate, abs=1e-12)
+    assert total_rate == pytest.approx((right_tax - base_tax) / step, abs=1e-6)
+    assert state_rate == pytest.approx(0.03, abs=1e-12)
+
+
 def test_state_total_solver_roundtrips_public_total():
     """Income solving targets the public federal-plus-state total."""
     target = 20_000.0


### PR DESCRIPTION
## Summary
- keep reverse-mode autodiff for smooth regions
- detect active piecewise boundaries on the requested input-to-output path
- take the composed output's right-hand derivative at those boundaries, matching the model's forward-derived convention
- preserve authoritative Runtime inputs while probing, including state-side fan-out nodes outside the current federal output path
- reuse one filing-status-aware reachable topological order for reverse mode and kink detection instead of sorting and scanning the full graph twice
- restore the true Additional Medicare derivative where Form 8959 has cancelling internal kinks without leaking phantom NIIT or AMT gradients through flat branches
- remove the deep-property exclusion and strict xfail for tenforty-dhi

This is deliberately broader than a coincident-Max special case. Zero-valued inputs routinely place max0 expressions on a boundary, so the contract is the composed right derivative whenever the requested input reaches an active piecewise kink.

At TY2024 Single, wages exactly 200,000 and self-employment income 11:
- d(additional_medicare)/d(wages) changes from 0.000 to 0.009
- d(total_tax)/d(wages) changes from 0.240 to 0.249

The review's NH reproducer is now pinned end to end: at wages 150,000 and taxable interest 50,000, d(total_tax)/d(interest) is 0.308 = 0.278 federal + 0.030 state, independent of cache order, and the state input remains 50,000 after the federal kink probe.

The systematic follow-up is stacked as #332 and contains only the tenforty-g79 matrix tests.

## Validation
- cargo test --lib: 32 passed
- targeted autodiff/state-total suite: 121 passed
- full suite: 988 passed, 12 skipped, 22 xfailed
- deep profile (10,000 examples): 988 passed, 12 skipped, 22 xfailed
- parity: 44 passed, 8 skipped, 11 xfailed
- Haskell format/lint, graph generation, and form sync: passed; generated forms unchanged
- changed-file pre-commit hooks: passed
- Tax-Calculator adapter/batch/goldens: 11 passed, 1 xfailed; the differential found an unrelated pre-existing low-income refundable-credit mismatch and is tracked as tenforty-m2h

Tracks tenforty-dhi.
