### PR TITLE
test(fixtures): add self-employment QBI pins

### DIFF
--- a/tests/fixtures/scenarios.py
+++ b/tests/fixtures/scenarios.py
@@ -27,7 +27,10 @@ from .tax_scenario import TaxScenario
 def scenario_id(scenario: TaxScenario) -> str:
     """Generate a pytest test ID from a scenario."""
     state_part = scenario.state or "FED"
-    return f"{state_part}-{scenario.year}-{scenario.filing_status}-{int(scenario.w2_income)}"
+    incomes = str(int(scenario.w2_income))
+    if scenario.self_employment_income:
+        incomes += f"-SE-{int(scenario.self_employment_income)}"
+    return f"{state_part}-{scenario.year}-{scenario.filing_status}-{incomes}"
 
 
 def run_tax_scenario(scenario: TaxScenario):
@@ -40,6 +43,7 @@ def run_tax_scenario(scenario: TaxScenario):
         state=scenario.state,
         filing_status=scenario.filing_status,
         w2_income=scenario.w2_income,
+        self_employment_income=scenario.self_employment_income,
         taxable_interest=scenario.taxable_interest,
         qualified_dividends=scenario.qualified_dividends,
         ordinary_dividends=scenario.ordinary_dividends,
@@ -80,6 +84,16 @@ def run_tax_scenario(scenario: TaxScenario):
             failures.append(
                 f"[{scenario.source}] AGI {result.federal_adjusted_gross_income} != "
                 f"expected {scenario.expected_federal_agi}"
+            )
+
+    if scenario.expected_federal_taxable_income is not None:
+        if result.federal_taxable_income != pytest.approx(
+            scenario.expected_federal_taxable_income, abs=0.01
+        ):
+            failures.append(
+                f"[{scenario.source}] Taxable income "
+                f"{result.federal_taxable_income} != "
+                f"expected {scenario.expected_federal_taxable_income}"
             )
 
     if scenario.known_failure:

--- a/tests/fixtures/silver_federal_scenarios.py
+++ b/tests/fixtures/silver_federal_scenarios.py
@@ -268,6 +268,47 @@ SILVER_STANDARD_FEDERAL_SCENARIOS = [
         expected_federal_tax=10965.0,
         expected_federal_agi=101900.0,
     ),
+    # Single with $100k SE profit and $60k LTCG.
+    # AGI: $100,000 - $7,064.775 half-SE tax + $60,000 = $152,935.225.
+    # Taxable before QBI: $152,935.225 - $14,600 standard deduction = $138,335.225.
+    # Form 8995 capital-gain limit:
+    # ($138,335.225 - $60,000) * 20% = $15,667.045 QBI deduction.
+    # Taxable income: $138,335.225 - $15,667.045 = $122,668.18.
+    # Income tax: $17,839.9996; SE tax: $14,129.55; total: $31,969.5496.
+    TaxScenario(
+        source="Tax-Calculator 6.7.2 / IRS Form 8995",
+        description="Single below QBI threshold with SE income and LTCG limit",
+        year=2024,
+        state=None,
+        filing_status="Single",
+        w2_income=0.0,
+        self_employment_income=100000.0,
+        long_term_capital_gains=60000.0,
+        expected_federal_tax=31969.5496,
+        expected_federal_agi=152935.225,
+        expected_federal_taxable_income=122668.18,
+        backend="graph",
+    ),
+    # Single with $250k SE profit and $60k LTCG. Tax-Calculator assumes zero
+    # business W-2 wages and UBIA for tenforty's input surface, so Form 8995-A
+    # reduces QBI to zero: taxable income is AGI $296,199.1125 less the $14,600
+    # standard deduction. The graph still applies simplified Form 8995 and
+    # deducts $44,319.8225, tracked by tenforty-mhe.
+    TaxScenario(
+        source="Tax-Calculator 6.7.2 / IRS Form 8995-A",
+        description="Single above QBI threshold with SE income and LTCG",
+        year=2024,
+        state=None,
+        filing_status="Single",
+        w2_income=0.0,
+        self_employment_income=250000.0,
+        long_term_capital_gains=60000.0,
+        expected_federal_tax=87757.866,
+        expected_federal_agi=296199.1125,
+        expected_federal_taxable_income=281599.1125,
+        known_failure="Graph lacks the above-threshold Form 8995-A limitation",
+        backend="graph",
+    ),
     # 2023 Single filer in 12% bracket
     # Taxable income: $30,000
     # Formula: $3,380

