### PR TITLE
feat(graph): expose full gradient vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,37 @@ The output is a pydantic model, and we've called its `.model_dump()` method to
 show the result as a dictionary.
 
 
+### Marginal Rates for Every Input
+
+The graph backend can differentiate a selected output with respect to every
+continuous public input at once:
+
+``` python
+from tenforty import marginal_rates
+
+rates = marginal_rates(
+    year=2024,
+    state="CA",
+    filing_status="Single",
+    w2_income=100_000,
+)
+
+rates["w2_income"]
+```
+
+The returned dictionary uses the same natural input names as
+`evaluate_return`. It includes federal inputs and any continuous inputs mapped
+by the selected state; discrete choices such as filing status and number of
+dependents are omitted. The existing `marginal_rate(..., wrt="w2_income")`
+function remains available for one input at a time.
+
+Tax calculations are piecewise functions. At a bracket, phase-out, or other
+active boundary, both marginal-rate APIs report the composed function's
+right-hand derivative: the change implied by adding a small amount to that
+input. Smooth entries in `marginal_rates` share one reverse-mode traversal per
+resolved output.
+
+
 ### Creating Tax Tables: Federal/State Tax Brackets as a Function of W2 Income
 
 The `evaluate_returns` method sweeps out a grid over any input arguments that

--- a/crates/tenforty-graph/src/autodiff.rs
+++ b/crates/tenforty-graph/src/autodiff.rs
@@ -68,17 +68,51 @@ pub fn gradient_sum(
     output: NodeId,
     inputs: &[NodeId],
 ) -> Result<f64, EvalError> {
-    let (adjoints, order) = adjoints_with_order(runtime, output)?;
-    let reverse_gradient = inputs
-        .iter()
-        .map(|input| adjoints.get(input).copied().unwrap_or(0.0))
-        .sum();
+    Ok(gradient_slices(runtime, output, &[inputs])?[0])
+}
 
