### PR TITLE
test(taxcalc): narrow the graph QBI signature

### DIFF
--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -93,10 +93,11 @@ everything downstream of them.
   business W-2 wages / UBIA / SSTB status — concepts absent from tenforty's
   API (taxcalc assumes zero business wages, phasing the deduction to zero
   above the upper threshold). Any fix must choose an assumption there and
-  document it. The graph's threshold table also incorrectly gives qualifying
-  widow(er) the doubled MFJ threshold; Form 8995 assigns widow(er) the
-  all-other-returns threshold. Both graph limitations are tracked by
-  tenforty-mhe.
+  document it. The spec also exports an unused QBI threshold table whose
+  qualifying-widow(er) value incorrectly matches MFJ rather than the
+  all-other-returns threshold. That dead constant does not affect results
+  today, but must be corrected before a future Form 8995 gate consumes it;
+  both pieces of work are tracked by tenforty-mhe.
 - **Signature narrowed (tenforty-gyp):** OTS remains excused on every
   self-employment case because it still omits Form 8995. Graph is now excused
   only when generated gross income can exceed the applicable simplified-method

--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -19,7 +19,7 @@ delete the signature, and update this table in the same PR.
 |----|---------|----------|--------|----------|
 | F1 | Schedule SE L8a never filled | mapping, both backends | fixed (#279, v2025.11) | @bg002h, #278 |
 | F2 | SE-tax error propagates to AGI | consequence of F1 | fixed with F1 | @bg002h, #278 |
-| F3 | QBI: missing (OTS) / gross base (graph) | OTS orchestration + graph spec | graph base fixed (tenforty-6hr); OTS omission + graph above-threshold open | @bg002h, #278 |
+| F3 | QBI: missing (OTS) / above-threshold limit (graph) | OTS orchestration + graph spec | graph base fixed and below-threshold signature narrowed; OTS omission + graph above-threshold open | @bg002h, #278 |
 | F4 | Form 8960 L5a omits short-term gains | mapping, both backends | fixed (OTS #296, graph: L5a imports Schedule D L16) | mapping assessment + differential sweep |
 | F5 | Graph Form 8959 Part II drops SE earnings (line 12 used min, not subtract) | graph spec | fixed | mapping assessment + differential sweep |
 | F6 | OTS 8959 never fires with zero wages | OTS activation semantics | fixed | differential sweep |
@@ -93,7 +93,21 @@ everything downstream of them.
   business W-2 wages / UBIA / SSTB status — concepts absent from tenforty's
   API (taxcalc assumes zero business wages, phasing the deduction to zero
   above the upper threshold). Any fix must choose an assumption there and
-  document it.
+  document it. The graph's threshold table also incorrectly gives qualifying
+  widow(er) the doubled MFJ threshold; Form 8995 assigns widow(er) the
+  all-other-returns threshold. Both graph limitations are tracked by
+  tenforty-mhe.
+- **Signature narrowed (tenforty-gyp):** OTS remains excused on every
+  self-employment case because it still omits Form 8995. Graph is now excused
+  only when generated gross income can exceed the applicable simplified-method
+  threshold ($191,950 / $383,900 MFJ in 2024; $197,300 / $394,600 MFJ in
+  2025). The predicate is deliberately conservative because signatures receive
+  inputs rather than computed taxable income: deductions may keep a high-gross
+  case below the threshold, but a case whose gross income is at or below the
+  threshold cannot cross it. Deterministic Single anchors cover both the net QBI
+  base ($50k wages / $80k SE) and its capital-gain limitation ($100k SE / $60k
+  LTCG); the latter makes the differential fail if Form 8995 line 13 stops
+  importing net capital gain.
 
 ### F4. NIIT omits short-term capital gains — shared omission, both backends
 

--- a/tests/known_defects_test.py
+++ b/tests/known_defects_test.py
@@ -60,6 +60,27 @@ def test_graph_qbi_uses_net_base():
     assert r.federal_taxable_income == pytest.approx(94_878.54, abs=1.0)
 
 
+@skip_if_graph_unavailable
+@pytest.mark.xfail(
+    reason="F3: graph never switches from Form 8995 to Form 8995-A",
+    strict=True,
+)
+def test_graph_qbi_applies_above_threshold_limitation():
+    """Single, $250k SE profit: Form 8995-A limits QBI with no business wages.
+
+    Tax-Calculator 6.7.2 assumes zero business W-2 wages and UBIA for the
+    inputs tenforty exposes, producing taxable income of $202,371.67. The graph
+    instead applies simplified Form 8995 above its statutory threshold.
+    """
+    r = evaluate_return(
+        year=2024,
+        filing_status="Single",
+        self_employment_income=250_000,
+        backend="graph",
+    )
+    assert r.federal_taxable_income == pytest.approx(202_371.67, abs=1.0)
+
+
 def test_ots_niit_includes_short_term_gains():
     """$300k wages + $50k STCG: NIIT is 3.8% of $50k = $1,900."""
     r = evaluate_return(

--- a/tests/taxcalc/policy_test.py
+++ b/tests/taxcalc/policy_test.py
@@ -1,0 +1,101 @@
+"""Focused tests for known-defect signature boundaries."""
+
+import pytest
+
+from .taxcalc_policy import (
+    QBI_SIMPLIFIED_THRESHOLD,
+    _f3_qbi,
+)
+
+_QBI_QUANTITIES = {"taxable_income", "income_tax", "total_tax"}
+_EXPECTED_QBI_THRESHOLDS = {
+    (2024, "Single"): 191_950.0,
+    (2024, "Married/Joint"): 383_900.0,
+    (2024, "Married/Sep"): 191_950.0,
+    (2024, "Head_of_House"): 191_950.0,
+    (2024, "Widow(er)"): 191_950.0,
+    (2025, "Single"): 197_300.0,
+    (2025, "Married/Joint"): 394_600.0,
+    (2025, "Married/Sep"): 197_300.0,
+    (2025, "Head_of_House"): 197_300.0,
+    (2025, "Widow(er)"): 197_300.0,
+}
+
+
+def _case(**updates):
+    case = {
+        "year": 2024,
+        "status": "Single",
+        "w2": 0.0,
+        "se": 0.0,
+        "stcg": 0.0,
+        "ltcg": 0.0,
+        "interest": 0.0,
+        "ord_div": 0.0,
+    }
+    case.update(updates)
+    return case
+
+
+def test_f3_keeps_ots_qbi_broadly_excused():
+    """OTS still omits QBI even when Form 8995's simplified method applies."""
+    case = _case(w2=50_000.0, se=80_000.0)
+
+    assert _f3_qbi("ots", case) == _QBI_QUANTITIES
+
+
+def test_f3_exposes_the_graph_net_qbi_anchor():
+    """The corrected below-threshold graph case must reach the differential."""
+    case = _case(w2=50_000.0, se=80_000.0)
+
+    assert _f3_qbi("graph", case) == set()
+
+
+def test_qbi_simplified_thresholds_match_form_8995():
+    """Only married filing jointly receives the doubled statutory threshold."""
+    assert QBI_SIMPLIFIED_THRESHOLD == _EXPECTED_QBI_THRESHOLDS
+
+
+@pytest.mark.parametrize(
+    ("year", "status", "threshold"),
+    [
+        (year, status, threshold)
+        for (year, status), threshold in _EXPECTED_QBI_THRESHOLDS.items()
+    ],
+)
+def test_f3_graph_excusal_starts_above_the_gross_income_threshold(
+    year, status, threshold
+):
+    """Every supported year/status uses its statutory Form 8995 threshold."""
+    at_threshold = _case(
+        year=year,
+        status=status,
+        w2=threshold - 1.0,
+        se=1.0,
+    )
+    above_threshold = {**at_threshold, "w2": threshold}
+
+    assert _f3_qbi("graph", at_threshold) == set()
+    assert _f3_qbi("graph", above_threshold) == _QBI_QUANTITIES
+
+
+@pytest.mark.parametrize("backend", ["ots", "graph"])
+def test_f3_does_not_fire_without_self_employment_income(backend):
+    """The signature cannot hide unrelated high-income disagreements."""
+    case = _case(w2=1_000_000.0)
+
+    assert _f3_qbi(backend, case) == set()
+
+
+def test_f3_unknown_contract_fails_loud():
+    """An unregistered year/status must not silently inherit an excusal."""
+    case = _case(year=2026, w2=500_000.0, se=1.0)
+
+    assert _f3_qbi("graph", case) == set()
+
+
+def test_f3_negative_gains_cannot_lower_the_conservative_bound():
+    """Future capital-loss generation must not expose an above-threshold case."""
+    case = _case(w2=191_950.0, se=1.0, stcg=-1_000_000.0)
+
+    assert _f3_qbi("graph", case) == _QBI_QUANTITIES

--- a/tests/taxcalc/taxcalc_differential_test.py
+++ b/tests/taxcalc/taxcalc_differential_test.py
@@ -122,6 +122,8 @@ def _anchor(**kw):
 ANCHOR_NIIT_STCG = _anchor(w2=300_000.0, stcg=50_000.0)
 ANCHOR_SE_WAGE_BASE = _anchor(w2=168_600.0, se=60_000.0)
 ANCHOR_8959_NO_WAGES = _anchor(se=300_000.0)
+ANCHOR_QBI_NET_BASE = _anchor(w2=50_000.0, se=80_000.0)
+ANCHOR_QBI_CAPITAL_GAIN_LIMIT = _anchor(se=100_000.0, ltcg=60_000.0)
 
 
 def taxcalc_batch(cases, wage_attribution="primary"):
@@ -232,6 +234,8 @@ def tenforty_components(case, backend):
 @example(cases=[ANCHOR_NIIT_STCG])
 @example(cases=[ANCHOR_SE_WAGE_BASE])
 @example(cases=[ANCHOR_8959_NO_WAGES])
+@example(cases=[ANCHOR_QBI_NET_BASE])
+@example(cases=[ANCHOR_QBI_CAPITAL_GAIN_LIMIT])
 @pytest.mark.parametrize("backend", ["ots", "graph"])
 def test_components_match_taxcalc(backend, cases):
     """Every quantity matches taxcalc within tolerance, unless excused by name."""

--- a/tests/taxcalc/taxcalc_policy.py
+++ b/tests/taxcalc/taxcalc_policy.py
@@ -26,20 +26,53 @@ STANDARD_DEDUCTION = {
     (2025, "Widow(er)"): 31_500.0,
 }
 
+QBI_SIMPLIFIED_THRESHOLD = {
+    (2024, "Single"): 191_950.0,
+    (2024, "Married/Joint"): 383_900.0,
+    (2024, "Married/Sep"): 191_950.0,
+    (2024, "Head_of_House"): 191_950.0,
+    (2024, "Widow(er)"): 191_950.0,
+    (2025, "Single"): 197_300.0,
+    (2025, "Married/Joint"): 394_600.0,
+    (2025, "Married/Sep"): 197_300.0,
+    (2025, "Head_of_House"): 197_300.0,
+    (2025, "Widow(er)"): 197_300.0,
+}
+
+_QBI_AFFECTED_QUANTITIES = {"taxable_income", "income_tax", "total_tax"}
+
 
 def _f3_qbi(backend: str, case: dict) -> set[str]:
-    """F3: QBI divergence on self-employment cases, now from two causes.
+    """F3: QBI divergence on self-employment cases from two remaining causes.
 
     OTS omits the deduction entirely (it reads 1040 line 13 as a direct input
-    and nothing supplies it — tenforty-6hr follow-up). The graph now nets the
-    half-SE deduction into the QBI base and agrees with taxcalc below the
-    section 199A threshold; above it the graph still uses the simplified Form
-    8995 (no W-2-wage/UBIA limit), so it diverges from taxcalc there — a
-    distinct limitation tracked separately. Both faults land on the same
-    self-employment cases, so the excusal stays broad until each is closed.
+    and nothing supplies it — tenforty-2u6), so every OTS case with QBI remains
+    excused. The graph agrees with taxcalc under the Form 8995 simplified-method
+    threshold, but lacks the Form 8995-A W-2-wage/UBIA limit above it
+    (tenforty-mhe).
+
+    Signature functions receive inputs rather than computed taxable income.
+    Gross generated income is a conservative proxy: deductions and the half-SE
+    adjustment can only reduce taxable income, so gross at or below the threshold
+    proves that Form 8995 applies. Gross above the threshold remains excused even
+    when deductions ultimately keep the case below it.
     """
-    if case.get("se", 0):
-        return {"taxable_income", "income_tax", "total_tax"}
+    if case.get("se", 0) <= 0:
+        return set()
+    if backend == "ots":
+        return _QBI_AFFECTED_QUANTITIES.copy()
+    if backend != "graph":
+        return set()
+
+    threshold = QBI_SIMPLIFIED_THRESHOLD.get((case.get("year"), case.get("status")))
+    if threshold is None:
+        return set()
+    income_upper_bound = sum(
+        max(0.0, case.get(field, 0))
+        for field in ("w2", "se", "stcg", "ltcg", "interest", "ord_div")
+    )
+    if income_upper_bound > threshold:
+        return _QBI_AFFECTED_QUANTITIES.copy()
     return set()
 
 


### PR DESCRIPTION
## Summary

- keep the F3 QBI excusal broad for OTS, which still omits Form 8995
- expose graph QBI cases whose gross-income upper bound is at or below the statutory simplified-method threshold
- pin every 2024/2025 filing-status boundary and add deterministic net-base and capital-gain-limit anchors
- add a strict-xfail burn-in for the active above-threshold Form 8995-A gap
- clarify that the incorrect qualifying-widow threshold is currently an unused constant that must be corrected before a future gate consumes it

## Why the proxy is safe

The policy only has generated inputs, not computed taxable income. Summing nonnegative generated income is an upper bound: deductions can move an above-bound case below the threshold, but cannot move an at-or-below-bound case above it. The signature can therefore remain conservatively broad without hiding below-threshold regressions.

## Validation

- `uv run pytest tests/taxcalc/policy_test.py -q --tb=line` — 17 passed
- `TENFORTY_TAXCALC=1 uv run pytest tests/taxcalc/ -q --tb=line` with TaxCalc 6.7.2 — 33 passed, 1 xfailed
- `uv run pytest tests/ -q --tb=line` — 1022 passed, 12 skipped, 23 xfailed
- `make run-hooks` — passed

## Mutation proof

Temporarily replacing Form 8995 line 13 net-capital-gain import with a key input makes the new Single anchor (`se=100000`, `ltcg=60000`) fail immediately: taxable income differs by $2,920.00 and total tax by $642.40. Restoring the import returns the complete TaxCalc suite to green.

The active above-threshold defect is separately pinned by a strict xfail: 2024 Single with $250,000 of SE income should produce $202,371.67 of taxable income under the TaxCalc 6.7.2 zero-business-wages assumption; the graph currently reports $177,279.29.

Closes tenforty-gyp after merge.