--- a/tests/fixtures/silver_federal_scenarios.py
+++ b/tests/fixtures/silver_federal_scenarios.py
@@ -293,7 +293,10 @@ SILVER_STANDARD_FEDERAL_SCENARIOS = [
     # business W-2 wages and UBIA for tenforty's input surface, so Form 8995-A
     # reduces QBI to zero: taxable income is AGI $296,199.1125 less the $14,600
     # standard deduction. The graph still applies simplified Form 8995 and
-    # deducts $44,319.8225, tracked by tenforty-mhe.
+    # deducts $44,319.8225, tracked by tenforty-mhe. These expected values pin
+    # Tax-Calculator's assumption, not a tenforty policy decision: if mhe adds
+    # business-wage/UBIA inputs, update this scenario rather than merely
+    # removing known_failure.
     TaxScenario(
         source="Tax-Calculator 6.7.2 / IRS Form 8995-A",
         description="Single above QBI threshold with SE income and LTCG",

--- a/tests/fixtures/tax_scenario.py
+++ b/tests/fixtures/tax_scenario.py
@@ -13,6 +13,7 @@ class TaxScenario:
     state: str | None
     filing_status: str
     w2_income: float
+    self_employment_income: float = 0.0
     taxable_interest: float = 0.0
     qualified_dividends: float = 0.0
     ordinary_dividends: float = 0.0
@@ -24,5 +25,6 @@ class TaxScenario:
     expected_federal_tax: float | None = None
     expected_state_tax: float | None = None
     expected_federal_agi: float | None = None
+    expected_federal_taxable_income: float | None = None
     known_failure: str | None = None
     backend: str | None = None


### PR DESCRIPTION
## Summary

- let `TaxScenario` express self-employment income and forward it through the shared runner
- add an asserted federal taxable-income output so silver scenarios can pin the effect of QBI end to end
- add a passing 2024 Single SE-plus-LTCG value case below the Form 8995 threshold where the capital-gain limit binds
- exercise the above-threshold SE-plus-LTCG composition through the scenario machinery, complementing the strict xfail already on main for the same Form 8995-A defect
- preserve existing scenario IDs while giving SE cases a distinguishing suffix

## Coverage scope

The fixture threading closes the structural gap: the silver tier previously could not express self-employment income at all. The numeric cases add independently sourced, hand-checkable end-to-end evidence in that tier. They are not the repository first detectors for these graph defects: existing structural and golden tests already catch the line-13 mutation, and main already carries a strict xfail for the above-threshold Form 8995-A gap.

## Numeric pins

The values were queried locally from pinned TaxCalc 6.7.2.

- below threshold: `se=100000`, `ltcg=60000`; QBI deduction $15,667.045, taxable income $122,668.18, federal total tax $31,969.5496
- above threshold: `se=250000`, `ltcg=60000`; TaxCalc assumes zero business wages/UBIA and gives no QBI deduction, taxable income $281,599.1125, federal total tax $87,757.866; the graph remains a known failure under tenforty-mhe

The above-threshold expectation records the current TaxCalc oracle, not a tenforty policy decision. If tenforty-mhe exposes business-wage or UBIA inputs instead of adopting zero defaults, update the expected scenario rather than merely removing `known_failure`.

## Pin sensitivity check

Temporarily replacing the 2024 Form 8995 line 13 import with a key input and rebuilding the source graphs makes the new below-threshold silver scenario fail: taxable income moves by $2,920.00 and federal tax by $642.40. Restoring the import returns the scenario to green. This confirms that the end-to-end value pin responds to the wiring; existing tests on main also detect this mutation.

## Validation

- focused QBI scenarios — 1 passed, 1 xfailed
- `uv run pytest tests/silver_standard_test.py -q --tb=line` — 233 passed, 4 xfailed
- `uv run pytest tests/ -q --tb=line` — 1023 passed, 12 skipped, 24 xfailed
- `make run-hooks` — passed

This is test-fixture work rather than a compute-engine change, so the deep engine sweep trio is not required.

Closes tenforty-z10 after merge.