-    if has_active_kink(runtime, &adjoints, inputs, &order) {
-        return forward_gradient(runtime, output, inputs);
+/// Compute grouped derivatives of one output in a single reverse pass.
+///
+/// Each inner slice names every graph node written by one natural input. In
+/// smooth regions all groups are read from the same adjoint map. A group whose
+/// requested path reaches an active piecewise boundary instead receives the
+/// same composed right-hand directional derivative as [`gradient_sum`].
+fn gradient_slices(
+    runtime: &mut Runtime,
+    output: NodeId,
+    input_groups: &[&[NodeId]],
+) -> Result<Vec<f64>, EvalError> {
+    let (adjoints, order) = adjoints_with_order(runtime, output)?;
+    let mut gradients = Vec::with_capacity(input_groups.len());
+
+    for inputs in input_groups {
+        let reverse_gradient = inputs
+            .iter()
+            .map(|input| adjoints.get(input).copied().unwrap_or(0.0))
+            .sum();
+        let gradient = if has_active_kink(runtime, &adjoints, inputs, &order) {
+            forward_gradient(runtime, output, inputs)?
+        } else {
+            reverse_gradient
+        };
+        gradients.push(gradient);
     }
 
-    Ok(reverse_gradient)
+    Ok(gradients)
+}
+
+/// Compute grouped derivatives of one output.
+///
+/// This is the vector form of [`gradient_sum`]: one reverse traversal supplies
+/// every smooth group, rather than repeating the traversal for each natural
+/// input.
+pub fn gradient_sums(
+    runtime: &mut Runtime,
+    output: NodeId,
+    input_groups: &[Vec<NodeId>],
+) -> Result<Vec<f64>, EvalError> {
+    let input_slices: Vec<_> = input_groups.iter().map(Vec::as_slice).collect();
+    gradient_slices(runtime, output, &input_slices)
 }
 
 fn has_active_kink(
@@ -199,10 +233,38 @@ pub fn gradient_sum_outputs(
     outputs: &[NodeId],
     inputs: &[NodeId],
 ) -> Result<f64, EvalError> {
-    outputs
-        .iter()
-        .map(|output| gradient_sum(runtime, *output, inputs))
-        .sum()
+    Ok(gradient_slices_outputs(runtime, outputs, &[inputs])?[0])
+}
+
+fn gradient_slices_outputs(
+    runtime: &mut Runtime,
+    outputs: &[NodeId],
+    input_groups: &[&[NodeId]],
+) -> Result<Vec<f64>, EvalError> {
+    let mut gradients = vec![0.0; input_groups.len()];
+    for output in outputs {
+        for (total, partial) in
+            gradients
+                .iter_mut()
+                .zip(gradient_slices(runtime, *output, input_groups)?)
+        {
+            *total += partial;
+        }
+    }
+    Ok(gradients)
+}
+
+/// Compute grouped derivatives of a sum of outputs.
+///
+/// Costs one reverse traversal per output in smooth regions, independent of
+/// the number of natural-input groups.
+pub fn gradient_sums_outputs(
+    runtime: &mut Runtime,
+    outputs: &[NodeId],
+    input_groups: &[Vec<NodeId>],
+) -> Result<Vec<f64>, EvalError> {
+    let input_slices: Vec<_> = input_groups.iter().map(Vec::as_slice).collect();
+    gradient_slices_outputs(runtime, outputs, &input_slices)
 }
 
 fn backprop(
@@ -635,6 +697,33 @@ mod tests {
         assert_eq!(runtime.input_value(0), Some(0.0));
         assert_eq!(runtime.input_value(1), Some(50.0));
         assert_eq!(runtime.eval_node(6).unwrap(), 40.0);
+    }
+
+    #[test]
+    fn test_grouped_gradients_preserve_inputs_and_kink_semantics() {
+        let graph = disjoint_fanout_graph();
+        let mut runtime = Runtime::new(&graph, FilingStatus::Single);
+        runtime.set_by_id(0, 0.0);
+        runtime.set_by_id(1, 50.0);
+
+        let gradients =
+            gradient_sums_outputs(&mut runtime, &[3, 6], &[vec![0, 1], vec![0], vec![1]]).unwrap();
+
+        assert_eq!(gradients, vec![2.0, 1.0, 1.0]);
+        assert_eq!(runtime.input_value(0), Some(0.0));
+        assert_eq!(runtime.input_value(1), Some(50.0));
+        assert_eq!(runtime.eval_node(6).unwrap(), 40.0);
+    }
+
+    #[test]
+    fn test_grouped_gradient_matches_scalar_at_coincident_max_ties() {
+        let graph = coincident_max_graph();
+        let mut runtime = Runtime::new(&graph, FilingStatus::Single);
+        runtime.set_by_id(0, 0.0);
+
+        let gradients = gradient_sums(&mut runtime, 8, &[vec![0]]).unwrap();
+
+        assert!((gradients[0] - 1.0).abs() < 1e-8);
     }
 
     #[test]

--- a/crates/tenforty-graph/src/autodiff.rs
+++ b/crates/tenforty-graph/src/autodiff.rs
@@ -727,6 +727,38 @@ mod tests {
     }
 
     #[test]
+    fn test_grouped_gradients_choose_kink_fallback_per_group() {
+        let mut graph = coincident_max_graph();
+        graph.nodes.insert(
+            9,
+            Node {
+                id: 9,
+                op: Op::Input,
+                name: Some("smooth_input".to_string()),
+            },
+        );
+        graph.nodes.insert(
+            10,
+            Node {
+                id: 10,
+                op: Op::Add { left: 9, right: 8 },
+                name: Some("output".to_string()),
+            },
+        );
+        graph.inputs.push(9);
+        graph.outputs = vec![10];
+
+        let mut runtime = Runtime::new(&graph, FilingStatus::Single);
+        runtime.set_by_id(0, 0.0);
+        runtime.set_by_id(9, 5.0);
+
+        let gradients = gradient_sums(&mut runtime, 10, &[vec![9], vec![0]]).unwrap();
+
+        assert_eq!(gradients[0], 1.0);
+        assert!((gradients[1] - 1.0).abs() < 1e-8);
+    }
+
+    #[test]
     fn test_gradient_vs_numerical() {
         let graph = simple_arithmetic_graph();
         let mut runtime = Runtime::new(&graph, FilingStatus::Single);

--- a/crates/tenforty-graph/src/python.rs
+++ b/crates/tenforty-graph/src/python.rs
@@ -690,6 +690,54 @@ impl Runtime {
         })
     }
 
+    /// Grouped total derivatives of the sum of `outputs`.
+    ///
+    /// Each inner input vector is one natural input's complete graph fan-out.
+    /// Smooth groups share one reverse traversal per output; groups crossing
+    /// an active kink preserve `gradient_multi_output`'s composed right-hand
+    /// derivative convention.
+    fn gradients_multi_output(
+        &mut self,
+        outputs: Vec<String>,
+        input_groups: Vec<Vec<String>>,
+    ) -> PyResult<Vec<f64>> {
+        self.inner.with_runtime_mut(|rt| {
+            if outputs.is_empty() {
+                return Err(PyValueError::new_err(
+                    "At least one output node is required",
+                ));
+            }
+            let output_ids = outputs
+                .iter()
+                .map(|name| {
+                    rt.graph()
+                        .node_id_by_name(name)
+                        .ok_or_else(|| PyValueError::new_err(format!("Node not found: {}", name)))
+                })
+                .collect::<PyResult<Vec<_>>>()?;
+            let input_ids = input_groups
+                .iter()
+                .map(|inputs| {
+                    let ids: Vec<_> = inputs
+                        .iter()
+                        .filter_map(|name| rt.graph().node_id_by_name(name))
+                        .collect();
+                    if ids.is_empty() {
+                        Err(PyValueError::new_err(format!(
+                            "None of the input nodes were found: {}",
+                            inputs.join(", ")
+                        )))
+                    } else {
+                        Ok(ids)
+                    }
+                })
+                .collect::<PyResult<Vec<_>>>()?;
+
+            autodiff::gradient_sums_outputs(rt, &output_ids, &input_ids)
+                .map_err(|e| PyValueError::new_err(format!("{}", e)))
+        })
+    }
+
     /// Solve for the value of a quantity written into several input nodes.
     ///
     /// Each Newton step assigns the trial value to every named node and steps

--- a/src/tenforty/__init__.py
+++ b/src/tenforty/__init__.py
@@ -4,6 +4,7 @@ from .core import (  # noqa: F401
     evaluate_return,
     evaluate_returns,
     marginal_rate,
+    marginal_rates,
     solve_for_income,
 )
 from .models import OTSError, OTSErrorPolicy, OTSParseError  # noqa: F401

--- a/src/tenforty/backends/graph.py
+++ b/src/tenforty/backends/graph.py
@@ -594,6 +594,35 @@ class GraphBackend:
 
         return evaluator.gradient_multi_output(output_nodes, input_nodes)
 
+    def gradients(
+        self, tax_input: TaxReturnInput, output: str
+    ) -> dict[str, float] | None:
+        """Compute gradients for every continuous public input.
+
+        Smooth inputs share one reverse traversal per resolved output. At an
+        active piecewise boundary, each affected input retains the scalar API's
+        composed right-hand derivative convention.
+        """
+        if not self.is_available():
+            return None
+
+        evaluator, _ = self._create_evaluator(tax_input)
+        output_nodes = self._output_nodes(tax_input, output)
+        state_mapping = STATE_NATURAL_TO_NODE.get(tax_input.state, {})
+        natural_names = [
+            name
+            for name, field in TaxReturnInput.model_fields.items()
+            if field.annotation is float
+            and (name in NATURAL_TO_NODES or name in state_mapping)
+        ]
+        input_groups = [
+            self._input_nodes(tax_input, name, output_nodes[0])
+            for name in natural_names
+        ]
+        values = evaluator.gradients_multi_output(output_nodes, input_groups)
+
+        return dict(zip(natural_names, values, strict=True))
+
     def solve(
         self, tax_input: TaxReturnInput, output: str, target: float, var: str
     ) -> float | None:

--- a/src/tenforty/backends/ots.py
+++ b/src/tenforty/backends/ots.py
@@ -46,6 +46,12 @@ class OTSBackend:
         """OTS does not support autodiff - returns None."""
         return None
 
+    def gradients(
+        self, tax_input: TaxReturnInput, output: str
+    ) -> dict[str, float] | None:
+        """OTS does not support autodiff - returns None."""
+        return None
+
     def solve(
         self, tax_input: TaxReturnInput, output: str, target: float, var: str
     ) -> float | None:

--- a/src/tenforty/backends/protocol.py
+++ b/src/tenforty/backends/protocol.py
@@ -29,6 +29,15 @@ class TaxBackend(Protocol):
         """
         ...
 
+    def gradients(
+        self, tax_input: TaxReturnInput, output: str
+    ) -> dict[str, float] | None:
+        """Compute gradients for every continuous public input.
+
+        Returns None if the backend does not support autodiff.
+        """
+        ...
+
     def solve(
         self, tax_input: TaxReturnInput, output: str, target: float, var: str
     ) -> float | None:

--- a/src/tenforty/core.py
+++ b/src/tenforty/core.py
@@ -969,6 +969,7 @@ def marginal_rate(
     itemized_deductions: float = 0.0,
     state_adjustment: float = 0.0,
     incentive_stock_option_gains: float = 0.0,
+    dependent_exemptions: float = 0.0,
     *,
     wrt: str = "w2_income",
     output: str = "total_tax",
@@ -995,6 +996,7 @@ def marginal_rate(
         itemized_deductions=itemized_deductions,
         state_adjustment=state_adjustment,
         incentive_stock_option_gains=incentive_stock_option_gains,
+        dependent_exemptions=dependent_exemptions,
     )
 
     from .backends.graph import GraphBackend
@@ -1004,6 +1006,68 @@ def marginal_rate(
         raise RuntimeError("Graph backend is not available")
 
     result = backend.gradient(tax_input, output, wrt)
+    if result is None:
+        raise RuntimeError("Graph backend does not support autodiff")
+
+    return result
+
+
+def marginal_rates(
+    year: int = 2025,
+    state: str | None = None,
+    filing_status: str = "Single",
+    num_dependents: int = 0,
+    standard_or_itemized: str = "Standard",
+    w2_income: float = 0.0,
+    taxable_interest: float = 0.0,
+    qualified_dividends: float = 0.0,
+    ordinary_dividends: float = 0.0,
+    short_term_capital_gains: float = 0.0,
+    long_term_capital_gains: float = 0.0,
+    self_employment_income: float = 0.0,
+    rental_income: float = 0.0,
+    schedule_1_income: float = 0.0,
+    itemized_deductions: float = 0.0,
+    state_adjustment: float = 0.0,
+    incentive_stock_option_gains: float = 0.0,
+    dependent_exemptions: float = 0.0,
+    *,
+    output: str = "total_tax",
+) -> dict[str, float]:
+    """Compute marginal rates for every continuous public input.
+
+    Smooth inputs are differentiated together in one reverse pass per resolved
+    output. At a piecewise boundary, affected entries use the composed
+    function's right-hand derivative, matching :func:`marginal_rate`.
+    """
+    tax_input = TaxReturnInput(
+        year=year,
+        state=state,
+        filing_status=filing_status,
+        num_dependents=num_dependents,
+        standard_or_itemized=standard_or_itemized,
+        w2_income=w2_income,
+        taxable_interest=taxable_interest,
+        qualified_dividends=qualified_dividends,
+        ordinary_dividends=ordinary_dividends,
+        short_term_capital_gains=short_term_capital_gains,
+        long_term_capital_gains=long_term_capital_gains,
+        self_employment_income=self_employment_income,
+        rental_income=rental_income,
+        schedule_1_income=schedule_1_income,
+        itemized_deductions=itemized_deductions,
+        state_adjustment=state_adjustment,
+        incentive_stock_option_gains=incentive_stock_option_gains,
+        dependent_exemptions=dependent_exemptions,
+    )
+
+    from .backends.graph import GraphBackend
+
+    backend = GraphBackend()
+    if not backend.is_available():
+        raise RuntimeError("Graph backend is not available")
+
+    result = backend.gradients(tax_input, output)
     if result is None:
         raise RuntimeError("Graph backend does not support autodiff")
 

--- a/tests/full_gradient_matrix_test.py
+++ b/tests/full_gradient_matrix_test.py
@@ -205,7 +205,7 @@ def test_full_graph_gradient_matrix_matches_evaluation_path():
     ),
 )
 def test_regional_gradient_matrix_around_boundaries(region, wrt, output, offset):
-    """Probe around every named region, with exact boundaries sampled directly."""
+    """Pin scalar wiring and grouped-gradient agreement in composed-smooth cells."""
     case = _case(region)
     value = float(case.get(wrt, 0.0)) + offset
     case[wrt] = value if wrt in _SIGNED_INCOMES else max(0.0, value)
@@ -213,6 +213,11 @@ def test_regional_gradient_matrix_around_boundaries(region, wrt, output, offset)
     assume(abs(forward - backward) < _GRAPH_TOLERANCE)
 
     analytical = _gradient(case, wrt, output)
+    vector = GraphBackend().gradients(TaxReturnInput(**case), output)
+    assert vector is not None
+    assert vector[wrt] == pytest.approx(analytical, abs=1e-12, rel=0.0), _failure(
+        region, wrt, output, vector[wrt], analytical
+    )
     assert analytical == pytest.approx(central, abs=_GRAPH_TOLERANCE), _failure(
         region, wrt, output, analytical, central
     )

--- a/tests/gradient_vector_test.py
+++ b/tests/gradient_vector_test.py
@@ -1,0 +1,171 @@
+"""Full-vector autodiff through the public graph API."""
+
+from __future__ import annotations
+
+import pytest
+
+from tenforty import marginal_rate, marginal_rates
+from tenforty.backends import GraphBackend, OTSBackend
+from tenforty.models import TaxReturnInput
+
+
+@pytest.fixture(scope="module")
+def graph_backend() -> GraphBackend:
+    """Provide the compiled graph backend or skip this module's integration tests."""
+    backend = GraphBackend()
+    if not backend.is_available():
+        pytest.skip("Graph backend not available")
+    return backend
+
+
+def test_gradient_vector_matches_scalar_api(graph_backend):
+    """Every vector entry retains the scalar natural-input semantics."""
+    tax_input = TaxReturnInput(
+        year=2024,
+        filing_status="Single",
+        w2_income=120_000.0,
+        taxable_interest=3_000.0,
+        qualified_dividends=2_000.0,
+        ordinary_dividends=5_000.0,
+        short_term_capital_gains=4_000.0,
+        long_term_capital_gains=6_000.0,
+        self_employment_income=10_000.0,
+        rental_income=2_000.0,
+        schedule_1_income=1_000.0,
+        itemized_deductions=20_000.0,
+        incentive_stock_option_gains=3_000.0,
+    )
+
+    gradients = graph_backend.gradients(tax_input, "federal_total_tax")
+
+    assert gradients is not None
+    assert list(gradients) == [
+        "w2_income",
+        "taxable_interest",
+        "qualified_dividends",
+        "ordinary_dividends",
+        "short_term_capital_gains",
+        "long_term_capital_gains",
+        "self_employment_income",
+        "rental_income",
+        "schedule_1_income",
+        "itemized_deductions",
+        "incentive_stock_option_gains",
+    ]
+    for natural_name, vector_gradient in gradients.items():
+        scalar_gradient = graph_backend.gradient(
+            tax_input, "federal_total_tax", natural_name
+        )
+        assert vector_gradient == pytest.approx(scalar_gradient, abs=1e-12)
+
+
+@pytest.mark.parametrize(
+    "natural_name",
+    ["w2_income", "taxable_interest", "long_term_capital_gains"],
+)
+def test_gradient_vector_matches_finite_difference_away_from_kinks(
+    graph_backend, natural_name
+):
+    """Representative smooth entries agree with a centered value oracle."""
+    tax_input = TaxReturnInput(
+        year=2024,
+        filing_status="Single",
+        w2_income=120_000.0,
+        taxable_interest=3_000.0,
+        qualified_dividends=2_000.0,
+        ordinary_dividends=5_000.0,
+        short_term_capital_gains=4_000.0,
+        long_term_capital_gains=6_000.0,
+    )
+    step = 0.01
+    value = getattr(tax_input, natural_name)
+    plus = tax_input.model_copy(update={natural_name: value + step})
+    minus = tax_input.model_copy(update={natural_name: value - step})
+
+    gradients = graph_backend.gradients(tax_input, "federal_total_tax")
+    finite_difference = (
+        graph_backend.evaluate(plus).federal_total_tax
+        - graph_backend.evaluate(minus).federal_total_tax
+    ) / (2 * step)
+
+    assert gradients is not None
+    assert gradients[natural_name] == pytest.approx(finite_difference, abs=1e-6)
+
+
+def test_gradient_vector_preserves_state_fanout_after_federal_kink(graph_backend):
+    """A vector probe cannot erase a state-side value used by a later output."""
+    tax_input = TaxReturnInput(
+        year=2024,
+        state="NH",
+        filing_status="Single",
+        w2_income=150_000.0,
+        taxable_interest=50_000.0,
+    )
+
+    gradients = graph_backend.gradients(tax_input, "total_tax")
+    scalar = graph_backend.gradient(tax_input, "total_tax", "taxable_interest")
+
+    assert gradients is not None
+    assert gradients["taxable_interest"] == pytest.approx(scalar, abs=1e-12)
+    assert gradients["taxable_interest"] == pytest.approx(0.308, abs=1e-6)
+
+
+def test_gradient_vector_preserves_right_derivative_at_coincident_kinks(graph_backend):
+    """The vector agrees with the scalar right derivative at the Medicare tie."""
+    tax_input = TaxReturnInput(
+        year=2024,
+        filing_status="Single",
+        w2_income=200_000.0,
+    )
+
+    gradients = graph_backend.gradients(tax_input, "federal_additional_medicare_tax")
+    scalar = graph_backend.gradient(
+        tax_input, "federal_additional_medicare_tax", "w2_income"
+    )
+
+    assert gradients is not None
+    assert gradients["w2_income"] == pytest.approx(scalar, abs=1e-12)
+    assert gradients["w2_income"] == pytest.approx(0.009, abs=1e-8)
+
+
+@pytest.mark.parametrize(
+    ("state", "state_input"),
+    [("CA", "state_adjustment"), ("GA", "dependent_exemptions")],
+)
+def test_gradient_vector_includes_selected_state_inputs(
+    graph_backend, state, state_input
+):
+    """Only continuous inputs mapped by the selected state join the vector."""
+    tax_input = TaxReturnInput(year=2024, state=state, w2_income=100_000.0)
+
+    gradients = graph_backend.gradients(tax_input, "total_tax")
+
+    assert gradients is not None
+    assert state_input in gradients
+
+
+def test_public_marginal_rates_matches_scalar_entry(graph_backend):
+    """The package-level vector API agrees with the existing scalar API."""
+    rates = marginal_rates(
+        year=2024,
+        state="CA",
+        filing_status="Single",
+        w2_income=100_000.0,
+    )
+
+    assert rates["w2_income"] == pytest.approx(
+        marginal_rate(
+            year=2024,
+            state="CA",
+            filing_status="Single",
+            w2_income=100_000.0,
+        ),
+        abs=1e-12,
+    )
+
+
+def test_ots_backend_has_no_gradient_vector():
+    """The protocol exposes the unsupported operation consistently on OTS."""
+    tax_input = TaxReturnInput(year=2024, w2_income=100_000.0)
+
+    assert OTSBackend().gradients(tax_input, "total_tax") is None

--- a/tests/unified_api_test.py
+++ b/tests/unified_api_test.py
@@ -2,7 +2,13 @@
 
 import pytest
 
-from tenforty import evaluate_return, evaluate_returns, marginal_rate, solve_for_income
+from tenforty import (
+    evaluate_return,
+    evaluate_returns,
+    marginal_rate,
+    marginal_rates,
+    solve_for_income,
+)
 
 
 class TestEvaluateReturn:
@@ -104,6 +110,19 @@ class TestMarginalRate:
 
         rate = marginal_rate(year=2024, w2_income=100_000)
         assert 0 < rate < 1
+
+
+class TestMarginalRates:
+    """Tests for the full gradient-vector API."""
+
+    def test_marginal_rates_raises_without_graph(self, monkeypatch):
+        """marginal_rates should fail clearly when graph support is absent."""
+        from tenforty.backends.graph import GraphBackend
+
+        monkeypatch.setattr(GraphBackend, "is_available", lambda self: False)
+
+        with pytest.raises(RuntimeError, match="Graph backend is not available"):
+            marginal_rates(year=2024, w2_income=100_000)
 
 
 class TestSolveForIncome:


### PR DESCRIPTION
## Summary

- expose `marginal_rates(...)`, returning gradients keyed by public natural input names
- compute smooth gradient groups with one reverse traversal per resolved output
- preserve scalar composed right-derivative semantics independently for inputs crossing active kinks
- retain federal/state fan-out, validator-derived couplings, and OTS protocol compatibility
- document the vector API and its boundary convention
- pin per-group kink selection with a mixed smooth/kink Rust regression and scalar/vector equality in the regional boundary matrix

Bead: `tenforty-xei`

## Local validation

- Rust: 35 passed
- Rust clippy/all-targets: passed
- pre-commit: passed
- graph formatting, strict lint, generation, and forms sync: passed
- ordinary suite: 1,002 passed, 12 skipped, 22 xfailed
- deep sweep: 1,002 passed, 12 skipped, 22 xfailed (318s)
- focused compiled vector suite: 10 passed
- OTS/graph parity: 44 passed, 8 skipped, 11 xfailed
- TaxCalc 6.7.2 differential: 14 passed, 1 xfailed