### PR TITLE
fix(ots): orchestrate Form 8995 deduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ Here are all arguments available for those two functions:
 | `short_term_capital_gains`   | float                    | 0.0                 |                                    |
 | `long_term_capital_gains`    | float                    | 0.0                 |                                    |
 | `self_employment_income`     | float                    | 0.0                 | Schedule C profit used by Schedule SE and QBI |
-| `qbi_w2_wages`               | float                    | 0.0                 | Graph only: W-2 wages paid by the QBI business or aggregation |
-| `qbi_ubia`                   | float                    | 0.0                 | Graph only: UBIA of qualified property for that business or aggregation |
-| `qbi_is_sstb`                | bool                     | False               | Graph only: whether that business or aggregation is an SSTB |
+| `qbi_w2_wages`               | float                    | 0.0                 | W-2 wages paid by the QBI business or aggregation |
+| `qbi_ubia`                   | float                    | 0.0                 | UBIA of qualified property for that business or aggregation |
+| `qbi_is_sstb`                | bool                     | False               | Whether that business or aggregation is an SSTB |
 | `schedule_1_income`          | float                    | 0.0                 |                                    |
 | `itemized_deductions`        | float                    | 0.0                 |                                    |
 | `state_adjustment`           | float                    | 0.0                 |                                    |
@@ -104,9 +104,10 @@ The three `qbi_` inputs describe one trade or business, or businesses the
 taxpayer has validly aggregated for section 199A. They are not totals across
 unrelated businesses, because Form 8995-A applies its wage and UBIA limitation
 per business or valid aggregation. Their defaults model a non-SSTB business
-with no business W-2 wages or qualified property. OpenTaxSolver does not
-compute Form 8995-A, so non-default `qbi_` inputs require `backend="graph"` and
-are rejected rather than silently ignored by the OTS backend.
+with no business W-2 wages or qualified property. The OTS backend uses OTS's
+Form 8995 for the independent QBI base and taxable-income ceiling, then applies
+the missing Form 8995-A wage, property, and SSTB limitation in tenforty's
+orchestration layer before rerunning Form 1040.
 
 The functions output these fields:
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The functions output these fields:
 | federal_effective_tax_rate      | Percentage of AGI paid in federal tax                 |
 | federal_tax_bracket             | Marginal federal tax bracket (0-37%)                  |
 | federal_taxable_income          | Income subject to federal tax after deductions        |
+| federal_qbi_deduction           | Qualified business income deduction (Form 8995/8995-A) |
 | federal_amt                     | Federal Alternative Minimum Tax                       |
 | federal_income_tax              | Federal income tax + AMT (excludes SE tax, NIIT, Additional Medicare Tax) |
 | federal_se_tax                  | Federal self-employment tax (Schedule SE)             |

