### PR TITLE
fix(taxcalc): compare pre-refund tax quantities

### DIFF
--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -34,6 +34,7 @@ delete the signature, and update this table in the same PR.
 | F16 | Suite adapter drops `iso`, so taxcalc sees no AMT preference | taxcalc harness | fixed (#295) | F14 adjudication |
 | F17 | Graph charges SE tax below the \$400 de-minimis floor | graph spec | open (tenforty-dw0) | differential sweep |
 | F19 | Deduction choice: taxcalc minimizes tax; tenforty maximizes the deduction | API contract, both backends | open (documented signature; tenforty-z31) | differential sweep |
+| F20 | Suite adapter compares post-refund `iitax` with pre-refund tenforty tax | taxcalc harness | fixed (tenforty-jte) | differential sweep |
 
 ## Method
 
@@ -362,6 +363,29 @@ dangerous — the moment AMT coverage is added (which `tenforty-y90` plans),
 every such case would compare tenforty *with* the preference against taxcalc
 *without* it, manufacturing large bogus divergences on both backends and
 burying any real one. Fix the adapter before adding the coverage.
+
+### F20. FIXED — the suite compares post-refund `iitax` with pre-refund tax
+
+Found while validating the graph autodiff kink fix. Tax-Calculator defines
+`iitax` as `c09200 - refund`: Form 1040 line 24 less its line-32 analogue of
+refundable credits. Tenforty's `federal_income_tax` and `federal_total_tax`
+are pre-refund line-24 quantities. The suite nevertheless mapped raw `iitax`
+directly, so a low-income return with an EITC appeared to disagree even though
+both engines reported zero pre-refund tax.
+
+The apparent batch-cardinality defect had the same cause. Tax-Calculator
+generates `credit_claim_urn` by row position for probabilistic EITC take-up.
+TY2024 Head of Household with wages of $802 receives no credit alone, but as
+the second row of a two-record batch it receives a $61.353 EITC: raw `iitax`
+changes from $0 to -$61.353 while pre-refund tax remains $0 in both cases.
+That microsimulation behavior is not part of the quantity this differential
+claims to compare.
+
+The adapter now adds `refund` back to `iitax` before applying its existing
+NIIT, self-employment-tax, and Additional-Medicare bucketing. It retains raw
+`iitax` and `refund` as diagnostics, and deterministic conformance tests pin
+both the one-record and multi-record cases. No policy signature excuses the
+difference.
 
 ### F7. Itemization semantics diverge between backends
 

--- a/tests/taxcalc/adapter_conformance_test.py
+++ b/tests/taxcalc/adapter_conformance_test.py
@@ -48,6 +48,13 @@ F14_CASE = {
     "iso": 200_000.0,
 }
 
+REFUNDABLE_CREDIT_CASE = {
+    **F14_CASE,
+    "status": "Head_of_House",
+    "w2": 802.0,
+    "iso": 0.0,
+}
+
 
 def test_iso_reaches_taxcalc_as_amt_preference():
     """An ISO spread must produce AMT in taxcalc, not silence."""
@@ -181,3 +188,28 @@ def test_taxcalc_keeps_the_standard_deduction_when_itemizing_is_free():
     # ... and it costs nothing, which is the whole reason taxable_income is excused.
     assert result["income_tax"] == pytest.approx(ours["income_tax"], abs=0.01)
     assert result["total_tax"] == pytest.approx(ours["total_tax"], abs=0.01)
+
+
+def test_refundable_credit_does_not_change_pre_refund_tax_contract():
+    """Record cardinality cannot change the pre-refund quantities we compare."""
+    single = taxcalc_batch([REFUNDABLE_CREDIT_CASE])[0]
+    zero_record = {**REFUNDABLE_CREDIT_CASE, "status": "Single", "w2": 0.0}
+    second_in_batch = taxcalc_batch([zero_record, REFUNDABLE_CREDIT_CASE])[1]
+
+    for result in (single, second_in_batch):
+        assert result["income_tax"] == pytest.approx(0.0, abs=0.01)
+        assert result["total_tax"] == pytest.approx(0.0, abs=0.01)
+
+
+def test_raw_iitax_remains_net_of_refundable_credits():
+    """The adapter preserves Tax-Calculator's raw post-refund diagnostics."""
+    zero_record = {**REFUNDABLE_CREDIT_CASE, "status": "Single", "w2": 0.0}
+    single = taxcalc_batch([REFUNDABLE_CREDIT_CASE])[0]
+    second_in_batch = taxcalc_batch([zero_record, REFUNDABLE_CREDIT_CASE])[1]
+
+    assert single["refund"] == pytest.approx(0.0, abs=0.001)
+    assert single["iitax"] == pytest.approx(0.0, abs=0.001)
+    assert second_in_batch["refund"] == pytest.approx(61.353, abs=0.001)
+    assert second_in_batch["iitax"] == pytest.approx(
+        -second_in_batch["refund"], abs=0.001
+    )

--- a/tests/taxcalc/adapter_conformance_test.py
+++ b/tests/taxcalc/adapter_conformance_test.py
@@ -209,6 +209,7 @@ def test_raw_iitax_remains_net_of_refundable_credits():
 
     assert single["refund"] == pytest.approx(0.0, abs=0.001)
     assert single["iitax"] == pytest.approx(0.0, abs=0.001)
+    # Pinned to TaxCalc 6.7.2; its row-derived credit_claim_urn may change on upgrade.
     assert second_in_batch["refund"] == pytest.approx(61.353, abs=0.001)
     assert second_in_batch["iitax"] == pytest.approx(
         -second_in_batch["refund"], abs=0.001

--- a/tests/taxcalc/taxcalc_differential_test.py
+++ b/tests/taxcalc/taxcalc_differential_test.py
@@ -171,9 +171,11 @@ def taxcalc_batch(cases, wage_attribution="primary"):
         arr = calc.array
         for row, i in enumerate(idx):
             iitax = float(arr("iitax")[row])
+            refund = float(arr("refund")[row])
             setax = float(arr("setax")[row])
             amc = float(arr("ptax_amc")[row])
             niit = float(arr("niit")[row])
+            pre_refund_iitax = iitax + refund
             out[i] = {
                 "agi": float(arr("c00100")[row]),
                 "taxable_income": float(arr("c04800")[row]),
@@ -181,10 +183,14 @@ def taxcalc_batch(cases, wage_attribution="primary"):
                 "niit": niit,
                 "addl_medicare": amc,
                 "amt": float(arr("c09600")[row]),
-                # taxcalc iitax includes NIIT; tenforty federal_income_tax
-                # excludes it.
-                "income_tax": iitax - niit,
-                "total_tax": iitax + setax + amc,
+                # Tax-Calculator nets refundable credits out of iitax, while
+                # tenforty's federal tax outputs stop at Form 1040 line 24.
+                # Add its line-32 analogue back before preserving the existing
+                # NIIT and employment-tax bucketing.
+                "income_tax": pre_refund_iitax - niit,
+                "total_tax": pre_refund_iitax + setax + amc,
+                "iitax": iitax,
+                "refund": refund,
             }
     return out
 


### PR DESCRIPTION
## Summary
- add Tax-Calculator's `refund` back to raw `iitax` before comparing with tenforty's pre-refund Form 1040 line-24 quantities
- preserve the existing NIIT, self-employment-tax, and Additional-Medicare bucketing
- retain raw `iitax` and `refund` diagnostics and pin the TY2024 HoH wages=$802 case both alone and as row two of a batch
- record the harness defect and resolution as F20 in the differential audit

## Why
Tax-Calculator's `iitax` is net of refundable credits, while tenforty's `federal_income_tax` and `federal_total_tax` stop before refunds. Tax-Calculator's row-position EITC take-up therefore made the same zero-tax filer appear to disagree only in a multi-record batch. Restoring `refund` compares the intended pre-refund quantity without masking Tax-Calculator's raw microsimulation behavior.

## Validation
- TaxCalc adapter conformance: 8 passed, 1 xfailed
- complete TaxCalc suite, including both differential backends: 16 passed, 1 xfailed
- default suite: 991 passed, 12 skipped, 22 xfailed
- changed-file and commit hooks: passed

Bead: tenforty-jte