--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -19,7 +19,7 @@ delete the signature, and update this table in the same PR.
 |----|---------|----------|--------|----------|
 | F1 | Schedule SE L8a never filled | mapping, both backends | fixed (#279, v2025.11) | @bg002h, #278 |
 | F2 | SE-tax error propagates to AGI | consequence of F1 | fixed with F1 | @bg002h, #278 |
-| F3 | QBI: missing (OTS) / above-threshold limit (graph) | OTS orchestration + graph spec | graph fixed (tenforty-6hr, tenforty-mhe); OTS omission open (tenforty-2u6) | @bg002h, #278 |
+| F3 | QBI: missing (OTS) / above-threshold limit (graph) | OTS orchestration + graph spec | fixed (tenforty-6hr, tenforty-mhe, tenforty-2u6) | @bg002h, #278 |
 | F4 | Form 8960 L5a omits short-term gains | mapping, both backends | fixed (OTS #296, graph: L5a imports Schedule D L16) | mapping assessment + differential sweep |
 | F5 | Graph Form 8959 Part II drops SE earnings (line 12 used min, not subtract) | graph spec | fixed | mapping assessment + differential sweep |
 | F6 | OTS 8959 never fires with zero wages | OTS activation semantics | fixed | differential sweep |
@@ -98,9 +98,11 @@ everything downstream of them.
   cases agree with TaxCalc where its parameters are correct. The previously
   dead threshold table is now live, with qualifying widow(er) corrected to the
   all-other-returns threshold and $50,000 phase-in range.
-- **Signature narrowed (tenforty-gyp, completed by tenforty-mhe):** OTS remains
-  excused on every self-employment case because it still omits Form 8995. The
-  graph F3 excusal is gone across both the simplified and Form 8995-A regions.
+- **OTS fixed (tenforty-2u6):** a preliminary OTS 1040 now feeds OTS's own Form
+  8995, preserving an independent QBI base and taxable-income/capital-gain
+  ceiling. Tenforty's orchestration applies the Form 8995-A wage, UBIA, and SSTB
+  phase calculation that OTS does not implement, injects the resulting deduction,
+  and reruns the 1040. The F3 differential signature is gone for both backends.
   Deterministic anchors cover the net QBI base, capital-gain limitation,
   zero-wage phase-in, both wage/UBIA branches, and SSTB treatment. F21 separately
   records TaxCalc's qualifying-widow(er) phase-range defect; it is not attributed
@@ -428,14 +430,13 @@ bugs are batch-path defects this scalar harness deliberately did not probe.
    - Form 8960 input_map: add `short_term_capital_gains` summed into L5a (F4);
    - activation: decide form firing from the *natural inputs consumed*, not
      the post-format values (F6);
-   - Form 8995: new phase-2 subordinate config fed by
-     taxable-income-before-QBI from the 1040 pass (F3), with the phase-out
-     assumption documented.
+   - Form 8995: completed in tenforty-2u6 with a preliminary OTS 1040 feeding
+     OTS Form 8995, tenforty's Form 8995-A limitation, and a final 1040 pass
+     carrying the resulting deduction (F3).
 4. **API decisions** (blocking full correctness, owner's call):
    - per-spouse wage/SE fields (completes F1 for MFJ; taxcalc's
      `e00200p`/`e00200s` is a working reference);
    - define "Itemized": force vs best-of, then make both backends match (F7);
-   - §199A above-threshold assumption (F3).
 5. **Keep the reference**: promote the harness to `scripts/`, commit a pinned
    golden fixture set at the semantic boundaries, and run the three-way sweep
    as a scheduled/pre-release job. Parity catches divergence; only an

--- a/src/tenforty/backends/graph.py
+++ b/src/tenforty/backends/graph.py
@@ -41,6 +41,7 @@ if _INCOME_TAX_STATES_WITHOUT_GRAPH_CONFIG:
 FEDERAL_OUTPUT_NODES: dict[str, str] = {
     "us_1040_L11_agi": "federal_adjusted_gross_income",
     "us_1040_L15_taxable_income": "federal_taxable_income",
+    "us_form_8995_L16_qbi_deduction": "federal_qbi_deduction",
     "us_1040_L24_total_tax": "federal_total_tax",
     "us_form_6251_L11_amt": "federal_amt",
     "us_schedule_se_L10_se_tax": "federal_se_tax",

--- a/src/tenforty/core.py
+++ b/src/tenforty/core.py
@@ -361,9 +361,72 @@ def evaluate_form(
 
 _FORM_DISPATCH_ALIASES = {
     "Form_6781": "f6781",
+    "Form_8995": "f8995",
     "Form_8959": "f8959",
     "Form_8960": "f8960",
 }
+
+_QBI_THRESHOLDS = {
+    2024: {"joint": 383_900.0, "other": 191_950.0},
+    2025: {"joint": 394_600.0, "other": 197_300.0},
+}
+
+
+def _form_8995_input_values(
+    year: int,
+    federal_return: dict[str, Any],
+) -> dict[str, Any]:
+    qbi = federal_return.get("S1_3", 0.0) - sum(
+        federal_return.get(key, 0.0) for key in ("S1_15", "S1_16", "S1_17")
+    )
+    if "D15" in federal_return and "D16" in federal_return:
+        capital_gain = max(
+            0.0,
+            min(federal_return["D15"], federal_return["D16"]),
+        )
+    else:
+        gain_key = "L7a" if year >= 2025 else "L7"
+        capital_gain = max(0.0, federal_return.get(gain_key, 0.0))
+    net_capital_gain = max(
+        0.0,
+        federal_return.get("L3a", 0.0) + capital_gain,
+    )
+    return {
+        "FileName1040": "__FED_FILENAME__",
+        "L1_i_c": qbi,
+        "L12": net_capital_gain,
+    }
+
+
+def _form_8995a_deduction(
+    year: int,
+    filing_status: Any,
+    natural_input: dict[str, Any],
+    federal_return: dict[str, Any],
+    form_8995: dict[str, Any],
+) -> float:
+    threshold_kind = "joint" if str(filing_status) == "Married/Joint" else "other"
+    threshold = _QBI_THRESHOLDS[year][threshold_kind]
+    phase_range = 100_000.0 if threshold_kind == "joint" else 50_000.0
+    taxable_income_before_qbi = federal_return.get("L15", 0.0)
+    phase = min(
+        1.0,
+        max(0.0, (taxable_income_before_qbi - threshold) / phase_range),
+    )
+
+    applicable_percentage = 1.0 - phase if natural_input["qbi_is_sstb"] else 1.0
+    qbi_component = form_8995.get("L5", 0.0) * applicable_percentage
+    applicable_wages = natural_input["qbi_w2_wages"] * applicable_percentage
+    applicable_ubia = natural_input["qbi_ubia"] * applicable_percentage
+    wage_property_limit = max(
+        0.5 * applicable_wages,
+        0.25 * applicable_wages + 0.025 * applicable_ubia,
+    )
+    reduction = max(0.0, qbi_component - wage_property_limit) * phase
+    limited_qbi_component = qbi_component - reduction
+    reit_ptp_component = form_8995.get("L9", 0.0)
+    taxable_income_limit = form_8995.get("L14", 0.0)
+    return min(limited_qbi_component + reit_ptp_component, taxable_income_limit)
 
 
 def _evaluate_subordinate(
@@ -371,6 +434,7 @@ def _evaluate_subordinate(
     form_id: str,
     form_values: dict[str, Any],
     on_error: str = "raise",
+    fed_form_text: str | None = None,
 ) -> dict[str, Any]:
     """Evaluate a single subordinate form (Schedule SE, Form 8959, etc.)."""
     key = (year, form_id)
@@ -380,7 +444,13 @@ def _evaluate_subordinate(
     form_text = generate_ots_return(form_values, form_config)
     logger.debug(f"Raw {form_id} OTS Input:\n{form_text}")
     dispatch_id = _FORM_DISPATCH_ALIASES.get(form_id, form_id)
-    ots_output = otslib._evaluate_form(year, dispatch_id, form_text, on_error=on_error)
+    ots_output = otslib._evaluate_form(
+        year,
+        dispatch_id,
+        form_text,
+        fed_form_text=fed_form_text,
+        on_error=on_error,
+    )
     logger.debug(f"Raw {form_id} OTS Output:\n{ots_output}")
     return parse_ots_return(ots_output, year=year, form_id=form_id)
 
@@ -516,7 +586,66 @@ def evaluate_natural_input_form(
         )
     logger.debug(f"{state_form_values=}")
 
-    # Phase 2: Evaluate 1040 (and state) with injected subordinate results.
+    # Phase 2: Run a preliminary 1040 for forms whose result feeds back into it.
+    for sub_cfg in subordinate_configs:
+        if sub_cfg.phase != 2:
+            continue
+        if (year.value, sub_cfg.form_id) not in OTS_FORM_CONFIG:
+            continue
+        if not subordinate_form_applies(sub_cfg, natural_form_values):
+            continue
+
+        federal_form_config = OTS_FORM_CONFIG[(year.value, federal_form_id)]
+        preliminary_form_text = generate_ots_return(
+            federal_form_values, federal_form_config
+        )
+        preliminary_output = otslib._evaluate_form(
+            year.value,
+            federal_form_id,
+            preliminary_form_text,
+            on_error=on_error,
+        )
+        preliminary_return = parse_ots_return(
+            preliminary_output,
+            year=year.value,
+            form_id=federal_form_id,
+        )
+        sub_form_values = sub_cfg.defaults | _form_8995_input_values(
+            year.value, preliminary_return
+        )
+        try:
+            sub_result = _evaluate_subordinate(
+                year.value,
+                sub_cfg.form_id,
+                sub_form_values,
+                on_error=on_error,
+                fed_form_text=preliminary_output,
+            )
+        except Exception:
+            if on_error == "raise":
+                raise
+            if on_error == "warn":
+                logger.warning(
+                    "Subordinate form %s/%s failed; skipping.",
+                    year.value,
+                    sub_cfg.form_id,
+                    exc_info=True,
+                )
+            continue
+
+        qbi_deduction = _form_8995a_deduction(
+            year.value,
+            natural_form_values["filing_status"],
+            natural_form_values,
+            preliminary_return,
+            sub_result,
+        )
+        for fed_key in sub_cfg.export_map.values():
+            federal_form_values[fed_key] = qbi_deduction
+        for natural_name in sub_cfg.output_map.values():
+            subordinate_natural_outputs[natural_name] = qbi_deduction
+
+    # Evaluate the final 1040 (and state) with injected subordinate results.
     fed_import_map = (
         state_natural_config.fed_import_map if state_natural_config else None
     )
@@ -646,11 +775,6 @@ def evaluate_return(
     )
 
     if backend == "ots":
-        if input_data.qbi_w2_wages or input_data.qbi_ubia or input_data.qbi_is_sstb:
-            raise NotImplementedError(
-                "QBI business W-2 wages, UBIA, and SSTB status are supported only "
-                "by backend='graph'; OpenTaxSolver does not compute Form 8995-A."
-            )
         return InterpretedTaxReturn(
             **evaluate_natural_input_form(
                 input_data.year,

--- a/src/tenforty/core.py
+++ b/src/tenforty/core.py
@@ -19,6 +19,7 @@ from .models import (
     SUBORDINATE_FORM_CONFIG,
     InterpretedTaxReturn,
     OTSFieldTerminator,
+    OTSFilingStatus,
     OTSForm,
     OTSParseError,
     OTSState,
@@ -405,7 +406,9 @@ def _form_8995a_deduction(
     federal_return: dict[str, Any],
     form_8995: dict[str, Any],
 ) -> float:
-    threshold_kind = "joint" if str(filing_status) == "Married/Joint" else "other"
+    threshold_kind = (
+        "joint" if filing_status == OTSFilingStatus.MARRIED_JOINT else "other"
+    )
     threshold = _QBI_THRESHOLDS[year][threshold_kind]
     phase_range = 100_000.0 if threshold_kind == "joint" else 50_000.0
     taxable_income_before_qbi = federal_return.get("L15", 0.0)

--- a/src/tenforty/models.py
+++ b/src/tenforty/models.py
@@ -1206,6 +1206,23 @@ _SUBORDINATE_FORM_CONFIG = [
         "export_map": {"L18": "S2_11"},
         "output_map": {"L18": "additional_medicare_tax"},
     },
+    # 2024 Form 8995/8995-A — Phase 2 (preliminary 1040 feeds the deduction
+    # back into the final 1040). OTS supplies the independent simplified-form
+    # components; Python orchestration applies the missing 8995-A limitation.
+    {
+        "year": 2024,
+        "form_id": "Form_8995",
+        "phase": 2,
+        "input_map": {},
+        "export_map": {"L15": "L13"},
+        "activation_naturals": [
+            "self_employment_income",
+            "qbi_w2_wages",
+            "qbi_ubia",
+            "qbi_is_sstb",
+        ],
+        "output_map": {"L15": "qbi_deduction"},
+    },
     # 2024 Form 8960 — Phase 3 (needs AGI from 1040)
     {
         "year": 2024,
@@ -1268,6 +1285,21 @@ _SUBORDINATE_FORM_CONFIG = [
         },
         "export_map": {"L18": "S2_11"},
         "output_map": {"L18": "additional_medicare_tax"},
+    },
+    # 2025 Form 8995/8995-A — Phase 2; see the 2024 entry above.
+    {
+        "year": 2025,
+        "form_id": "Form_8995",
+        "phase": 2,
+        "input_map": {},
+        "export_map": {"L15": "L13a"},
+        "activation_naturals": [
+            "self_employment_income",
+            "qbi_w2_wages",
+            "qbi_ubia",
+            "qbi_is_sstb",
+        ],
+        "output_map": {"L15": "qbi_deduction"},
     },
     # 2025 Form 8960 — Phase 3
     {

--- a/src/tenforty/models.py
+++ b/src/tenforty/models.py
@@ -353,6 +353,7 @@ class InterpretedTaxReturn(BaseModel):
     federal_effective_tax_rate: float = 0.0
     federal_tax_bracket: float = 0.0
     federal_taxable_income: float = 0.0
+    federal_qbi_deduction: float = 0.0
     federal_amt: float = 0.0
     federal_income_tax: float = 0.0
     federal_se_tax: float = 0.0

--- a/tests/known_defects_test.py
+++ b/tests/known_defects_test.py
@@ -31,15 +31,6 @@ skip_if_graph_unavailable = pytest.mark.skipif(
 )
 
 
-@pytest.mark.xfail(reason="F3: OTS never supplies 1040 line 13 (QBI)", strict=True)
-def test_ots_qbi_deduction_reaches_1040():
-    """MFJ, $80k SE profit: §199A deduction is $9,029.64, taxable $36,118.54."""
-    r = evaluate_return(
-        year=2024, filing_status="Married/Joint", self_employment_income=80_000
-    )
-    assert r.federal_taxable_income == pytest.approx(36_118.54, abs=1.0)
-
-
 @skip_if_graph_unavailable
 def test_graph_qbi_uses_net_base():
     """Single, $50k wages + $80k SE: QBI base must be net of the half-SE deduction.

--- a/tests/mapping_completeness_test.py
+++ b/tests/mapping_completeness_test.py
@@ -53,10 +53,10 @@ INVENTORY = {
     ("form_8960", "ordinary_dividends"): {"ots": "mapped", "graph": "mapped"},
     ("form_8960", "long_term_capital_gains"): {"ots": "mapped", "graph": "mapped"},
     ("form_8960", "short_term_capital_gains"): {"ots": "mapped", "graph": "mapped"},
-    ("form_8995", "self_employment_income"): {
-        "ots": "missing:F3",  # no Form 8995 config exists at all
-        "graph": "mapped",
-    },
+    ("form_8995", "self_employment_income"): {"ots": "mapped", "graph": "mapped"},
+    ("form_8995", "qbi_w2_wages"): {"ots": "mapped", "graph": "mapped"},
+    ("form_8995", "qbi_ubia"): {"ots": "mapped", "graph": "mapped"},
+    ("form_8995", "qbi_is_sstb"): {"ots": "mapped", "graph": "mapped"},
     # Form 8995 line 13 (net capital gain) is deliberately NOT inventoried here,
     # for either capital-gain natural. The derivative is the wrong instrument for
     # it: line 13 imports the same gain that line 12 already carries, so a

--- a/tests/ots_qbi_test.py
+++ b/tests/ots_qbi_test.py
@@ -140,6 +140,9 @@ def test_ots_qbi_business_inputs_have_scalar_batch_parity():
     assert batch["federal_taxable_income"][0] == pytest.approx(
         scalar.federal_taxable_income, abs=0.01
     )
+    assert batch["federal_qbi_deduction"][0] == pytest.approx(
+        scalar.federal_qbi_deduction, abs=0.01
+    )
     assert batch["federal_total_tax"][0] == pytest.approx(
         scalar.federal_total_tax, abs=0.01
     )

--- a/tests/ots_qbi_test.py
+++ b/tests/ots_qbi_test.py
@@ -1,0 +1,145 @@
+"""OTS Form 8995/8995-A orchestration and public-input contract."""
+
+import pytest
+
+from tenforty import evaluate_return, evaluate_returns
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_taxable_income"),
+    [
+        (
+            {
+                "year": 2024,
+                "filing_status": "Married/Joint",
+                "self_employment_income": 80_000.0,
+            },
+            36_118.54,
+        ),
+        (
+            {
+                "year": 2024,
+                "filing_status": "Single",
+                "self_employment_income": 100_000.0,
+                "long_term_capital_gains": 60_000.0,
+            },
+            122_668.18,
+        ),
+        (
+            {
+                "year": 2025,
+                "filing_status": "Single",
+                "self_employment_income": 100_000.0,
+                "long_term_capital_gains": 60_000.0,
+            },
+            121_748.18,
+        ),
+        (
+            {
+                "year": 2024,
+                "filing_status": "Head_of_House",
+                "self_employment_income": 100_000.0,
+                "short_term_capital_gains": 65_535.0,
+                "taxable_interest": 14_091.0,
+                "itemized_deductions": 38_552.0,
+                "qbi_w2_wages": 103_466.0,
+            },
+            115_422.18,
+        ),
+    ],
+)
+def test_ots_form_8995_reaches_the_final_1040(case, expected_taxable_income):
+    """OTS supplies its net QBI and capital-gain-limited deduction to the 1040."""
+    result = evaluate_return(**case, backend="ots")
+
+    assert result.federal_taxable_income == pytest.approx(
+        expected_taxable_income, abs=0.01
+    )
+
+
+@pytest.mark.parametrize(
+    ("extra", "expected_taxable_income"),
+    [
+        ({}, 237_697.61),
+        ({"qbi_w2_wages": 20_000.0}, 228_317.61),
+        ({"qbi_ubia": 400_000.0}, 228_317.61),
+        ({"qbi_is_sstb": True}, 238_778.56),
+        (
+            {
+                "qbi_w2_wages": 20_000.0,
+                "qbi_ubia": 400_000.0,
+                "qbi_is_sstb": True,
+            },
+            237_906.22,
+        ),
+    ],
+)
+def test_ots_business_inputs_apply_the_form_8995a_phase_in(
+    extra, expected_taxable_income
+):
+    """Wages, UBIA, and SSTB status produce the official partial-phase result."""
+    result = evaluate_return(
+        year=2024,
+        filing_status="Single",
+        self_employment_income=100_000.0,
+        taxable_interest=160_514.775,
+        backend="ots",
+        **extra,
+    )
+
+    assert result.federal_taxable_income == pytest.approx(
+        expected_taxable_income, abs=0.01
+    )
+
+
+@pytest.mark.parametrize(
+    ("extra", "expected_taxable_income"),
+    [
+        ({}, 281_599.11),
+        ({"qbi_w2_wages": 40_000.0}, 261_599.11),
+        ({"qbi_ubia": 800_000.0}, 261_599.11),
+        ({"qbi_w2_wages": 40_000.0, "qbi_is_sstb": True}, 281_599.11),
+    ],
+)
+def test_ots_above_range_uses_the_full_wage_limit_and_excludes_sstb(
+    extra, expected_taxable_income
+):
+    """Above the range, non-SSTB limits fully apply and SSTB QBI is excluded."""
+    result = evaluate_return(
+        year=2024,
+        filing_status="Single",
+        self_employment_income=250_000.0,
+        long_term_capital_gains=60_000.0,
+        backend="ots",
+        **extra,
+    )
+
+    assert result.federal_taxable_income == pytest.approx(
+        expected_taxable_income, abs=0.01
+    )
+
+
+def test_ots_qbi_business_inputs_have_scalar_batch_parity():
+    """OTS zip-mode evaluation preserves every QBI business input."""
+    kwargs = {
+        "year": 2024,
+        "filing_status": "Single",
+        "self_employment_income": 100_000.0,
+        "taxable_interest": 160_514.775,
+        "qbi_w2_wages": 20_000.0,
+        "qbi_ubia": 400_000.0,
+        "qbi_is_sstb": True,
+    }
+    scalar = evaluate_return(**kwargs, backend="ots")
+    batch = evaluate_returns(
+        **{name: [value] for name, value in kwargs.items()},
+        backend="ots",
+        mode="zip",
+    )
+
+    assert batch["federal_taxable_income"][0] == pytest.approx(
+        scalar.federal_taxable_income, abs=0.01
+    )
+    assert batch["federal_total_tax"][0] == pytest.approx(
+        scalar.federal_total_tax, abs=0.01
+    )

--- a/tests/parity/backend_parity_test.py
+++ b/tests/parity/backend_parity_test.py
@@ -502,6 +502,51 @@ def test_graph_se_income_produces_qbi_deduction(self_employment_income):
     )
 
 
+# Cross-backend evaluation is an expensive oracle, so keep this sweep bounded.
+@skip_if_backends_unavailable
+@given(
+    year=st.sampled_from([2024, 2025]),
+    filing_status=st.sampled_from(
+        ["Single", "Married/Joint", "Married/Sep", "Widow(er)"]
+    ),
+    self_employment_income=st.integers(10_000, 500_000),
+    taxable_interest=st.integers(0, 200_000),
+    long_term_capital_gains=st.integers(0, 100_000),
+    qbi_w2_wages=st.integers(0, 200_000),
+    qbi_ubia=st.integers(0, 2_000_000),
+    qbi_is_sstb=st.booleans(),
+)
+@settings(max_examples=100, deadline=None)
+def test_qbi_form_8995a_parity(
+    year,
+    filing_status,
+    self_employment_income,
+    taxable_interest,
+    long_term_capital_gains,
+    qbi_w2_wages,
+    qbi_ubia,
+    qbi_is_sstb,
+):
+    """The independent Python and graph §199A implementations remain aligned."""
+    kwargs = {
+        "year": year,
+        "filing_status": filing_status,
+        "self_employment_income": self_employment_income,
+        "taxable_interest": taxable_interest,
+        "long_term_capital_gains": long_term_capital_gains,
+        "qbi_w2_wages": qbi_w2_wages,
+        "qbi_ubia": qbi_ubia,
+        "qbi_is_sstb": qbi_is_sstb,
+    }
+
+    ots = evaluate_return(**kwargs, backend="ots")
+    graph = evaluate_return(**kwargs, backend="graph")
+
+    assert ots.federal_qbi_deduction == pytest.approx(
+        graph.federal_qbi_deduction, abs=0.02
+    )
+
+
 @skip_if_backends_unavailable
 @given(w2_income=st.integers(50_000, 200_000))
 @settings(max_examples=50)

--- a/tests/qbi_form_8995a_test.py
+++ b/tests/qbi_form_8995a_test.py
@@ -187,17 +187,3 @@ def test_qbi_business_amounts_cannot_be_negative(field):
     """Wages and UBIA reject amounts outside their nonnegative domain."""
     with pytest.raises(ValidationError):
         TaxReturnInput(**{field: -1.0})
-
-
-@pytest.mark.parametrize(
-    "extra",
-    [
-        {"qbi_w2_wages": 1.0},
-        {"qbi_ubia": 1.0},
-        {"qbi_is_sstb": True},
-    ],
-)
-def test_ots_rejects_graph_only_qbi_business_inputs(extra):
-    """OTS fails explicitly rather than silently dropping Form 8995-A inputs."""
-    with pytest.raises(NotImplementedError, match="Form 8995-A"):
-        evaluate_return(self_employment_income=100_000.0, **extra)

--- a/tests/taxcalc/policy_test.py
+++ b/tests/taxcalc/policy_test.py
@@ -4,12 +4,10 @@ import pytest
 
 from .taxcalc_policy import (
     QBI_SIMPLIFIED_THRESHOLD,
-    _f3_qbi,
     _f21_taxcalc_qw_qbi_phase_range,
 )
 
-_QBI_QUANTITIES = {"taxable_income", "income_tax", "total_tax"}
-_F21_QUANTITIES = _QBI_QUANTITIES | {"amt"}
+_F21_QUANTITIES = {"taxable_income", "amt", "income_tax", "total_tax"}
 _EXPECTED_QBI_THRESHOLDS = {
     (2024, "Single"): 191_950.0,
     (2024, "Married/Joint"): 383_900.0,
@@ -39,39 +37,9 @@ def _case(**updates):
     return case
 
 
-def test_f3_keeps_ots_qbi_broadly_excused():
-    """OTS still omits QBI even when Form 8995's simplified method applies."""
-    case = _case(w2=50_000.0, se=80_000.0)
-
-    assert _f3_qbi("ots", case) == _QBI_QUANTITIES
-
-
-def test_f3_exposes_the_graph_net_qbi_anchor():
-    """The corrected below-threshold graph case must reach the differential."""
-    case = _case(w2=50_000.0, se=80_000.0)
-
-    assert _f3_qbi("graph", case) == set()
-
-
 def test_qbi_simplified_thresholds_match_form_8995():
     """Only married filing jointly receives the doubled statutory threshold."""
     assert QBI_SIMPLIFIED_THRESHOLD == _EXPECTED_QBI_THRESHOLDS
-
-
-@pytest.mark.parametrize(("year", "status"), sorted(_EXPECTED_QBI_THRESHOLDS))
-def test_f3_never_excuses_the_graph(year, status):
-    """The graph now implements both Form 8995 and Form 8995-A."""
-    case = _case(year=year, status=status, w2=1_000_000.0, se=100_000.0)
-
-    assert _f3_qbi("graph", case) == set()
-
-
-@pytest.mark.parametrize("backend", ["ots", "graph"])
-def test_f3_does_not_fire_without_self_employment_income(backend):
-    """The signature cannot hide unrelated high-income disagreements."""
-    case = _case(w2=1_000_000.0)
-
-    assert _f3_qbi(backend, case) == set()
 
 
 def test_f21_excuses_only_the_qw_taxcalc_phase_range():
@@ -80,7 +48,7 @@ def test_f21_excuses_only_the_qw_taxcalc_phase_range():
     reference = {"taxable_income": 200_000.0, "qbi_deduction": 10_000.0}
 
     assert _f21_taxcalc_qw_qbi_phase_range("graph", case, reference) == _F21_QUANTITIES
-    assert _f21_taxcalc_qw_qbi_phase_range("ots", case, reference) == set()
+    assert _f21_taxcalc_qw_qbi_phase_range("ots", case, reference) == _F21_QUANTITIES
     assert (
         _f21_taxcalc_qw_qbi_phase_range(
             "graph", {**case, "status": "Single"}, reference

--- a/tests/taxcalc/taxcalc_differential_test.py
+++ b/tests/taxcalc/taxcalc_differential_test.py
@@ -11,11 +11,10 @@ Structural choices:
   (policy deepcopy and parameter expansion) but is vectorized over records, so
   each hypothesis example is a *list* of cases evaluated in one taxcalc call.
   Shrinking collapses a failing list to the single minimal failing case.
-- **target()-guided graph search.** Each quantity's worst UNEXCUSED graph
-  disagreement is fed to hypothesis as an optimization target, so generation
-  climbs toward novel divergence instead of re-finding tracked defects. OTS
-  uses ordinary generation because harmless tax-table rounding otherwise
-  attracts the optimizer and causes repeated TaxCalc rebuilds.
+- **target()-guided search.** Each quantity's worst UNEXCUSED disagreement
+  beyond its allowed tolerance is fed to hypothesis as an optimization target,
+  so generation climbs toward novel divergence instead of harmless rounding or
+  already-tracked defects.
 - **@example anchors.** The audit's known counterexamples are pinned so every
   run exercises them deterministically regardless of search luck.
 - **MFJ attribution bounds.** taxcalc requires per-spouse wages; tenforty's
@@ -293,13 +292,13 @@ def tenforty_components(case, backend):
     }
 
 
-def _assert_components_match_taxcalc(backend, cases, *, guide_search):
+def _assert_components_match_taxcalc(backend, cases):
     expected = taxcalc_batch(cases)
     mfj_present = any(c["status"] == "Married/Joint" for c in cases)
     expected_alt = taxcalc_batch(cases, "spouse") if mfj_present else expected
 
     failures = []
-    worst = dict.fromkeys(QUANTITIES, 0.0)
+    worst_excess = dict.fromkeys(QUANTITIES, 0.0)
     for case, exp, exp_alt in zip(cases, expected, expected_alt, strict=True):
         ours = tenforty_components(case, backend)
         excused = excused_quantities(backend, case, exp)
@@ -310,20 +309,16 @@ def _assert_components_match_taxcalc(backend, cases, *, guide_search):
             diff = max(lo - ours[quantity], ours[quantity] - hi, 0.0)
             if quantity in excused:
                 continue
-            worst[quantity] = max(worst[quantity], diff)
+            worst_excess[quantity] = max(worst_excess[quantity], max(0.0, diff - tol))
             if diff > tol:
                 failures.append(
                     f"{case}: {quantity} got={ours[quantity]:,.2f} "
                     f"expected=[{lo:,.2f}, {hi:,.2f}] (diff {diff:,.2f} > {tol})"
                 )
-    if guide_search:
-        # target() accepts one observation per label per example, so feed it the
-        # batch maximum of unexcused disagreement: hypothesis steers toward novel
-        # divergence, not the already-tracked defects. OTS is excluded because
-        # its expected tax-table rounding gives the optimiser a harmless nonzero
-        # gradient and causes repeated TaxCalc rebuilds without new coverage.
-        for quantity, diff in worst.items():
-            target(diff, label=quantity)
+    # target() accepts one observation per label per example, so feed it the
+    # batch maximum beyond tolerance: harmless OTS rounding has a zero gradient.
+    for quantity, excess in worst_excess.items():
+        target(excess, label=quantity)
     assert not failures, "\n".join(failures[:5])
 
 
@@ -341,7 +336,7 @@ def _assert_components_match_taxcalc(backend, cases, *, guide_search):
 @pytest.mark.parametrize("backend", ["ots", "graph"])
 def test_components_match_taxcalc(backend, cases):
     """Every quantity matches taxcalc within tolerance, unless excused by name."""
-    _assert_components_match_taxcalc(backend, cases, guide_search=backend == "graph")
+    _assert_components_match_taxcalc(backend, cases)
 
 
 # TaxCalc is an expensive oracle, so randomized QBI cases are batched and bounded.
@@ -353,7 +348,7 @@ def test_components_match_taxcalc(backend, cases):
 @given(cases=st.lists(_qbi_case_strategy(), min_size=1, max_size=30))
 def test_qbi_business_inputs_match_taxcalc(cases):
     """Generated graph wages, UBIA, and SSTB inputs agree with TaxCalc."""
-    _assert_components_match_taxcalc("graph", cases, guide_search=True)
+    _assert_components_match_taxcalc("graph", cases)
 
 
 # OTS executes three native forms per record, so use fewer, denser oracle batches.
@@ -365,4 +360,4 @@ def test_qbi_business_inputs_match_taxcalc(cases):
 @given(cases=st.lists(_qbi_case_strategy(), min_size=5, max_size=30))
 def test_ots_qbi_business_inputs_match_taxcalc(cases):
     """Generated OTS wages, UBIA, and SSTB inputs agree with TaxCalc."""
-    _assert_components_match_taxcalc("ots", cases, guide_search=False)
+    _assert_components_match_taxcalc("ots", cases)

--- a/tests/taxcalc/taxcalc_differential_test.py
+++ b/tests/taxcalc/taxcalc_differential_test.py
@@ -11,9 +11,11 @@ Structural choices:
   (policy deepcopy and parameter expansion) but is vectorized over records, so
   each hypothesis example is a *list* of cases evaluated in one taxcalc call.
   Shrinking collapses a failing list to the single minimal failing case.
-- **target()-guided search.** Each quantity's worst UNEXCUSED disagreement is
-  fed to hypothesis as an optimization target, so generation climbs toward
-  novel divergence instead of re-finding tracked defects.
+- **target()-guided graph search.** Each quantity's worst UNEXCUSED graph
+  disagreement is fed to hypothesis as an optimization target, so generation
+  climbs toward novel divergence instead of re-finding tracked defects. OTS
+  uses ordinary generation because harmless tax-table rounding otherwise
+  attracts the optimizer and causes repeated TaxCalc rebuilds.
 - **@example anchors.** The audit's known counterexamples are pinned so every
   run exercises them deterministically regardless of search luck.
 - **MFJ attribution bounds.** taxcalc requires per-spouse wages; tenforty's
@@ -291,7 +293,7 @@ def tenforty_components(case, backend):
     }
 
 
-def _assert_components_match_taxcalc(backend, cases):
+def _assert_components_match_taxcalc(backend, cases, *, guide_search):
     expected = taxcalc_batch(cases)
     mfj_present = any(c["status"] == "Married/Joint" for c in cases)
     expected_alt = taxcalc_batch(cases, "spouse") if mfj_present else expected
@@ -314,11 +316,14 @@ def _assert_components_match_taxcalc(backend, cases):
                     f"{case}: {quantity} got={ours[quantity]:,.2f} "
                     f"expected=[{lo:,.2f}, {hi:,.2f}] (diff {diff:,.2f} > {tol})"
                 )
-    # target() accepts one observation per label per example, so feed it the
-    # batch maximum of unexcused disagreement: hypothesis steers toward novel
-    # divergence, not the already-tracked defects.
-    for quantity, diff in worst.items():
-        target(diff, label=quantity)
+    if guide_search:
+        # target() accepts one observation per label per example, so feed it the
+        # batch maximum of unexcused disagreement: hypothesis steers toward novel
+        # divergence, not the already-tracked defects. OTS is excluded because
+        # its expected tax-table rounding gives the optimiser a harmless nonzero
+        # gradient and causes repeated TaxCalc rebuilds without new coverage.
+        for quantity, diff in worst.items():
+            target(diff, label=quantity)
     assert not failures, "\n".join(failures[:5])
 
 
@@ -336,7 +341,7 @@ def _assert_components_match_taxcalc(backend, cases):
 @pytest.mark.parametrize("backend", ["ots", "graph"])
 def test_components_match_taxcalc(backend, cases):
     """Every quantity matches taxcalc within tolerance, unless excused by name."""
-    _assert_components_match_taxcalc(backend, cases)
+    _assert_components_match_taxcalc(backend, cases, guide_search=backend == "graph")
 
 
 # TaxCalc is an expensive oracle, so randomized QBI cases are batched and bounded.
@@ -347,5 +352,17 @@ def test_components_match_taxcalc(backend, cases):
 )
 @given(cases=st.lists(_qbi_case_strategy(), min_size=1, max_size=30))
 def test_qbi_business_inputs_match_taxcalc(cases):
-    """Generated wages, UBIA, and SSTB inputs agree with TaxCalc on the graph."""
-    _assert_components_match_taxcalc("graph", cases)
+    """Generated graph wages, UBIA, and SSTB inputs agree with TaxCalc."""
+    _assert_components_match_taxcalc("graph", cases, guide_search=True)
+
+
+# OTS executes three native forms per record, so use fewer, denser oracle batches.
+@settings(
+    max_examples=8,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
+)
+@given(cases=st.lists(_qbi_case_strategy(), min_size=5, max_size=30))
+def test_ots_qbi_business_inputs_match_taxcalc(cases):
+    """Generated OTS wages, UBIA, and SSTB inputs agree with TaxCalc."""
+    _assert_components_match_taxcalc("ots", cases, guide_search=False)

--- a/tests/taxcalc/taxcalc_policy.py
+++ b/tests/taxcalc/taxcalc_policy.py
@@ -39,22 +39,7 @@ QBI_SIMPLIFIED_THRESHOLD = {
     (2025, "Widow(er)"): 197_300.0,
 }
 
-_QBI_AFFECTED_QUANTITIES = {"taxable_income", "income_tax", "total_tax"}
-_F21_AFFECTED_QUANTITIES = _QBI_AFFECTED_QUANTITIES | {"amt"}
-
-
-def _f3_qbi(backend: str, case: dict) -> set[str]:
-    """F3: OTS omits QBI on every self-employment case.
-
-    OTS omits the deduction entirely (it reads 1040 line 13 as a direct input
-    and nothing supplies it — tenforty-2u6), so every OTS case with QBI remains
-    excused. The graph implements both the simplified and Form 8995-A paths.
-    """
-    if case.get("se", 0) <= 0:
-        return set()
-    if backend == "ots":
-        return _QBI_AFFECTED_QUANTITIES.copy()
-    return set()
+_F21_AFFECTED_QUANTITIES = {"taxable_income", "amt", "income_tax", "total_tax"}
 
 
 def _f21_taxcalc_qw_qbi_phase_range(
@@ -62,7 +47,7 @@ def _f21_taxcalc_qw_qbi_phase_range(
 ) -> set[str]:
     """F21: TaxCalc doubles the QBI phase-in range for qualifying widow(er)."""
     if (
-        backend != "graph"
+        backend not in {"graph", "ots"}
         or case.get("status") != "Widow(er)"
         or case.get("se", 0) <= 0
         or reference is None
@@ -218,7 +203,6 @@ def _f14_taxcalc_omits_amt_std_addback(backend: str, case: dict) -> set[str]:
 
 
 SIGNATURES: list[Callable[[str, dict], set[str]]] = [
-    _f3_qbi,
     _f7_itemized_semantics,
     _f11_ots_hoh_bracket,
     _f12_itemized_category_amt,


### PR DESCRIPTION
## Summary

- run a preliminary OTS Form 1040 and feed its independent QBI base and taxable-income/capital-gain ceiling through OTS Form 8995
- apply the missing Form 8995-A W-2 wage, UBIA, and SSTB limitation in tenforty orchestration, then rerun the final 1040 with the deduction
- expose the existing QBI business inputs on the OTS backend, retire the F3 xfail/differential signature, and publish `federal_qbi_deduction` on both backends
- add deterministic boundary coverage, randomized OTS/TaxCalc coverage, and randomized cross-backend QBI parity; the randomized sweep found and now pins the distinction between short-term gains and Form 8995 net capital gain
- compare filing status through the enum and guide both differential backends only with disagreement beyond their allowed tolerance

This leaves vendored OpenTaxSolver unchanged. OTS remains the independent source for the quantities it implements; tenforty supplies only the missing multi-pass orchestration and Form 8995-A limitation. F21 remains the separately tracked TaxCalc qualifying-widow(er) phase-range defect.

## Validation

- `make test-deep`: 1076 passed, 12 skipped, 21 xfailed
- `uv run pytest tests/parity/ -q`: 45 passed, 8 skipped, 11 xfailed
- `TENFORTY_TAXCALC=1 uv run pytest tests/taxcalc/ -q`: 28 passed, 2 xfailed in 6:19
- default suite: 1076 passed, 12 skipped, 21 xfailed
- focused OTS QBI and graph batch-output tests: 104 passed
- `make run-hooks`: passed

Tracks tenforty-2u6.