### PR TITLE
test(taxcalc): model differential defect deltas

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,11 @@ jobs:
         TENFORTY_TAXCALC: '1'
       run: uv run pytest tests/taxcalc/adapter_conformance_test.py -q
 
+    - name: Verify committed TaxCalc goldens
+      run: >-
+        uv run python scripts/taxcalc_audit.py
+        --check-goldens tests/taxcalc/fixtures/taxcalc_goldens.json
+
   # The shipped extension is built features=["python"] (setup.py), so the JIT +
   # SIMD batch path — including reachability-slicing in compile_batch — is
   # compiled out of every other job here and of pip installs. Without this job

--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -44,7 +44,7 @@ signature, and update this table in the same PR.
 
 ## Method
 
-1,178 boundary-focused federal cases (SS wage base, NIIT/additional-Medicare
+1,179 boundary-focused federal cases (SS wage base, NIIT/additional-Medicare
 thresholds, QBI interactions, capital-gain mixes, dividend subsets, forced
 itemization) across all five filing statuses, evaluated on three engines:
 tenforty OTS, tenforty graph, and taxcalc. Eight quantities compared per case:
@@ -630,6 +630,13 @@ F24 models only the signed difference between OTS's stale addition and the
 official F23 addition; the two ranges compose. The vendored source remains
 unchanged, and the upstream report plus strict-xfail are tracked by
 `tenforty-2jv`.
+
+An independent golden witness places OTS AMTI at $850,000: above the stale
+$831,150 threshold but below the official $875,950 threshold. F24 contributes
+$1,649.38 of modeled AMT there while F23 contributes exactly zero, preventing
+the overlapping high-income witness from masking an error in either model.
+The effective rate is 35% in this interval: 28% tentative minimum tax plus the
+7% effect of phasing out another 25 cents of exemption per added dollar.
 
 ### F25. NEW, ADJUDICATED — graph Form 6251 retains the stale MFS gain ceiling
 

--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -6,14 +6,14 @@ Update 2026-07-21: PR #279 has since merged, fixing F1/F2; the remaining
 findings are burned into the suite as strict xfails in
 `tests/known_defects_test.py`.
 Reference: [Tax-Calculator](https://github.com/PSLmodels/Tax-Calculator) (`taxcalc` 6.7.2, CC0),
-federal only, tax year 2024.
+federal only, tax years 2024 and 2025.
 
 ## Findings ledger
 
 Every disagreement class gets an ID here, a narrative section below, a
-strict-xfail burn-in in `tests/known_defects_test.py`, and an excusing
-signature in `tests/taxcalc/taxcalc_policy.py`. Fixes must flip the burn-in,
-delete the signature, and update this table in the same PR.
+strict-xfail burn-in, and a bounded-delta signature in
+`tests/taxcalc/taxcalc_policy.py`. Fixes must flip the burn-in, delete the
+signature, and update this table in the same PR.
 
 | ID | Finding | At fault | Status | Found by |
 |----|---------|----------|--------|----------|
@@ -32,18 +32,24 @@ delete the signature, and update this table in the same PR.
 | F13 | 2025 MFS 15%-rate ceiling wrong (266,700 vs 300,000), inline in 1040 not Tables | graph spec | fixed | differential grid |
 | F14 | AMT std-deduction add-back divergence (ISO cases) | taxcalc (and graph, now fixed) | graph fixed (tenforty-8ik); taxcalc omits add-back, upstream note pending | H_amt stratum |
 | F16 | Suite adapter drops `iso`, so taxcalc sees no AMT preference | taxcalc harness | fixed (#295) | F14 adjudication |
-| F17 | Graph charges SE tax below the \$400 de-minimis floor | graph spec | open (tenforty-dw0) | differential sweep |
+| F17 | Graph charges SE tax below the \$400 de-minimis floor | graph spec | fixed (tenforty-dw0, #297) | differential sweep |
 | F19 | Deduction choice: taxcalc minimizes tax; tenforty maximizes the deduction | API contract, both backends | open (documented signature; tenforty-z31) | differential sweep |
 | F20 | Suite adapter compares post-refund `iitax` with pre-refund tenforty tax | taxcalc harness | fixed (tenforty-jte) | differential sweep |
 | F21 | 199A QBI phase-in range is doubled for qualifying widow(er) | upstream TaxCalc parameter | open (tenforty-2jg; upstream report pending) | Form 8995-A adjudication |
+| F22 | OTS cancels the AMT standard-deduction add-back when taxable income floors at zero | upstream OpenTaxSolver | open (tenforty-by2; upstream report pending) | randomized ISO differential |
+| F23 | MFS high-income AMTI increase omitted | graph spec + upstream TaxCalc | open (tenforty-3bt, tenforty-doo) | randomized high-income ISO differential |
+| F24 | OTS 2024 MFS AMTI increase uses stale 2023 constants | upstream OpenTaxSolver | open (tenforty-2jv; upstream report pending) | F23 adjudication |
+| F25 | Graph Form 6251 uses stale 2025 MFS 15%-gain ceiling | graph spec | open (tenforty-c9a) | randomized MFS ISO/gain differential |
+| F26 | TaxCalc lets unused itemization reduce AMTI below the taxable-income floor | upstream TaxCalc | open (tenforty-w7t; upstream report pending) | randomized itemized ISO/loss differential |
 
 ## Method
 
-363 boundary-focused federal cases (SS wage base, NIIT/additional-Medicare
+1,178 boundary-focused federal cases (SS wage base, NIIT/additional-Medicare
 thresholds, QBI interactions, capital-gain mixes, dividend subsets, forced
 itemization) across all five filing statuses, evaluated on three engines:
-tenforty OTS, tenforty graph, and taxcalc. Seven quantities compared per case:
-AGI, taxable income, SE tax, NIIT, additional Medicare tax, AMT, total tax.
+tenforty OTS, tenforty graph, and taxcalc. Eight quantities compared per case:
+AGI, taxable income, SE tax, NIIT, additional Medicare tax, AMT, income tax,
+and total tax.
 
 - Tolerances: $2, except $15 for total tax (OTS uses the 1040 tax tables,
   which quantize taxable income in $50 steps; taxcalc uses exact formulas).
@@ -51,11 +57,13 @@ AGI, taxable income, SE tax, NIIT, additional Medicare tax, AMT, total tax.
   `w2_income` is a household aggregate. taxcalc was run with wages attributed
   to the self-employed primary and separately to the other spouse; a tenforty
   MFJ value is flagged only if it falls outside both bounds.
-- Out of scope: states (taxcalc has none), dependents/credits, ISO/AMT
-  preference items, rental and schedule-1 income, batch evaluation paths.
+- Out of scope: states (taxcalc has none), dependents/credits, rental and
+  schedule-1 income. ISO/AMT preference cases and scalar/batch identity are now
+  covered; TaxCalc itself has no tenforty-style batch API to compare directly.
 
-Harness: `audit_harness.py` + `analyze*.py` (session scratchpad; candidates
-for `scripts/` promotion).
+Harness: `scripts/taxcalc_audit.py`; the committed fixture records the exact
+TaxCalc version and can be regenerated or checked byte-for-semantics from that
+canonical case grid.
 
 ## Findings
 
@@ -561,3 +569,100 @@ The signature covers taxable income, AMT, income tax, and total tax because the
 incorrect deduction can propagate through both regular taxable income and AMTI.
 The upstream report is staged in `docs/upstream-taxcalc-reports.md`; tracked by
 `tenforty-2jg`.
+
+### F22. NEW, ADJUDICATED — OTS loses the AMT taxable-income floor
+
+The randomized ISO strategy found a case below the regular taxable-income
+floor: 2024 Head of Household, no regular income, the standard deduction, and
+a $200,000 ISO exercise spread. Form 1040 line 15 is zero. Form 6251 then adds
+the $21,900 standard deduction on line 2a, so AMTI is $221,900. After the
+$85,700 exemption, tentative minimum tax and AMT are **$35,412.00**.
+
+The graph follows that form path. OTS reports **$29,718.00** because
+`form6251_AlternativeMinimumTax` replaces line 1 with the unfloored
+`L11 - L14` whenever Form 1040 line 15 is zero. Here that is -$21,900; line
+2a adds $21,900 back and the two cancel, leaving AMTI at $200,000. This is an
+upstream tax-logic defect, so the vendored source remains unchanged.
+
+TaxCalc 6.7.2 reports **$24,024.00** for the same return. That is the already
+adjudicated F14 defect: it starts AMTI from AGI less the standard deduction,
+producing $178,100. Below the regular taxable-income floor, the full gap between
+TaxCalc and the Form 6251 path is the standard deduction plus its unused part,
+not merely one standard deduction. F14's bounded model now reflects that; F22
+adds a separate negative OTS correction, so the two mechanisms compose without
+a blanket waiver.
+
+The strict-xfail compares OTS directly with the hand-worked graph value and
+will flip when an OTS release preserves the Form 1040 line-15 floor. The
+upstream report is staged in `docs/upstream-ots-reports.md`; tracked by
+`tenforty-by2`.
+
+### F23. NEW, ADJUDICATED — graph and TaxCalc omit the MFS AMTI increase
+
+The 2025 Form 6251 instructions have a special line-4 rule for married filing
+separately: above $900,350 of AMTI, add 25% of the excess to line 4, capped at
+$68,500. For 2024 the threshold is $875,950 and the cap is $66,650. OTS has the
+mechanism; the graph goes straight from the ordinary AMTI sum to the exemption,
+and TaxCalc's `c62100` path likewise only zeros the exemption above its terminal
+threshold.
+
+A clean 2025 witness is MFS with $750,000 wages and a $300,000 ISO spread.
+Before the special rule, AMTI is $1,050,000. The required addition is
+25% x ($1,050,000 - $900,350) = $37,412.50, increasing AMT by $10,475.50.
+OTS reports the official **$68,380.75**; graph reports **$57,905.25** and
+TaxCalc is lower still because F14 independently omits the standard-deduction
+add-back.
+
+The F23 reference-delta model is deliberately one-sided and applies only to
+OTS: TaxCalc is the reference with the omission, OTS carries the required
+positive amount, and graph currently shares the reference defect. Separate
+strict-xfails pin the graph and TaxCalc omissions. Tracked by `tenforty-3bt`
+and `tenforty-doo`; the TaxCalc report is staged upstream.
+
+### F24. NEW, ADJUDICATED — OTS 2024 uses stale MFS line-4 constants
+
+OTS's 2024 routine implements the F23 mechanism with the prior-year threshold
+and cap: $831,150 and $63,250. The official 2024 instructions use $875,950 and
+$66,650. On the clean $750,000-wage / $300,000-ISO witness, OTS reports
+**$71,832.75** while the official 2024 rule gives **$68,696.75**.
+
+F24 models only the signed difference between OTS's stale addition and the
+official F23 addition; the two ranges compose. The vendored source remains
+unchanged, and the upstream report plus strict-xfail are tracked by
+`tenforty-2jv`.
+
+### F25. NEW, ADJUDICATED — graph Form 6251 retains the stale MFS gain ceiling
+
+F13 corrected the 2025 MFS 15%-rate ceiling in the 1040 qualified-dividend and
+capital-gain worksheet from $266,700 to $300,000. Form 6251 Part III contains a
+second hand-written copy and still uses $266,700, so an AMT-binding MFS return
+can move up to $33,300 of preferential income from the 15% band to 20%.
+
+The deterministic witness has $250,000 wages, $15,458 STCG, $6,032 LTCG,
+$49,171 interest, $11,057 qualified dividends, $19,444 itemized deductions,
+and a $50,000 ISO spread. Graph AMT is **$2,459.55** versus TaxCalc's
+**$2,218.80**; the $240.75 difference is exactly 5% of the $4,815 that reaches
+the stale band.
+
+F25 permits only the 5-point spread over at most the $33,300 bad interval, a
+maximum $1,665 positive graph delta. Its strict-xfail and a dedicated golden
+witness track `tenforty-c9a`; the fix should replace the duplicate constant
+with the shared table source.
+
+### F26. NEW, ADJUDICATED — TaxCalc loses the itemized taxable-income floor
+
+TaxCalc's itemizer AMTI branch reconstructs Form 6251 line 4 directly from AGI
+less itemized deductions plus AMT add-backs. When allowed itemized deductions
+exceed AGI, their unused portion therefore makes the base negative. Form 6251
+line 1 is Form 1040 line 15, which has already floored taxable income at zero;
+unused itemization cannot carry through that line.
+
+The witness is 2024 MFS with a large net capital loss, $15,079 interest,
+$33,112 ordinary dividends ($16,556 qualified), $50,061 itemized deductions,
+and a $300,000 ISO spread. AGI is $46,691, so $3,370 of itemization is unused.
+Graph starts line 1 at zero and reports AMT **$58,376.32**. TaxCalc carries the
+-$3,370 through AMTI and reports **$57,432.72**, lower by $943.60 (28%).
+
+F26 applies only to the positive graph-minus-TaxCalc effect of that unused
+deduction, bounded by the same AMT/preferential slopes as F12. A TaxCalc
+strict-xfail, upstream draft, and golden witness track `tenforty-w7t`.

--- a/docs/upstream-ots-reports.md
+++ b/docs/upstream-ots-reports.md
@@ -126,3 +126,96 @@ The same shape applies to 2023 (`20800.0`) and 2025 (`23625.0`).
 tax-logic disagreement, we do apply it locally, as a narrow and documented
 exception, via `patch_az_widow_std_deduction` in `ots/amalgamate.py`. We would
 much rather drop that patch and track the release.
+
+---
+
+## 3. Form 6251 line 1 goes negative when Form 1040 taxable income is zero
+
+**Releases:** OpenTaxSolver2024_22.06, OpenTaxSolver2025_23.06
+**Files:**
+- `src/taxsolve_US_1040_2024.c`, `form6251_AlternativeMinimumTax`
+- `src/taxsolve_US_1040_2025.c`, `form6251_AlternativeMinimumTax`
+
+The AMT routine substitutes an unfloored quantity for Form 6251 line 1 when
+Form 1040 line 15 is zero:
+
+```c
+if (L[15] > 0.0)
+  amtws[1] = L[15];
+else
+  amtws[1] = L[11] - L[14];
+```
+
+Form 6251 line 1 is Form 1040 line 15, which is already floored at zero. The
+fallback can be negative when deductions exceed AGI. Because line 2a later adds
+back the standard deduction, the negative line 1 cancels some or all of the
+required add-back.
+
+**Minimal reproducer:** 2024 Head of Household, under age 65, no regular
+income, standard deduction, and a $200,000 incentive-stock-option adjustment
+on `AMTws3`.
+
+| quantity | Form 6251 | OpenTaxSolver2024_22.06 |
+|---|---:|---:|
+| line 1, regular taxable income | $0.00 | -$21,900.00 |
+| line 2a, standard-deduction add-back | $21,900.00 | $21,900.00 |
+| line 4, AMTI | $221,900.00 | $200,000.00 |
+| line 5, exemption | $85,700.00 | $85,700.00 |
+| AMT | **$35,412.00** | **$29,718.00** |
+
+The $5,694 difference is 26% of the unused $21,900 deduction. The defect is
+not Head-of-Household-specific; that status simply makes the arithmetic easy
+to inspect. It applies whenever Form 1040 line 15 floors at zero while an AMT
+preference makes Form 6251 live.
+
+**Suggested fix:** use the floored Form 1040 value unconditionally:
+
+```c
+amtws[1] = L[15];
+```
+
+We have not patched the vendored source because this changes a computed tax
+figure. A strict-xfail in tenforty records the defect until an upstream release
+carries the correction.
+
+---
+
+## 4. The 2024 Form 6251 MFS line-4 rule uses 2023 constants
+
+**Release:** OpenTaxSolver2024_22.06
+**File:** `src/taxsolve_US_1040_2024.c`,
+`form6251_AlternativeMinimumTax`
+
+OpenTaxSolver implements the special high-income married-filing-separately
+increase, but the 2024 routine starts it at $831,150 and caps it at $63,250:
+
+```c
+if ((status == MARRIED_FILING_SEPARATE) && (amtws[4] > 831150.0))
+  {
+   if (amtws[4] > 1084150.0)
+    amtws[4] = amtws[4] + 63250.0;
+   else
+    amtws[4] = amtws[4] + 0.25 * (amtws[4] - 831150.0);
+  }
+```
+
+Those are the 2023 amounts. The 2024 Form 6251 instructions use a threshold of
+**$875,950**, a terminal point of **$1,142,550**, and a cap of **$66,650**.
+The routine's exemption logic immediately below already carries the correct
+2024 $875,950 terminal threshold and $66,650 exemption, so the file is
+internally inconsistent.
+
+**Reproducer:** 2024 married filing separately, $750,000 wages, standard
+deduction, and a $300,000 ISO adjustment. Pre-increase AMTI is $1,050,000.
+
+| implementation | line-4 addition | AMT |
+|---|---:|---:|
+| official 2024 rule | $43,512.50 | **$68,696.75** |
+| OpenTaxSolver2024_22.06 | $54,712.50 | **$71,832.75** |
+
+The $3,136 overstatement is 28% of the $11,200 excessive addition. The 2025
+OTS routine has the correct current-year constants, so the problem is confined
+to the 2024 release.
+
+We have not patched the vendored source because this is a tax-logic change. A
+strict-xfail records it until an upstream release carries the corrected table.

--- a/docs/upstream-taxcalc-reports.md
+++ b/docs/upstream-taxcalc-reports.md
@@ -184,3 +184,82 @@ Tax-Calculator's $100,000 range applies a 25% phase-in percentage instead,
 which produces its $13,940.28375 result. The corresponding qualifying-widow(er)
 gap should be $50,000, matching Single, Married/Sep, and Head of Household;
 only Married/Joint receives $100,000.
+
+---
+
+## 3. Bug: high-income MFS Form 6251 line-4 increase is omitted
+
+**Where:** `taxcalc/calcfunctions.py`, the `c62100` / Form 6251 Part II path.
+
+The 2025 Form 6251 instructions require a married-filing-separately filer with
+line 4 above $900,350 to add 25% of the excess to line 4, capped at $68,500.
+For 2024 the threshold is $875,950 and the cap is $66,650. Tax-Calculator
+zeros the MFS exemption above `AMT_em_pe`, but it never adds this separate
+amount to `c62100`.
+
+### Reproducer
+
+```python
+import pandas as pd
+import taxcalc
+
+data = pd.DataFrame(
+    [{
+        "RECID": 1,
+        "MARS": 3,
+        "XTOT": 1,
+        "age_head": 40,
+        "age_spouse": 0,
+        "e00200": 750_000.0,
+        "e00200p": 750_000.0,
+        "e00200s": 0.0,
+        "cmbtp": 300_000.0,
+    }]
+)
+records = taxcalc.Records(data=data, start_year=2025, gfactors=None, weights=None)
+calc = taxcalc.Calculator(policy=taxcalc.Policy(), records=records)
+calc.advance_to_year(2025)
+calc.calc_all()
+print(calc.array("c62100")[0], calc.array("c09600")[0])
+```
+
+Before the special rule, Form 6251 line 4 is $1,050,000. The instructions add
+25% x ($1,050,000 - $900,350) = $37,412.50. That raises AMT by $10,475.50.
+An independent Form 6251 implementation reports AMT of **$68,380.75**;
+Tax-Calculator 6.7.2 omits the increase. Its result is lower by a further
+$4,410 because of the separate standard-deduction issue described in report 1.
+
+The missing operation is distinct from setting the exemption to zero. The
+official instructions say to increase line 4 first, and then use that increased
+amount throughout the remainder of Form 6251.
+
+---
+
+## 4. Bug: unused itemized deductions reduce AMTI below Form 1040 line 15
+
+**Where:** `taxcalc/calcfunctions.py`, the itemizer branch that constructs
+`c62100`.
+
+Form 6251 line 1 is Form 1040 line 15, whose taxable income is floored at zero.
+Tax-Calculator instead reconstructs the itemizer's AMTI base directly from AGI
+less itemized deductions. If allowed itemized deductions exceed AGI, the unused
+portion passes through as a negative line-1 amount and reduces AMTI.
+
+### Reproducer
+
+Use a 2024 married-filing-separately record with short-term gain -$211,156,
+long-term gain $33,745, taxable interest $15,079, ordinary dividends $33,112
+($16,556 qualified), mortgage-interest carrier `e19200=50061`, and
+`cmbtp=300000`. The section 1211(b) MFS loss cap leaves AGI of $46,691, so
+$3,370 of itemization is unused and Form 1040 line 15 is zero.
+
+| quantity | Tax-Calculator 6.7.2 | Form 6251 line path |
+|---|---:|---:|
+| Form 1040 line 15 | $0.00 | $0.00 |
+| Form 6251 line-1 base used | -$3,370.00 | $0.00 |
+| AMTI | $296,630.00 | $300,000.00 |
+| AMT | **$57,432.72** | **$58,376.32** |
+
+The $943.60 AMT difference is 28% of the unused $3,370 deduction. Preserving
+the Form 1040 taxable-income floor before applying Form 6251 adjustments would
+make the two branches agree with the form's line sequence.

--- a/scripts/taxcalc_audit.py
+++ b/scripts/taxcalc_audit.py
@@ -13,8 +13,8 @@ Modes:
 
 Scope notes:
 - Federal only (taxcalc has no state model).
-- No dependents, no ISO gains, no rental/schedule-1 income (taxcalc mapping
-  for those is ambiguous or absent).
+- No dependents or rental/schedule-1 income (taxcalc mapping for those is
+  ambiguous or absent). ISO exercise spread is carried as `cmbtp`.
 - Itemized deductions are mapped to taxcalc interest paid (e19200), an
   uncapped carrier for tenforty's uncategorized aggregate.
 - MFJ wage attribution: taxcalc requires per-spouse wages; tenforty's
@@ -39,6 +39,7 @@ warnings.filterwarnings("ignore")
 _POLICY_PATH = Path(__file__).parent.parent / "tests" / "taxcalc" / "taxcalc_policy.py"
 _spec = importlib.util.spec_from_file_location("taxcalc_policy", _POLICY_PATH)
 taxcalc_policy = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = taxcalc_policy
 _spec.loader.exec_module(taxcalc_policy)
 
 STATUSES = ["Single", "Married/Joint", "Married/Sep", "Head_of_House", "Widow(er)"]
@@ -63,6 +64,7 @@ QUANTITIES = (
     "income_tax",
     "total_tax",
 )
+REFERENCE_FIELDS = (*QUANTITIES, "amti", "qbi_deduction")
 
 
 def build_cases() -> list[dict]:
@@ -177,6 +179,51 @@ def build_cases() -> list[dict]:
                 for iso in (50_000, 200_000):
                     add(year, "H_amt", status=st, w2=w2, iso=iso)
 
+        # L_amt_floor: Form 1040 line 15 is zero, but Form 6251 line 2a still
+        # adds back the standard deduction. This is the F22 OTS witness and a
+        # below-floor counterpart to the positive-income F14 cases.
+        for st in STATUSES:
+            add(year, "L_amt_floor", status=st, iso=200_000)
+
+        # M_amt_mfs: the special high-income line-4 increase. TaxCalc and the
+        # graph omit it (F23); OTS 2024 uses stale prior-year constants (F24).
+        add(
+            year,
+            "M_amt_mfs",
+            status="Married/Sep",
+            w2=750_000,
+            iso=300_000,
+        )
+        if year == 2025:
+            add(
+                year,
+                "N_amt_mfs_gain",
+                status="Married/Sep",
+                w2=250_000,
+                stcg=15_458,
+                ltcg=6_032,
+                interest=49_171,
+                ord_div=11_057,
+                qual_div=11_057,
+                itemized=19_444,
+                std_or_item="Itemized",
+                iso=50_000,
+            )
+        if year == 2024:
+            add(
+                year,
+                "O_amt_itemized_floor",
+                status="Married/Sep",
+                stcg=-211_156,
+                ltcg=33_745,
+                interest=15_079,
+                ord_div=33_112,
+                qual_div=16_556,
+                itemized=50_061,
+                std_or_item="Itemized",
+                iso=300_000,
+            )
+
         # I_straddle: per-status additional-Medicare and NIIT thresholds
         amedt = pol.AMEDT_ec[0]
         niit_thd = pol.NIIT_thd[0]
@@ -203,6 +250,38 @@ def build_cases() -> list[dict]:
                 qual_div=10_000,
                 interest=5_000,
             )
+
+        # J_loss: section 1211(b) loss caps, including a positive long-term leg
+        # inside an overall loss so the QCG worksheet's smaller-of rule is live.
+        for st in ("Single", "Married/Sep"):
+            for loss in (-1_000, -3_000, -50_000):
+                add(
+                    year,
+                    "J_loss",
+                    status=st,
+                    w2=300_000,
+                    interest=100_000,
+                    stcg=loss,
+                )
+            add(
+                year,
+                "J_loss",
+                status=st,
+                w2=300_000,
+                interest=100_000,
+                stcg=-50_000,
+                ltcg=10_000,
+            )
+
+        # K_deduction: taxcalc minimizes tax while tenforty maximizes the
+        # deduction when extra itemization lands wholly in the 0% LTCG band.
+        add(
+            year,
+            "K_deduction",
+            status="Head_of_House",
+            ltcg=60_000,
+            itemized=50_000 if year == 2024 else 56_000,
+        )
 
     for i, c in enumerate(cases):
         c["case_id"] = i
@@ -289,9 +368,11 @@ def run_taxcalc(cases, wage_attribution="primary"):
         arr = calc.array
         for i, c in enumerate(year_cases):
             iitax = float(arr("iitax")[i])
+            refund = float(arr("refund")[i])
             setax = float(arr("setax")[i])
             amc = float(arr("ptax_amc")[i])
             niit = float(arr("niit")[i])
+            pre_refund_iitax = iitax + refund
             out[c["case_id"]] = {
                 "agi": float(arr("c00100")[i]),
                 "taxable_income": float(arr("c04800")[i]),
@@ -299,11 +380,10 @@ def run_taxcalc(cases, wage_attribution="primary"):
                 "niit": niit,
                 "addl_medicare": amc,
                 "amt": float(arr("c09600")[i]),
-                # taxcalc iitax includes NIIT; tenforty's federal_income_tax
-                # excludes it (and SE tax and additional Medicare).
-                "income_tax": iitax - niit,
-                "total_tax": iitax + setax + amc,
-                "qbided": float(arr("qbided")[i]),
+                "amti": float(arr("c62100")[i]),
+                "income_tax": pre_refund_iitax - niit,
+                "total_tax": pre_refund_iitax + setax + amc,
+                "qbi_deduction": float(arr("qbided")[i]),
             }
     return out
 
@@ -316,12 +396,12 @@ def taxcalc_expectations(cases):
     return primary, spouse
 
 
-def write_goldens(cases, path):
-    """Write committed golden fixtures with taxcalc metadata."""
+def golden_payload(cases):
+    """Build the versioned golden payload for a canonical case grid."""
     import taxcalc as tc
 
     primary, spouse = taxcalc_expectations(cases)
-    payload = {
+    return {
         "meta": {
             "taxcalc_version": tc.__version__,
             "generated": date.today().isoformat(),
@@ -331,9 +411,9 @@ def write_goldens(cases, path):
         "cases": [
             {
                 **{k: c[k] for k in c if k != "case_id"},
-                "expected": {q: primary[c["case_id"]][q] for q in QUANTITIES},
+                "expected": {q: primary[c["case_id"]][q] for q in REFERENCE_FIELDS},
                 "expected_spouse_attr": (
-                    {q: spouse[c["case_id"]][q] for q in QUANTITIES}
+                    {q: spouse[c["case_id"]][q] for q in REFERENCE_FIELDS}
                     if c["case_id"] in spouse
                     else None
                 ),
@@ -341,9 +421,30 @@ def write_goldens(cases, path):
             for c in cases
         ],
     }
+
+
+def write_goldens(cases, path):
+    """Write committed golden fixtures with taxcalc metadata."""
+    payload = golden_payload(cases)
     Path(path).parent.mkdir(parents=True, exist_ok=True)
     Path(path).write_text(json.dumps(payload, indent=1) + "\n")
     print(f"wrote {len(cases)} golden cases to {path}", file=sys.stderr)
+
+
+def check_goldens(cases, path):
+    """Regenerate golden semantics and compare them with the committed fixture."""
+    expected = json.loads(Path(path).read_text())
+    regenerated = golden_payload(cases)
+    expected["meta"].pop("generated", None)
+    regenerated["meta"].pop("generated", None)
+    if regenerated == expected:
+        print(f"golden fixture is current: {path}")
+        return 0
+    print(
+        f"golden fixture is stale: regenerate with --goldens {path}",
+        file=sys.stderr,
+    )
+    return 1
 
 
 def check(cases):
@@ -352,7 +453,7 @@ def check(cases):
     ots = run_tenforty(cases, "ots")
     graph = run_tenforty(cases, "graph")
 
-    unclassified, known, errors = [], [], []
+    unclassified, modeled_mismatches, errors = [], [], []
     for c in cases:
         cid = c["case_id"]
         exp = primary[cid]
@@ -362,26 +463,29 @@ def check(cases):
             if "error" in got:
                 errors.append((backend, c, got["error"]))
                 continue
-            excused = taxcalc_policy.excused_quantities(backend, c)
+            deltas = taxcalc_policy.modeled_deltas(backend, c, exp)
             for q in QUANTITIES:
                 tol = taxcalc_policy.tolerance(backend, q, exp["taxable_income"], c)
                 lo = hi = exp[q]
                 if exp_alt is not None:
                     lo, hi = min(lo, exp_alt[q]), max(hi, exp_alt[q])
-                if lo - tol <= got[q] <= hi + tol:
+                delta = deltas.get(q, taxcalc_policy.ZERO_DELTA)
+                if lo + delta.minimum - tol <= got[q] <= hi + delta.maximum + tol:
                     continue
                 record = (backend, c, q, got[q], exp[q])
-                (known if q in excused else unclassified).append(record)
+                (modeled_mismatches if q in deltas else unclassified).append(record)
 
     print(
-        f"cases={len(cases)} known_disagreements={len(known)} "
+        f"cases={len(cases)} modeled_mismatches={len(modeled_mismatches)} "
         f"unclassified={len(unclassified)} backend_errors={len(errors)}"
     )
     for backend, c, err in errors:
         print(f"ERROR  {backend} case={c}: {err}")
     for backend, c, q, got, exp in unclassified[:25]:
         print(f"UNCLASSIFIED  {backend} {q} got={got:,.2f} expected={exp:,.2f} {c}")
-    return 1 if (unclassified or errors) else 0
+    for backend, c, q, got, exp in modeled_mismatches[:25]:
+        print(f"MODELED_MISMATCH  {backend} {q} got={got:,.2f} expected={exp:,.2f} {c}")
+    return 1 if (unclassified or modeled_mismatches or errors) else 0
 
 
 def main():
@@ -389,6 +493,7 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("csv", nargs="?", default=None)
     parser.add_argument("--goldens", metavar="PATH")
+    parser.add_argument("--check-goldens", metavar="PATH")
     parser.add_argument("--check", action="store_true")
     args = parser.parse_args()
 
@@ -398,6 +503,8 @@ def main():
     if args.goldens:
         write_goldens(cases, args.goldens)
         return 0
+    if args.check_goldens:
+        return check_goldens(cases, args.check_goldens)
     if args.check:
         return check(cases)
 

--- a/scripts/taxcalc_audit.py
+++ b/scripts/taxcalc_audit.py
@@ -210,6 +210,18 @@ def build_cases() -> list[dict]:
                 iso=50_000,
             )
         if year == 2024:
+            # P_amt_mfs_stale_only: OTS AMTI is above its stale 2023 line-4
+            # threshold but below the official 2024 threshold. F24 is active
+            # here while F23's official addition is exactly zero.
+            add(
+                year,
+                "P_amt_mfs_stale_only",
+                status="Married/Sep",
+                w2=600_000,
+                itemized=20_000,
+                std_or_item="Itemized",
+                iso=250_000,
+            )
             add(
                 year,
                 "O_amt_itemized_floor",

--- a/tests/known_defects_test.py
+++ b/tests/known_defects_test.py
@@ -319,6 +319,90 @@ def test_amt_std_addback_agrees_across_backends():
 
 
 @pytest.mark.xfail(
+    reason="F22: OTS cancels the Form 6251 standard-deduction add-back when "
+    "Form 1040 taxable income floors at zero",
+    strict=True,
+)
+@skip_if_graph_unavailable
+def test_ots_amt_preserves_the_zero_taxable_income_floor():
+    """Form 6251 line 1 is zero, not negative unused standard deduction."""
+    kwargs = dict(
+        year=2024,
+        filing_status="Head_of_House",
+        incentive_stock_option_gains=200_000,
+    )
+    ots = evaluate_return(backend="ots", **kwargs)
+    graph = evaluate_return(backend="graph", **kwargs)
+
+    assert ots.federal_amt == pytest.approx(graph.federal_amt, abs=2.0)
+    assert graph.federal_amt == pytest.approx(35_412.00, abs=1.0)
+
+
+@pytest.mark.xfail(
+    reason="F23: graph and TaxCalc omit the Form 6251 high-income MFS "
+    "increase on line 4",
+    strict=True,
+)
+@skip_if_graph_unavailable
+def test_graph_applies_the_high_income_mfs_amt_increase():
+    """2025 MFS line 4 adds 25% of AMTI above $900,350."""
+    kwargs = dict(
+        year=2025,
+        filing_status="Married/Sep",
+        w2_income=750_000,
+        incentive_stock_option_gains=300_000,
+    )
+    ots = evaluate_return(backend="ots", **kwargs)
+    graph = evaluate_return(backend="graph", **kwargs)
+
+    assert graph.federal_amt == pytest.approx(ots.federal_amt, abs=2.0)
+    assert ots.federal_amt == pytest.approx(68_380.75, abs=1.0)
+
+
+@pytest.mark.xfail(
+    reason="F24: OTS 2024 uses the 2023 MFS AMT line-4 threshold and cap",
+    strict=True,
+)
+def test_ots_2024_mfs_amt_uses_current_year_line4_constants():
+    """The official 2024 threshold is $875,950 and the cap is $66,650."""
+    result = evaluate_return(
+        year=2024,
+        filing_status="Married/Sep",
+        backend="ots",
+        w2_income=750_000,
+        incentive_stock_option_gains=300_000,
+    )
+
+    assert result.federal_amt == pytest.approx(68_696.75, abs=1.0)
+
+
+@pytest.mark.xfail(
+    reason="F25: graph Form 6251 uses $266,700 instead of the 2025 MFS "
+    "$300,000 capital-gain ceiling",
+    strict=True,
+)
+@skip_if_graph_unavailable
+def test_graph_2025_mfs_amt_uses_the_current_capital_gain_ceiling():
+    """The stale band moves $4,815 from the 15% AMT band into the 20% band."""
+    result = evaluate_return(
+        year=2025,
+        filing_status="Married/Sep",
+        backend="graph",
+        w2_income=250_000,
+        short_term_capital_gains=15_458,
+        long_term_capital_gains=6_032,
+        taxable_interest=49_171,
+        ordinary_dividends=11_057,
+        qualified_dividends=11_057,
+        itemized_deductions=19_444,
+        standard_or_itemized="Itemized",
+        incentive_stock_option_gains=50_000,
+    )
+
+    assert result.federal_amt == pytest.approx(2_218.80, abs=1.0)
+
+
+@pytest.mark.xfail(
     reason="F7: backends disagree on 'Itemized' semantics",
     strict=True,
 )
@@ -342,6 +426,25 @@ def test_itemized_semantics_agree_across_backends():
     assert ots.federal_taxable_income == pytest.approx(
         graph.federal_taxable_income, abs=1.0
     )
+
+
+@pytest.mark.xfail(
+    reason="F19: TaxCalc minimizes tax while tenforty maximizes the deduction",
+    strict=True,
+)
+@pytest.mark.parametrize("backend", ["ots", "graph"])
+def test_deduction_choice_matches_taxcalc_when_itemizing_is_free(backend):
+    """TaxCalc keeps the standard deduction when larger itemization saves no tax."""
+    result = evaluate_return(
+        year=2025,
+        filing_status="Head_of_House",
+        long_term_capital_gains=58_509.0,
+        itemized_deductions=56_482.0,
+        backend=backend,
+    )
+
+    assert result.federal_taxable_income == pytest.approx(34_884.0, abs=0.01)
+    assert result.federal_total_tax == pytest.approx(0.0, abs=0.01)
 
 
 @skip_if_graph_unavailable

--- a/tests/taxcalc/adapter_conformance_test.py
+++ b/tests/taxcalc/adapter_conformance_test.py
@@ -64,6 +64,28 @@ F21_QW_QBI_PHASE_IN_CASE = {
     "iso": 0.0,
 }
 
+F23_MFS_AMT_LINE4_CASE = {
+    **F14_CASE,
+    "year": 2025,
+    "status": "Married/Sep",
+    "w2": 750_000.0,
+    "iso": 300_000.0,
+}
+
+F26_ITEMIZED_AMT_FLOOR_CASE = {
+    **F14_CASE,
+    "status": "Married/Sep",
+    "w2": 0.0,
+    "stcg": -211_156.0,
+    "ltcg": 33_745.0,
+    "interest": 15_079.0,
+    "ord_div": 33_112.0,
+    "qual_div": 16_556.0,
+    "itemized": 50_061.0,
+    "std_or_item": "Itemized",
+    "iso": 300_000.0,
+}
+
 
 def test_iso_reaches_taxcalc_as_amt_preference():
     """An ISO spread must produce AMT in taxcalc, not silence."""
@@ -151,6 +173,29 @@ def test_taxcalc_qw_qbi_uses_the_all_other_returns_phase_in_range():
     """The QW midpoint must apply 50%, not 25%, of the wage-limit reduction."""
     result = taxcalc_batch([F21_QW_QBI_PHASE_IN_CASE])[0]
     assert result["taxable_income"] == pytest.approx(207_656.4775, abs=0.01)
+
+
+@pytest.mark.xfail(
+    reason="F23: TaxCalc omits the Form 6251 high-income MFS increase on line 4",
+    strict=True,
+)
+def test_taxcalc_applies_the_high_income_mfs_amt_increase():
+    """The 2025 line-4 increase raises AMT to the official $68,380.75."""
+    result = taxcalc_batch([F23_MFS_AMT_LINE4_CASE])[0]
+
+    assert result["amt"] == pytest.approx(68_380.75, abs=1.0)
+
+
+@pytest.mark.xfail(
+    reason="F26: TaxCalc lets unused itemized deductions reduce Form 6251 "
+    "line 1 below the Form 1040 taxable-income floor",
+    strict=True,
+)
+def test_taxcalc_preserves_the_itemized_taxable_income_floor_in_amti():
+    """The $3,370 unused deduction cannot reduce Form 6251 line 1 below zero."""
+    result = taxcalc_batch([F26_ITEMIZED_AMT_FLOOR_CASE])[0]
+
+    assert result["amt"] == pytest.approx(58_376.32, abs=1.0)
 
 
 @pytest.mark.parametrize(
@@ -261,6 +306,26 @@ def test_refundable_credit_does_not_change_pre_refund_tax_contract():
     for result in (single, second_in_batch):
         assert result["income_tax"] == pytest.approx(0.0, abs=0.01)
         assert result["total_tax"] == pytest.approx(0.0, abs=0.01)
+
+
+@pytest.mark.parametrize("case", [F14_CASE, REFUNDABLE_CREDIT_CASE])
+def test_tax_components_reconcile_to_total(case):
+    """Both the oracle adapter and tenforty preserve the public tax identity."""
+    reference = taxcalc_batch([case])[0]
+    reference_components = (
+        reference["income_tax"]
+        + reference["se_tax"]
+        + reference["niit"]
+        + reference["addl_medicare"]
+    )
+    assert reference_components == pytest.approx(reference["total_tax"], abs=0.01)
+
+    for backend in ("ots", "graph"):
+        ours = evaluate_components(case, backend)
+        our_components = (
+            ours["income_tax"] + ours["se_tax"] + ours["niit"] + ours["addl_medicare"]
+        )
+        assert our_components == pytest.approx(ours["total_tax"], abs=0.01)
 
 
 def test_raw_iitax_remains_net_of_refundable_credits():

--- a/tests/taxcalc/batch_conformance_test.py
+++ b/tests/taxcalc/batch_conformance_test.py
@@ -15,19 +15,10 @@ from pathlib import Path
 import pytest
 
 from tenforty import evaluate_return, evaluate_returns
-
-from .taxcalc_policy import evaluate_components
+from tenforty.models import InterpretedTaxReturn
 
 FIXTURE = Path(__file__).parent / "fixtures" / "taxcalc_goldens.json"
-
-BATCH_QUANTITY_COLUMNS = {
-    "agi": "federal_adjusted_gross_income",
-    "taxable_income": "federal_taxable_income",
-    "se_tax": "federal_se_tax",
-    "niit": "federal_niit",
-    "addl_medicare": "federal_additional_medicare_tax",
-    "total_tax": "federal_total_tax",
-}
+OUTPUT_FIELDS = tuple(InterpretedTaxReturn.model_fields)
 
 
 def _graph_available() -> bool:
@@ -43,6 +34,38 @@ def _sample_cases(n=24) -> list[dict]:
     cases = json.loads(FIXTURE.read_text())["cases"]
     step = max(1, len(cases) // n)
     return cases[::step][:n]
+
+
+def _scalar_result(case: dict, backend: str) -> InterpretedTaxReturn:
+    return evaluate_return(
+        year=case["year"],
+        filing_status=case["status"],
+        w2_income=case["w2"],
+        self_employment_income=case["se"],
+        short_term_capital_gains=case["stcg"],
+        long_term_capital_gains=case["ltcg"],
+        taxable_interest=case["interest"],
+        ordinary_dividends=case["ord_div"],
+        qualified_dividends=case["qual_div"],
+        itemized_deductions=case["itemized"],
+        incentive_stock_option_gains=case.get("iso", 0.0),
+        standard_or_itemized=case["std_or_item"],
+        backend=backend,
+    )
+
+
+def _assert_full_output_row(df, row: int, scalar: InterpretedTaxReturn) -> None:
+    missing = set(OUTPUT_FIELDS) - set(df.columns)
+    assert not missing, f"batch dropped public output columns: {sorted(missing)}"
+    mismatches = []
+    for field in OUTPUT_FIELDS:
+        batch_value = float(df[field][row])
+        scalar_value = float(getattr(scalar, field))
+        if abs(batch_value - scalar_value) > 0.02:
+            mismatches.append(
+                f"{field}: batch={batch_value:,.2f} scalar={scalar_value:,.2f}"
+            )
+    assert not mismatches, "\n".join(mismatches[:5])
 
 
 backends = pytest.mark.parametrize(
@@ -74,22 +97,14 @@ def test_zip_batch_matches_scalar(backend):
         ordinary_dividends=[c["ord_div"] for c in cases],
         qualified_dividends=[c["qual_div"] for c in cases],
         itemized_deductions=[c["itemized"] for c in cases],
+        incentive_stock_option_gains=[c.get("iso", 0.0) for c in cases],
         standard_or_itemized=[c["std_or_item"] for c in cases],
         backend=backend,
         mode="zip",
     )
     assert len(df) == len(cases)
-    mismatches = []
     for i, case in enumerate(cases):
-        scalar = evaluate_components(case, backend)
-        for quantity, column in BATCH_QUANTITY_COLUMNS.items():
-            batch_value = float(df[column][i])
-            if abs(batch_value - scalar[quantity]) > 0.02:
-                mismatches.append(
-                    f"row {i} {case}: {quantity} batch={batch_value:,.2f} "
-                    f"scalar={scalar[quantity]:,.2f}"
-                )
-    assert not mismatches, "\n".join(mismatches[:5])
+        _assert_full_output_row(df, i, _scalar_result(case, backend))
 
 
 @backends
@@ -112,6 +127,4 @@ def test_cross_grid_matches_scalar(backend):
             w2_income=float(df["w2_income"][i]),
             backend=backend,
         )
-        assert float(df["federal_total_tax"][i]) == pytest.approx(
-            scalar.federal_total_tax, abs=0.02
-        )
+        _assert_full_output_row(df, i, scalar)

--- a/tests/taxcalc/fixtures/taxcalc_goldens.json
+++ b/tests/taxcalc/fixtures/taxcalc_goldens.json
@@ -1,12 +1,12 @@
 {
  "meta": {
   "taxcalc_version": "6.7.2",
-  "generated": "2026-07-21",
+  "generated": "2026-07-31",
   "years": [
    2024,
    2025
   ],
-  "n_cases": 1146
+  "n_cases": 1178
  },
  "cases": [
   {
@@ -31,7 +31,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1062.4454000000005,
-    "total_tax": 5301.3104
+    "total_tax": 5301.3104,
+    "amti": 10624.454000000002,
+    "qbi_deduction": 2656.1135000000004
    },
    "expected_spouse_attr": null
   },
@@ -57,7 +59,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 3719.46896,
-    "total_tax": 12197.19896
+    "total_tax": 12197.19896,
+    "amti": 32928.908,
+    "qbi_deduction": 8232.227
    },
    "expected_spouse_attr": null
   },
@@ -83,7 +87,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 17018.299399999996,
-    "total_tax": 38212.62439999999
+    "total_tax": 38212.62439999999,
+    "amti": 99842.26999999999,
+    "qbi_deduction": 24960.5675
    },
    "expected_spouse_attr": null
   },
@@ -109,7 +115,9 @@
     "addl_medicare": 693.4499999999999,
     "amt": 0.0,
     "income_tax": 65200.10125000001,
-    "total_tax": 94834.40125000001
+    "total_tax": 94834.40125000001,
+    "amti": 270929.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -135,7 +143,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 4016.0,
-    "total_tax": 4016.0
+    "total_tax": 4016.0,
+    "amti": 35400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -161,7 +171,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7747.979880000001,
-    "total_tax": 11986.84488
+    "total_tax": 11986.84488,
+    "amti": 57704.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": null
   },
@@ -187,7 +199,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 12654.959759999998,
-    "total_tax": 21132.689759999997
+    "total_tax": 21132.689759999997,
+    "amti": 80008.908,
+    "qbi_deduction": 11152.227
    },
    "expected_spouse_attr": null
   },
@@ -213,7 +227,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 28541.032,
-    "total_tax": 47264.657
+    "total_tax": 47264.657,
+    "amti": 147910.55,
+    "qbi_deduction": 28127.6375
    },
    "expected_spouse_attr": null
   },
@@ -239,7 +255,9 @@
     "addl_medicare": 1143.4499999999998,
     "amt": 0.0,
     "income_tax": 83785.10125,
-    "total_tax": 107669.40125000001
+    "total_tax": 107669.40125000001,
+    "amti": 324029.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -265,7 +283,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 18338.5,
-    "total_tax": 18338.5
+    "total_tax": 18338.5,
+    "amti": 105400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -291,7 +311,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 23691.568960000004,
-    "total_tax": 27930.433960000002
+    "total_tax": 27930.433960000002,
+    "amti": 127704.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": null
   },
@@ -317,7 +339,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 29125.70416,
-    "total_tax": 36758.99416
+    "total_tax": 36758.99416,
+    "amti": 150346.684,
+    "qbi_deduction": 11236.671000000002
    },
    "expected_spouse_attr": null
   },
@@ -343,7 +367,9 @@
     "addl_medicare": 526.7249999999999,
     "amt": 0.0,
     "income_tax": 58007.115625,
-    "total_tax": 68577.46562500001
+    "total_tax": 68577.46562500001,
+    "amti": 250378.1875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -369,7 +395,9 @@
     "addl_medicare": 1773.4499999999998,
     "amt": 0.0,
     "income_tax": 109804.10125,
-    "total_tax": 125638.40125000001
+    "total_tax": 125638.40125000001,
+    "amti": 398369.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -395,7 +423,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 30002.5,
-    "total_tax": 30002.5
+    "total_tax": 30002.5,
+    "amti": 154000.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -421,7 +451,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 35685.36928,
-    "total_tax": 36488.81428
+    "total_tax": 36488.81428,
+    "amti": 177678.622,
+    "qbi_deduction": 5919.655500000001
    },
    "expected_spouse_attr": null
   },
@@ -447,7 +479,9 @@
     "addl_medicare": 216.08999999999997,
     "amt": 0.0,
     "income_tax": 43730.70334287107,
-    "total_tax": 45553.68334287107
+    "total_tax": 45553.68334287107,
+    "amti": 206388.1354464721,
+    "qbi_deduction": 6808.419553527903
    },
    "expected_spouse_attr": null
   },
@@ -473,7 +507,9 @@
     "addl_medicare": 964.1249999999999,
     "amt": 0.0,
     "income_tax": 76071.735625,
-    "total_tax": 81053.085625
+    "total_tax": 81053.085625,
+    "amti": 301991.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -499,7 +535,9 @@
     "addl_medicare": 2210.85,
     "amt": 0.0,
     "income_tax": 127868.72124999999,
-    "total_tax": 138114.02125
+    "total_tax": 138114.02125,
+    "amti": 449982.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -525,7 +563,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 37538.5,
-    "total_tax": 37538.5
+    "total_tax": 37538.5,
+    "amti": 185400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -551,7 +591,9 @@
     "addl_medicare": 249.34499999999997,
     "amt": 0.0,
     "income_tax": 45464.86136107776,
-    "total_tax": 46517.65136107776
+    "total_tax": 46517.65136107776,
+    "amti": 211807.379253368,
+    "qbi_deduction": 3190.898246631976
    },
    "expected_spouse_attr": null
   },
@@ -577,7 +619,9 @@
     "addl_medicare": 498.68999999999994,
     "amt": 0.0,
     "income_tax": 55983.54425,
-    "total_tax": 58089.12425
+    "total_tax": 58089.12425,
+    "amti": 244596.555,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -603,7 +647,9 @@
     "addl_medicare": 1246.725,
     "amt": 0.0,
     "income_tax": 87061.735625,
-    "total_tax": 92325.68562500001
+    "total_tax": 92325.68562500001,
+    "amti": 333391.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -629,7 +675,9 @@
     "addl_medicare": 2493.45,
     "amt": 0.0,
     "income_tax": 138858.72125,
-    "total_tax": 149386.62125000003
+    "total_tax": 149386.62125000003,
+    "amti": 481382.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -655,7 +703,9 @@
     "addl_medicare": 540.0,
     "amt": 0.0,
     "income_tax": 56264.75,
-    "total_tax": 56804.75
+    "total_tax": 56804.75,
+    "amti": 245400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -681,7 +731,9 @@
     "addl_medicare": 789.345,
     "amt": 0.0,
     "income_tax": 66624.147125,
-    "total_tax": 68216.93712500001
+    "total_tax": 68216.93712500001,
+    "amti": 274998.2775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -707,7 +759,9 @@
     "addl_medicare": 1038.69,
     "amt": 0.0,
     "income_tax": 76983.54424999999,
-    "total_tax": 79629.12425
+    "total_tax": 79629.12425,
+    "amti": 304596.555,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -733,7 +787,9 @@
     "addl_medicare": 1786.725,
     "amt": 0.0,
     "income_tax": 108061.735625,
-    "total_tax": 113865.68562500001
+    "total_tax": 113865.68562500001,
+    "amti": 393391.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -759,7 +815,9 @@
     "addl_medicare": 3033.45,
     "amt": 0.0,
     "income_tax": 159858.72125,
-    "total_tax": 170926.62125000003
+    "total_tax": 170926.62125000003,
+    "amti": 541382.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -785,7 +843,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 105264.75,
-    "total_tax": 107064.75
+    "total_tax": 107064.75,
+    "amti": 385400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -811,7 +871,9 @@
     "addl_medicare": 2049.345,
     "amt": 0.0,
     "income_tax": 115624.147125,
-    "total_tax": 118476.93712500001
+    "total_tax": 118476.93712500001,
+    "amti": 414998.2775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -837,7 +899,9 @@
     "addl_medicare": 2298.6899999999996,
     "amt": 0.0,
     "income_tax": 125983.54424999999,
-    "total_tax": 129889.12425
+    "total_tax": 129889.12425,
+    "amti": 444596.555,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -863,7 +927,9 @@
     "addl_medicare": 3046.7249999999995,
     "amt": 0.0,
     "income_tax": 157061.73562499997,
-    "total_tax": 164125.68562499998
+    "total_tax": 164125.68562499998,
+    "amti": 533391.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -889,7 +955,9 @@
     "addl_medicare": 4293.45,
     "amt": 0.0,
     "income_tax": 210299.37675,
-    "total_tax": 222627.27675000002
+    "total_tax": 222627.27675000002,
+    "amti": 681382.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -915,7 +983,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 0.0,
-    "total_tax": 4238.865
+    "total_tax": 4238.865,
+    "amti": -1319.432499999999,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 27880.5675,
@@ -925,7 +995,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 0.0,
-    "total_tax": 4238.865
+    "total_tax": 4238.865,
+    "amti": -1319.432499999999,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -950,7 +1022,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2124.890800000001,
-    "total_tax": 10602.6208
+    "total_tax": 10602.6208,
+    "amti": 21248.908000000003,
+    "qbi_deduction": 5312.227000000001
    },
    "expected_spouse_attr": {
     "agi": 55761.135,
@@ -960,7 +1034,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2124.890800000001,
-    "total_tax": 10602.6208
+    "total_tax": 10602.6208,
+    "amti": 21248.908000000003,
+    "qbi_deduction": 5312.227000000001
    }
   },
   {
@@ -985,7 +1061,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10115.472399999999,
-    "total_tax": 31309.797399999996
+    "total_tax": 31309.797399999996,
+    "amti": 88162.26999999999,
+    "qbi_deduction": 22040.5675
    },
    "expected_spouse_attr": {
     "agi": 139402.8375,
@@ -995,7 +1073,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10115.472399999999,
-    "total_tax": 31309.797399999996
+    "total_tax": 31309.797399999996,
+    "amti": 88162.26999999999,
+    "qbi_deduction": 22040.5675
    }
   },
   {
@@ -1020,7 +1100,9 @@
     "addl_medicare": 243.45,
     "amt": 0.0,
     "income_tax": 35300.2784,
-    "total_tax": 64484.5784
+    "total_tax": 64484.5784,
+    "amti": 205063.66,
+    "qbi_deduction": 51265.91500000001
    },
    "expected_spouse_attr": {
     "agi": 285529.575,
@@ -1030,7 +1112,9 @@
     "addl_medicare": 243.45,
     "amt": 0.0,
     "income_tax": 35300.2784,
-    "total_tax": 64484.5784
+    "total_tax": 64484.5784,
+    "amti": 205063.66,
+    "qbi_deduction": 51265.91500000001
    }
   },
   {
@@ -1055,7 +1139,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2080.0,
-    "total_tax": 2080.0
+    "total_tax": 2080.0,
+    "amti": 20800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 50000.0,
@@ -1065,7 +1151,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2080.0,
-    "total_tax": 2080.0
+    "total_tax": 2080.0,
+    "amti": 20800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -1090,7 +1178,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 4708.53448,
-    "total_tax": 8947.39948
+    "total_tax": 8947.39948,
+    "amti": 43104.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": {
     "agi": 77880.5675,
@@ -1100,7 +1190,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 4708.53448,
-    "total_tax": 8947.39948
+    "total_tax": 8947.39948,
+    "amti": 43104.454,
+    "qbi_deduction": 5576.1135
    }
   },
   {
@@ -1125,7 +1217,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7385.0689600000005,
-    "total_tax": 15862.79896
+    "total_tax": 15862.79896,
+    "amti": 65408.907999999996,
+    "qbi_deduction": 11152.227
    },
    "expected_spouse_attr": {
     "agi": 105761.135,
@@ -1135,7 +1229,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7385.0689600000005,
-    "total_tax": 15862.79896
+    "total_tax": 15862.79896,
+    "amti": 65408.907999999996,
+    "qbi_deduction": 11152.227
    }
   },
   {
@@ -1160,7 +1256,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 19434.320999999996,
-    "total_tax": 38157.945999999996
+    "total_tax": 38157.945999999996,
+    "amti": 133310.55,
+    "qbi_deduction": 28127.6375
    },
    "expected_spouse_attr": {
     "agi": 189402.8375,
@@ -1170,7 +1268,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 19216.899399999995,
-    "total_tax": 40411.22439999999
+    "total_tax": 40411.22439999999,
+    "amti": 132322.27,
+    "qbi_deduction": 27880.5675
    }
   },
   {
@@ -1195,7 +1295,9 @@
     "addl_medicare": 693.4499999999999,
     "amt": 0.0,
     "income_tax": 46493.8784,
-    "total_tax": 69928.17839999999
+    "total_tax": 69928.17839999999,
+    "amti": 251703.66000000003,
+    "qbi_deduction": 57725.91500000001
    },
    "expected_spouse_attr": {
     "agi": 335529.575,
@@ -1205,7 +1307,9 @@
     "addl_medicare": 693.4499999999999,
     "amt": 0.0,
     "income_tax": 45898.678400000004,
-    "total_tax": 75532.9784
+    "total_tax": 75532.9784,
+    "amti": 249223.66000000003,
+    "qbi_deduction": 57105.91500000001
    }
   },
   {
@@ -1230,7 +1334,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10432.0,
-    "total_tax": 10432.0
+    "total_tax": 10432.0,
+    "amti": 90800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 120000.0,
@@ -1240,7 +1346,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10432.0,
-    "total_tax": 10432.0
+    "total_tax": 10432.0,
+    "amti": 90800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -1265,7 +1373,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 14988.979879999997,
-    "total_tax": 19227.844879999997
+    "total_tax": 19227.844879999997,
+    "amti": 113104.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": {
     "agi": 147880.5675,
@@ -1275,7 +1385,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 14988.979879999997,
-    "total_tax": 19227.844879999997
+    "total_tax": 19227.844879999997,
+    "amti": 113104.454,
+    "qbi_deduction": 5576.1135
    }
   },
   {
@@ -1300,7 +1412,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 19970.27048,
-    "total_tax": 27603.56048
+    "total_tax": 27603.56048,
+    "amti": 135746.684,
+    "qbi_deduction": 11236.671000000002
    },
    "expected_spouse_attr": {
     "agi": 175761.135,
@@ -1310,7 +1424,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 19895.959759999998,
-    "total_tax": 28373.689759999997
+    "total_tax": 28373.689759999997,
+    "amti": 135408.908,
+    "qbi_deduction": 11152.227
    }
   },
   {
@@ -1335,7 +1451,9 @@
     "addl_medicare": 76.725,
     "amt": 0.0,
     "income_tax": 35712.812,
-    "total_tax": 45833.162
+    "total_tax": 45833.162,
+    "amti": 206782.55,
+    "qbi_deduction": 28995.6375
    },
    "expected_spouse_attr": {
     "agi": 259402.8375,
@@ -1345,7 +1463,9 @@
     "addl_medicare": 76.725,
     "amt": 0.0,
     "income_tax": 34642.3448,
-    "total_tax": 55913.394799999995
+    "total_tax": 55913.394799999995,
+    "amti": 202322.27,
+    "qbi_deduction": 27880.5675
    }
   },
   {
@@ -1370,7 +1490,9 @@
     "addl_medicare": 1323.4499999999998,
     "amt": 0.0,
     "income_tax": 64127.1584,
-    "total_tax": 79511.4584
+    "total_tax": 79511.4584,
+    "amti": 325175.66000000003,
+    "qbi_deduction": 58593.91500000001
    },
    "expected_spouse_attr": {
     "agi": 405529.575,
@@ -1380,7 +1502,9 @@
     "addl_medicare": 1323.4499999999998,
     "amt": 0.0,
     "income_tax": 62698.678400000004,
-    "total_tax": 92962.9784
+    "total_tax": 92962.9784,
+    "amti": 319223.66000000003,
+    "qbi_deduction": 57105.91500000001
    }
   },
   {
@@ -1405,7 +1529,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 20774.0,
-    "total_tax": 20774.0
+    "total_tax": 20774.0,
+    "amti": 139400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 168600.0,
@@ -1415,7 +1541,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 20774.0,
-    "total_tax": 20774.0
+    "total_tax": 20774.0,
+    "amti": 139400.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -1440,7 +1568,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 25983.296840000003,
-    "total_tax": 26786.741840000002
+    "total_tax": 26786.741840000002,
+    "amti": 163078.622,
+    "qbi_deduction": 5919.655500000001
    },
    "expected_spouse_attr": {
     "agi": 196480.5675,
@@ -1450,7 +1580,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 25680.97988,
-    "total_tax": 29919.844879999997
+    "total_tax": 29919.844879999997,
+    "amti": 161704.454,
+    "qbi_deduction": 5576.1135
    }
   },
   {
@@ -1475,7 +1607,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 31192.593680000005,
-    "total_tax": 32799.483680000005
+    "total_tax": 32799.483680000005,
+    "amti": 186757.244,
+    "qbi_deduction": 11839.311000000002
    },
    "expected_spouse_attr": {
     "agi": 224361.135,
@@ -1485,7 +1619,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 30587.959759999994,
-    "total_tax": 39065.689759999994
+    "total_tax": 39065.689759999994,
+    "amti": 184008.908,
+    "qbi_deduction": 11152.227
    }
   },
   {
@@ -1510,7 +1646,9 @@
     "addl_medicare": 514.125,
     "amt": 0.0,
     "income_tax": 47955.3464,
-    "total_tax": 52486.6964
+    "total_tax": 52486.6964,
+    "amti": 257793.11,
+    "qbi_deduction": 29598.277500000004
    },
    "expected_spouse_attr": {
     "agi": 308002.8375,
@@ -1520,7 +1658,9 @@
     "addl_medicare": 514.125,
     "amt": 0.0,
     "income_tax": 46306.344800000006,
-    "total_tax": 68014.7948
+    "total_tax": 68014.7948,
+    "amti": 250922.27000000002,
+    "qbi_deduction": 27880.5675
    }
   },
   {
@@ -1545,7 +1685,9 @@
     "addl_medicare": 1760.85,
     "amt": 0.0,
     "income_tax": 85504.9197498884,
-    "total_tax": 95300.2197498884
+    "total_tax": 95300.2197498884,
+    "amti": 406662.24921840127,
+    "qbi_deduction": 28720.52578159874
    },
    "expected_spouse_attr": {
     "agi": 454129.575,
@@ -1555,7 +1697,9 @@
     "addl_medicare": 1760.85,
     "amt": 0.0,
     "income_tax": 80574.2717517956,
-    "total_tax": 111275.97175179562
+    "total_tax": 111275.97175179562,
+    "amti": 391253.97422436124,
+    "qbi_deduction": 33675.60077563875
    }
   },
   {
@@ -1580,7 +1724,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 27682.0,
-    "total_tax": 27682.0
+    "total_tax": 27682.0,
+    "amti": 170800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 200000.0,
@@ -1590,7 +1736,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 27682.0,
-    "total_tax": 27682.0
+    "total_tax": 27682.0,
+    "amti": 170800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -1615,7 +1763,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 32891.296839999995,
-    "total_tax": 33694.741839999995
+    "total_tax": 33694.741839999995,
+    "amti": 194478.622,
+    "qbi_deduction": 5919.655500000001
    },
    "expected_spouse_attr": {
     "agi": 227880.5675,
@@ -1625,7 +1775,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 32588.97988,
-    "total_tax": 36827.84488
+    "total_tax": 36827.84488,
+    "amti": 193104.454,
+    "qbi_deduction": 5576.1135
    }
   },
   {
@@ -1650,7 +1802,9 @@
     "addl_medicare": 48.69,
     "amt": 0.0,
     "income_tax": 38442.73856,
-    "total_tax": 40098.31856
+    "total_tax": 40098.31856,
+    "amti": 218157.244,
+    "qbi_deduction": 11839.311000000002
    },
    "expected_spouse_attr": {
     "agi": 255761.135,
@@ -1660,7 +1814,9 @@
     "addl_medicare": 48.69,
     "amt": 0.0,
     "income_tax": 37783.13792,
-    "total_tax": 46309.55792000001
+    "total_tax": 46309.55792000001,
+    "amti": 215408.908,
+    "qbi_deduction": 11152.227
    }
   },
   {
@@ -1685,7 +1841,9 @@
     "addl_medicare": 796.7249999999999,
     "amt": 0.0,
     "income_tax": 55491.346399999995,
-    "total_tax": 60305.29639999999
+    "total_tax": 60305.29639999999,
+    "amti": 289193.11,
+    "qbi_deduction": 29598.277500000004
    },
    "expected_spouse_attr": {
     "agi": 339402.8375,
@@ -1695,7 +1853,9 @@
     "addl_medicare": 796.7249999999999,
     "amt": 0.0,
     "income_tax": 53842.34480000001,
-    "total_tax": 75833.39480000001
+    "total_tax": 75833.39480000001,
+    "amti": 282322.27,
+    "qbi_deduction": 27880.5675
    }
   },
   {
@@ -1720,7 +1880,9 @@
     "addl_medicare": 2043.4499999999998,
     "amt": 0.0,
     "income_tax": 101500.98959628842,
-    "total_tax": 111578.88959628841
+    "total_tax": 111578.88959628841,
+    "amti": 456649.9674884013,
+    "qbi_deduction": 10132.807511598738
    },
    "expected_spouse_attr": {
     "agi": 485529.575,
@@ -1730,7 +1892,9 @@
     "addl_medicare": 2043.4499999999998,
     "amt": 0.0,
     "income_tax": 96360.2740909956,
-    "total_tax": 127344.57409099561
+    "total_tax": 127344.57409099561,
+    "amti": 440585.23153436126,
+    "qbi_deduction": 15744.343465638747
    }
   },
   {
@@ -1755,7 +1919,9 @@
     "addl_medicare": 90.0,
     "amt": 0.0,
     "income_tax": 41477.0,
-    "total_tax": 41567.0
+    "total_tax": 41567.0,
+    "amti": 230800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 260000.0,
@@ -1765,7 +1931,9 @@
     "addl_medicare": 90.0,
     "amt": 0.0,
     "income_tax": 41477.0,
-    "total_tax": 41567.0
+    "total_tax": 41567.0,
+    "amti": 230800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -1790,7 +1958,9 @@
     "addl_medicare": 339.34499999999997,
     "amt": 0.0,
     "income_tax": 47159.869280000006,
-    "total_tax": 48302.65928000001
+    "total_tax": 48302.65928000001,
+    "amti": 254478.62200000003,
+    "qbi_deduction": 5919.655500000001
    },
    "expected_spouse_attr": {
     "agi": 287880.5675,
@@ -1800,7 +1970,9 @@
     "addl_medicare": 339.34499999999997,
     "amt": 0.0,
     "income_tax": 46830.06896,
-    "total_tax": 51408.278959999996
+    "total_tax": 51408.278959999996,
+    "amti": 253104.45400000003,
+    "qbi_deduction": 5576.1135
    }
   },
   {
@@ -1825,7 +1997,9 @@
     "addl_medicare": 588.6899999999999,
     "amt": 0.0,
     "income_tax": 52842.73856,
-    "total_tax": 55038.31856
+    "total_tax": 55038.31856,
+    "amti": 278157.244,
+    "qbi_deduction": 11839.311000000002
    },
    "expected_spouse_attr": {
     "agi": 315761.135,
@@ -1835,7 +2009,9 @@
     "addl_medicare": 588.6899999999999,
     "amt": 0.0,
     "income_tax": 52183.137919999994,
-    "total_tax": 61249.55791999999
+    "total_tax": 61249.55791999999,
+    "amti": 275408.908,
+    "qbi_deduction": 11152.227
    }
   },
   {
@@ -1860,7 +2036,9 @@
     "addl_medicare": 1336.725,
     "amt": 0.0,
     "income_tax": 69891.3464,
-    "total_tax": 75245.2964
+    "total_tax": 75245.2964,
+    "amti": 349193.11,
+    "qbi_deduction": 29598.277500000004
    },
    "expected_spouse_attr": {
     "agi": 399402.8375,
@@ -1870,7 +2048,9 @@
     "addl_medicare": 1336.725,
     "amt": 0.0,
     "income_tax": 68242.34480000002,
-    "total_tax": 90773.39480000002
+    "total_tax": 90773.39480000002,
+    "amti": 342322.27,
+    "qbi_deduction": 27880.5675
    }
   },
   {
@@ -1895,7 +2075,9 @@
     "addl_medicare": 2583.45,
     "amt": 0.0,
     "income_tax": 125123.47125,
-    "total_tax": 135741.37125000003
+    "total_tax": 135741.37125000003,
+    "amti": 526782.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 545529.575,
@@ -1905,7 +2087,9 @@
     "addl_medicare": 2583.45,
     "amt": 0.0,
     "income_tax": 121464.85124999999,
-    "total_tax": 152989.15125
+    "total_tax": 152989.15125,
+    "amti": 516329.57499999995,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -1930,7 +2114,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 75077.0,
-    "total_tax": 76427.0
+    "total_tax": 76427.0,
+    "amti": 370800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 400000.0,
@@ -1940,7 +2126,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 75077.0,
-    "total_tax": 76427.0
+    "total_tax": 76427.0,
+    "amti": 370800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -1965,7 +2153,9 @@
     "addl_medicare": 1599.345,
     "amt": 0.0,
     "income_tax": 81918.6842212589,
-    "total_tax": 84321.4742212589
+    "total_tax": 84321.4742212589,
+    "amti": 395455.26319143403,
+    "qbi_deduction": 4943.0143085659865
    },
    "expected_spouse_attr": {
     "agi": 427880.5675,
@@ -1975,7 +2165,9 @@
     "addl_medicare": 1599.345,
     "amt": 0.0,
     "income_tax": 81430.16327031812,
-    "total_tax": 87268.37327031813
+    "total_tax": 87268.37327031813,
+    "amti": 393928.6352197441,
+    "qbi_deduction": 4751.932280255887
    }
   },
   {
@@ -2000,7 +2192,9 @@
     "addl_medicare": 1848.69,
     "amt": 0.0,
     "income_tax": 90929.72272215552,
-    "total_tax": 94385.30272215552
+    "total_tax": 94385.30272215552,
+    "amti": 423614.758506736,
+    "qbi_deduction": 6381.796493263952
    },
    "expected_spouse_attr": {
     "agi": 455761.135,
@@ -2010,7 +2204,9 @@
     "addl_medicare": 1848.69,
     "amt": 0.0,
     "income_tax": 89826.30387711247,
-    "total_tax": 100152.72387711247
+    "total_tax": 100152.72387711247,
+    "amti": 420166.5746159765,
+    "qbi_deduction": 6394.560384023549
    }
   },
   {
@@ -2035,7 +2231,9 @@
     "addl_medicare": 2596.725,
     "amt": 0.0,
     "income_tax": 122326.48562499999,
-    "total_tax": 128940.435625
+    "total_tax": 128940.435625,
+    "amti": 518791.38749999995,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 539402.8375,
@@ -2045,7 +2243,9 @@
     "addl_medicare": 2596.725,
     "amt": 0.0,
     "income_tax": 119320.49312500001,
-    "total_tax": 143111.543125
+    "total_tax": 143111.543125,
+    "amti": 510202.8375,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -2070,7 +2270,9 @@
     "addl_medicare": 3843.45,
     "amt": 0.0,
     "income_tax": 174123.47125,
-    "total_tax": 186001.37125000003
+    "total_tax": 186001.37125000003,
+    "amti": 666782.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 685529.575,
@@ -2080,7 +2282,9 @@
     "addl_medicare": 3843.45,
     "amt": 0.0,
     "income_tax": 170464.85125,
-    "total_tax": 203249.15125000002
+    "total_tax": 203249.15125000002,
+    "amti": 656329.575,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -2105,7 +2309,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1062.4454000000005,
-    "total_tax": 5301.3104
+    "total_tax": 5301.3104,
+    "amti": 10624.454000000002,
+    "qbi_deduction": 2656.1135000000004
    },
    "expected_spouse_attr": null
   },
@@ -2131,7 +2337,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 3719.46896,
-    "total_tax": 12197.19896
+    "total_tax": 12197.19896,
+    "amti": 32928.908,
+    "qbi_deduction": 8232.227
    },
    "expected_spouse_attr": null
   },
@@ -2157,7 +2365,9 @@
     "addl_medicare": 121.725,
     "amt": 0.0,
     "income_tax": 17018.299399999996,
-    "total_tax": 38334.34939999999
+    "total_tax": 38334.34939999999,
+    "amti": 99842.26999999999,
+    "qbi_deduction": 24960.5675
    },
    "expected_spouse_attr": null
   },
@@ -2183,7 +2393,9 @@
     "addl_medicare": 1368.4499999999998,
     "amt": 0.0,
     "income_tax": 65200.10125000001,
-    "total_tax": 95509.40125000001
+    "total_tax": 95509.40125000001,
+    "amti": 270929.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2209,7 +2421,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 4016.0,
-    "total_tax": 4016.0
+    "total_tax": 4016.0,
+    "amti": 35400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2235,7 +2449,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7747.979880000001,
-    "total_tax": 11986.84488
+    "total_tax": 11986.84488,
+    "amti": 57704.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": null
   },
@@ -2261,7 +2477,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 12654.959759999998,
-    "total_tax": 21132.689759999997
+    "total_tax": 21132.689759999997,
+    "amti": 80008.908,
+    "qbi_deduction": 11152.227
    },
    "expected_spouse_attr": null
   },
@@ -2287,7 +2505,9 @@
     "addl_medicare": 571.7249999999999,
     "amt": 0.0,
     "income_tax": 28541.032,
-    "total_tax": 47836.382
+    "total_tax": 47836.382,
+    "amti": 147910.55,
+    "qbi_deduction": 28127.6375
    },
    "expected_spouse_attr": null
   },
@@ -2313,7 +2533,9 @@
     "addl_medicare": 1818.4499999999998,
     "amt": 0.0,
     "income_tax": 83785.10125,
-    "total_tax": 108344.40125000001
+    "total_tax": 108344.40125000001,
+    "amti": 324029.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2339,7 +2561,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 18338.5,
-    "total_tax": 18338.5
+    "total_tax": 18338.5,
+    "amti": 105400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2365,7 +2589,9 @@
     "addl_medicare": 204.34499999999997,
     "amt": 0.0,
     "income_tax": 23691.56896,
-    "total_tax": 28134.778960000003
+    "total_tax": 28134.778960000003,
+    "amti": 127704.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": null
   },
@@ -2391,7 +2617,9 @@
     "addl_medicare": 453.68999999999994,
     "amt": 0.0,
     "income_tax": 29125.704160000005,
-    "total_tax": 37212.684160000004
+    "total_tax": 37212.684160000004,
+    "amti": 150346.684,
+    "qbi_deduction": 11236.671000000002
    },
    "expected_spouse_attr": null
   },
@@ -2417,7 +2645,9 @@
     "addl_medicare": 1201.725,
     "amt": 0.0,
     "income_tax": 58007.115625,
-    "total_tax": 69252.46562500001
+    "total_tax": 69252.46562500001,
+    "amti": 250378.1875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2443,7 +2673,9 @@
     "addl_medicare": 2448.45,
     "amt": 0.0,
     "income_tax": 110459.49275,
-    "total_tax": 126968.79275000001
+    "total_tax": 126968.79275000001,
+    "amti": 398369.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2469,7 +2701,9 @@
     "addl_medicare": 392.4,
     "amt": 0.0,
     "income_tax": 30002.5,
-    "total_tax": 30394.9
+    "total_tax": 30394.9,
+    "amti": 154000.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2495,7 +2729,9 @@
     "addl_medicare": 641.7449999999999,
     "amt": 0.0,
     "income_tax": 35685.36928,
-    "total_tax": 37130.55928
+    "total_tax": 37130.55928,
+    "amti": 177678.622,
+    "qbi_deduction": 5919.655500000001
    },
    "expected_spouse_attr": null
   },
@@ -2521,7 +2757,9 @@
     "addl_medicare": 891.0899999999999,
     "amt": 0.0,
     "income_tax": 43730.70334287107,
-    "total_tax": 46228.68334287107
+    "total_tax": 46228.68334287107,
+    "amti": 206388.1354464721,
+    "qbi_deduction": 6808.419553527903
    },
    "expected_spouse_attr": null
   },
@@ -2547,7 +2785,9 @@
     "addl_medicare": 1639.125,
     "amt": 0.0,
     "income_tax": 76071.735625,
-    "total_tax": 81728.085625
+    "total_tax": 81728.085625,
+    "amti": 301991.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2573,7 +2813,9 @@
     "addl_medicare": 2885.85,
     "amt": 0.0,
     "income_tax": 129556.37675000001,
-    "total_tax": 140476.67675
+    "total_tax": 140476.67675,
+    "amti": 449982.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2599,7 +2841,9 @@
     "addl_medicare": 675.0,
     "amt": 0.0,
     "income_tax": 37538.5,
-    "total_tax": 38213.5
+    "total_tax": 38213.5,
+    "amti": 185400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2625,7 +2869,9 @@
     "addl_medicare": 924.345,
     "amt": 0.0,
     "income_tax": 45464.86136107776,
-    "total_tax": 47192.65136107776
+    "total_tax": 47192.65136107776,
+    "amti": 211807.379253368,
+    "qbi_deduction": 3190.898246631976
    },
    "expected_spouse_attr": null
   },
@@ -2651,7 +2897,9 @@
     "addl_medicare": 1173.69,
     "amt": 0.0,
     "income_tax": 55983.54425,
-    "total_tax": 58764.12425
+    "total_tax": 58764.12425,
+    "amti": 244596.555,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2677,7 +2925,9 @@
     "addl_medicare": 1921.725,
     "amt": 0.0,
     "income_tax": 87061.735625,
-    "total_tax": 93000.68562500001
+    "total_tax": 93000.68562500001,
+    "amti": 333391.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2703,7 +2953,9 @@
     "addl_medicare": 3168.45,
     "amt": 0.0,
     "income_tax": 141174.37675,
-    "total_tax": 152377.27675000002
+    "total_tax": 152377.27675000002,
+    "amti": 481382.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2729,7 +2981,9 @@
     "addl_medicare": 1215.0,
     "amt": 0.0,
     "income_tax": 56264.75,
-    "total_tax": 57479.75
+    "total_tax": 57479.75,
+    "amti": 245400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2755,7 +3009,9 @@
     "addl_medicare": 1464.345,
     "amt": 0.0,
     "income_tax": 66624.147125,
-    "total_tax": 68891.93712500001
+    "total_tax": 68891.93712500001,
+    "amti": 274998.2775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2781,7 +3037,9 @@
     "addl_medicare": 1713.69,
     "amt": 0.0,
     "income_tax": 76983.54424999999,
-    "total_tax": 80304.12425
+    "total_tax": 80304.12425,
+    "amti": 304596.555,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2807,7 +3065,9 @@
     "addl_medicare": 2461.725,
     "amt": 0.0,
     "income_tax": 108617.563375,
-    "total_tax": 115096.51337500001
+    "total_tax": 115096.51337500001,
+    "amti": 393391.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2833,7 +3093,9 @@
     "addl_medicare": 3708.45,
     "amt": 0.0,
     "income_tax": 163374.37675,
-    "total_tax": 175117.27675000002
+    "total_tax": 175117.27675000002,
+    "amti": 541382.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2859,7 +3121,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 105660.75,
-    "total_tax": 108135.75
+    "total_tax": 108135.75,
+    "amti": 385400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2885,7 +3149,9 @@
     "addl_medicare": 2724.345,
     "amt": 0.0,
     "income_tax": 116612.11267500001,
-    "total_tax": 120139.90267500002
+    "total_tax": 120139.90267500002,
+    "amti": 414998.2775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2911,7 +3177,9 @@
     "addl_medicare": 2973.69,
     "amt": 0.0,
     "income_tax": 127563.47534999998,
-    "total_tax": 132144.05534999998
+    "total_tax": 132144.05534999998,
+    "amti": 444596.555,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2937,7 +3205,9 @@
     "addl_medicare": 3721.725,
     "amt": 0.0,
     "income_tax": 160417.56337499997,
-    "total_tax": 168156.51337499998
+    "total_tax": 168156.51337499998,
+    "amti": 533391.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2963,7 +3233,9 @@
     "addl_medicare": 4968.45,
     "amt": 0.0,
     "income_tax": 215174.37675,
-    "total_tax": 228177.27675000002
+    "total_tax": 228177.27675000002,
+    "amti": 681382.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -2989,7 +3261,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 478.4454000000005,
-    "total_tax": 4717.3104
+    "total_tax": 4717.3104,
+    "amti": 4784.4540000000015,
+    "qbi_deduction": 1196.1135000000002
    },
    "expected_spouse_attr": null
   },
@@ -3015,7 +3289,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2919.668960000001,
-    "total_tax": 11397.39896
+    "total_tax": 11397.39896,
+    "amti": 27088.908000000003,
+    "qbi_deduction": 6772.227000000001
    },
    "expected_spouse_attr": null
   },
@@ -3041,7 +3317,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 14039.4994,
-    "total_tax": 35233.8244
+    "total_tax": 35233.8244,
+    "amti": 94002.26999999999,
+    "qbi_deduction": 23500.5675
    },
    "expected_spouse_attr": null
   },
@@ -3067,7 +3345,9 @@
     "addl_medicare": 693.4499999999999,
     "amt": 0.0,
     "income_tax": 60952.35125000001,
-    "total_tax": 90586.65125000001
+    "total_tax": 90586.65125000001,
+    "amti": 263629.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3093,7 +3373,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 3041.0,
-    "total_tax": 3041.0
+    "total_tax": 3041.0,
+    "amti": 28100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3119,7 +3401,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5717.53448,
-    "total_tax": 9956.39948
+    "total_tax": 9956.39948,
+    "amti": 50404.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": null
   },
@@ -3145,7 +3429,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 9354.959760000002,
-    "total_tax": 17832.68976
+    "total_tax": 17832.68976,
+    "amti": 72708.908,
+    "qbi_deduction": 11152.227
    },
    "expected_spouse_attr": null
   },
@@ -3171,7 +3457,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 25095.532,
-    "total_tax": 43819.157
+    "total_tax": 43819.157,
+    "amti": 140610.55,
+    "qbi_deduction": 28127.6375
    },
    "expected_spouse_attr": null
   },
@@ -3197,7 +3485,9 @@
     "addl_medicare": 1143.4499999999998,
     "amt": 0.0,
     "income_tax": 79537.35125,
-    "total_tax": 103421.65125000001
+    "total_tax": 103421.65125000001,
+    "amti": 316729.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3223,7 +3513,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 14941.0,
-    "total_tax": 14941.0
+    "total_tax": 14941.0,
+    "amti": 98100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3249,7 +3541,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 20246.068960000004,
-    "total_tax": 24484.933960000002
+    "total_tax": 24484.933960000002,
+    "amti": 120404.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": null
   },
@@ -3275,7 +3569,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 25680.20416,
-    "total_tax": 33313.49416
+    "total_tax": 33313.49416,
+    "amti": 143046.684,
+    "qbi_deduction": 11236.671000000002
    },
    "expected_spouse_attr": null
   },
@@ -3301,7 +3597,9 @@
     "addl_medicare": 526.7249999999999,
     "amt": 0.0,
     "income_tax": 53778.020000000004,
-    "total_tax": 64348.37
+    "total_tax": 64348.37,
+    "amti": 243078.1875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3327,7 +3625,9 @@
     "addl_medicare": 1773.4499999999998,
     "amt": 0.0,
     "income_tax": 105556.35125,
-    "total_tax": 121390.65125000001
+    "total_tax": 121390.65125000001,
+    "amti": 391069.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3353,7 +3653,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 26557.0,
-    "total_tax": 26557.0
+    "total_tax": 26557.0,
+    "amti": 146700.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3379,7 +3681,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 32239.86928,
-    "total_tax": 33043.31428
+    "total_tax": 33043.31428,
+    "amti": 170378.622,
+    "qbi_deduction": 5919.655500000001
    },
    "expected_spouse_attr": null
   },
@@ -3405,7 +3709,9 @@
     "addl_medicare": 216.08999999999997,
     "amt": 0.0,
     "income_tax": 39148.07073295107,
-    "total_tax": 40971.050732951066
+    "total_tax": 40971.050732951066,
+    "amti": 197359.5960404721,
+    "qbi_deduction": 8536.958959527903
    },
    "expected_spouse_attr": null
   },
@@ -3431,7 +3737,9 @@
     "addl_medicare": 964.1249999999999,
     "amt": 0.0,
     "income_tax": 71823.985625,
-    "total_tax": 76805.335625
+    "total_tax": 76805.335625,
+    "amti": 294691.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3457,7 +3765,9 @@
     "addl_medicare": 2210.85,
     "amt": 0.0,
     "income_tax": 123620.97124999999,
-    "total_tax": 133866.27125
+    "total_tax": 133866.27125,
+    "amti": 442682.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3483,7 +3793,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 34093.0,
-    "total_tax": 34093.0
+    "total_tax": 34093.0,
+    "amti": 178100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3509,7 +3821,9 @@
     "addl_medicare": 249.34499999999997,
     "amt": 0.0,
     "income_tax": 41158.795056117764,
-    "total_tax": 42211.585056117765
+    "total_tax": 42211.585056117765,
+    "amti": 203643.109550368,
+    "qbi_deduction": 4055.1679496319757
    },
    "expected_spouse_attr": null
   },
@@ -3535,7 +3849,9 @@
     "addl_medicare": 498.68999999999994,
     "amt": 0.0,
     "income_tax": 51575.29867151107,
-    "total_tax": 53680.87867151107
+    "total_tax": 53680.87867151107,
+    "amti": 236194.68334847208,
+    "qbi_deduction": 1101.8716515279011
    },
    "expected_spouse_attr": null
   },
@@ -3561,7 +3877,9 @@
     "addl_medicare": 1246.725,
     "amt": 0.0,
     "income_tax": 82813.985625,
-    "total_tax": 88077.93562500001
+    "total_tax": 88077.93562500001,
+    "amti": 326091.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3587,7 +3905,9 @@
     "addl_medicare": 2493.45,
     "amt": 0.0,
     "income_tax": 134610.97125,
-    "total_tax": 145138.87125000003
+    "total_tax": 145138.87125000003,
+    "amti": 474082.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3613,7 +3933,9 @@
     "addl_medicare": 540.0,
     "amt": 0.0,
     "income_tax": 52185.0,
-    "total_tax": 52725.0
+    "total_tax": 52725.0,
+    "amti": 238100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3639,7 +3961,9 @@
     "addl_medicare": 789.345,
     "amt": 0.0,
     "income_tax": 62376.39712500001,
-    "total_tax": 63969.18712500001
+    "total_tax": 63969.18712500001,
+    "amti": 267698.2775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3665,7 +3989,9 @@
     "addl_medicare": 1038.69,
     "amt": 0.0,
     "income_tax": 72735.79424999999,
-    "total_tax": 75381.37425
+    "total_tax": 75381.37425,
+    "amti": 297296.555,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3691,7 +4017,9 @@
     "addl_medicare": 1786.725,
     "amt": 0.0,
     "income_tax": 103813.985625,
-    "total_tax": 109617.93562500001
+    "total_tax": 109617.93562500001,
+    "amti": 386091.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3717,7 +4045,9 @@
     "addl_medicare": 3033.45,
     "amt": 0.0,
     "income_tax": 155610.97125,
-    "total_tax": 166678.87125000003
+    "total_tax": 166678.87125000003,
+    "amti": 534082.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3743,7 +4073,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 101017.0,
-    "total_tax": 102817.0
+    "total_tax": 102817.0,
+    "amti": 378100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3769,7 +4101,9 @@
     "addl_medicare": 2049.345,
     "amt": 0.0,
     "income_tax": 111376.397125,
-    "total_tax": 114229.18712500001
+    "total_tax": 114229.18712500001,
+    "amti": 407698.2775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3795,7 +4129,9 @@
     "addl_medicare": 2298.6899999999996,
     "amt": 0.0,
     "income_tax": 121735.79424999999,
-    "total_tax": 125641.37425
+    "total_tax": 125641.37425,
+    "amti": 437296.555,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3821,7 +4157,9 @@
     "addl_medicare": 3046.7249999999995,
     "amt": 0.0,
     "income_tax": 152813.98562499997,
-    "total_tax": 159877.93562499998
+    "total_tax": 159877.93562499998,
+    "amti": 526091.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3847,7 +4185,9 @@
     "addl_medicare": 4293.45,
     "amt": 0.0,
     "income_tax": 205905.62675,
-    "total_tax": 218233.52675000002
+    "total_tax": 218233.52675000002,
+    "amti": 674082.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3873,7 +4213,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 0.0,
-    "total_tax": 4238.865
+    "total_tax": 4238.865,
+    "amti": -1319.432499999999,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -3899,7 +4241,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2124.890800000001,
-    "total_tax": 10602.6208
+    "total_tax": 10602.6208,
+    "amti": 21248.908000000003,
+    "qbi_deduction": 5312.227000000001
    },
    "expected_spouse_attr": null
   },
@@ -3925,7 +4269,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10115.472399999999,
-    "total_tax": 31309.797399999996
+    "total_tax": 31309.797399999996,
+    "amti": 88162.26999999999,
+    "qbi_deduction": 22040.5675
    },
    "expected_spouse_attr": null
   },
@@ -3951,7 +4297,9 @@
     "addl_medicare": 693.4499999999999,
     "amt": 0.0,
     "income_tax": 42722.169290446705,
-    "total_tax": 72356.46929044671
+    "total_tax": 72356.46929044671,
+    "amti": 235988.20537686127,
+    "qbi_deduction": 20341.369623138744
    },
    "expected_spouse_attr": null
   },
@@ -3977,7 +4325,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2080.0,
-    "total_tax": 2080.0
+    "total_tax": 2080.0,
+    "amti": 20800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4003,7 +4353,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 4708.53448,
-    "total_tax": 8947.39948
+    "total_tax": 8947.39948,
+    "amti": 43104.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": null
   },
@@ -4029,7 +4381,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7385.0689600000005,
-    "total_tax": 15862.79896
+    "total_tax": 15862.79896,
+    "amti": 65408.907999999996,
+    "qbi_deduction": 11152.227
    },
    "expected_spouse_attr": null
   },
@@ -4055,7 +4409,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 19434.320999999996,
-    "total_tax": 38157.945999999996
+    "total_tax": 38157.945999999996,
+    "amti": 133310.55,
+    "qbi_deduction": 28127.6375
    },
    "expected_spouse_attr": null
   },
@@ -4081,7 +4437,9 @@
     "addl_medicare": 1143.4499999999998,
     "amt": 0.0,
     "income_tax": 60348.098,
-    "total_tax": 84232.398
+    "total_tax": 84232.398,
+    "amti": 309429.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4107,7 +4465,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10432.0,
-    "total_tax": 10432.0
+    "total_tax": 10432.0,
+    "amti": 90800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4133,7 +4493,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 14988.979879999997,
-    "total_tax": 19227.844879999997
+    "total_tax": 19227.844879999997,
+    "amti": 113104.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": null
   },
@@ -4159,7 +4521,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 19970.27048,
-    "total_tax": 27603.56048
+    "total_tax": 27603.56048,
+    "amti": 135746.684,
+    "qbi_deduction": 11236.671000000002
    },
    "expected_spouse_attr": null
   },
@@ -4185,7 +4549,9 @@
     "addl_medicare": 526.7249999999999,
     "amt": 0.0,
     "income_tax": 38762.79496887688,
-    "total_tax": 49333.14496887688
+    "total_tax": 49333.14496887688,
+    "amti": 219490.81237032032,
+    "qbi_deduction": 16287.375129679689
    },
    "expected_spouse_attr": null
   },
@@ -4211,7 +4577,9 @@
     "addl_medicare": 1773.4499999999998,
     "amt": 0.0,
     "income_tax": 78189.698,
-    "total_tax": 94023.998
+    "total_tax": 94023.998,
+    "amti": 383769.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4237,7 +4605,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 20774.0,
-    "total_tax": 20774.0
+    "total_tax": 20774.0,
+    "amti": 139400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4263,7 +4633,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 25983.296840000003,
-    "total_tax": 26786.741840000002
+    "total_tax": 26786.741840000002,
+    "amti": 163078.622,
+    "qbi_deduction": 5919.655500000001
    },
    "expected_spouse_attr": null
   },
@@ -4289,7 +4661,9 @@
     "addl_medicare": 216.08999999999997,
     "amt": 0.0,
     "income_tax": 31365.71306979193,
-    "total_tax": 33188.69306979193
+    "total_tax": 33188.69306979193,
+    "amti": 187544.15031723605,
+    "qbi_deduction": 11052.404682763952
    },
    "expected_spouse_attr": null
   },
@@ -4315,7 +4689,9 @@
     "addl_medicare": 964.1249999999999,
     "amt": 0.0,
     "income_tax": 54735.10801330407,
-    "total_tax": 59716.458013304065
+    "total_tax": 59716.458013304065,
+    "amti": 286042.1167221003,
+    "qbi_deduction": 1349.2707778996846
    },
    "expected_spouse_attr": null
   },
@@ -4341,7 +4717,9 @@
     "addl_medicare": 2210.85,
     "amt": 0.0,
     "income_tax": 94695.48800000001,
-    "total_tax": 104940.78800000002
+    "total_tax": 104940.78800000002,
+    "amti": 435382.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4367,7 +4745,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 27682.0,
-    "total_tax": 27682.0
+    "total_tax": 27682.0,
+    "amti": 170800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4393,7 +4773,9 @@
     "addl_medicare": 249.34499999999997,
     "amt": 0.0,
     "income_tax": 33001.32080321049,
-    "total_tax": 34054.11080321049
+    "total_tax": 34054.11080321049,
+    "amti": 194978.73092368402,
+    "qbi_deduction": 5419.546576315988
    },
    "expected_spouse_attr": null
   },
@@ -4419,7 +4801,9 @@
     "addl_medicare": 498.68999999999994,
     "amt": 0.0,
     "income_tax": 39523.80655309665,
-    "total_tax": 41629.38655309665
+    "total_tax": 41629.38655309665,
+    "amti": 222661.69397123603,
+    "qbi_deduction": 7334.861028763952
    },
    "expected_spouse_attr": null
   },
@@ -4445,7 +4829,9 @@
     "addl_medicare": 1246.725,
     "amt": 0.0,
     "income_tax": 62594.933000000005,
-    "total_tax": 67858.88300000002
+    "total_tax": 67858.88300000002,
+    "amti": 318791.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4471,7 +4857,9 @@
     "addl_medicare": 2493.45,
     "amt": 0.0,
     "income_tax": 104743.48800000001,
-    "total_tax": 115271.388
+    "total_tax": 115271.388,
+    "amti": 466782.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4497,7 +4885,9 @@
     "addl_medicare": 540.0,
     "amt": 0.0,
     "income_tax": 41477.0,
-    "total_tax": 42017.0
+    "total_tax": 42017.0,
+    "amti": 230800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4523,7 +4913,9 @@
     "addl_medicare": 789.345,
     "amt": 0.0,
     "income_tax": 48132.32581368417,
-    "total_tax": 49725.11581368417
+    "total_tax": 49725.11581368417,
+    "amti": 258530.52422368404,
+    "qbi_deduction": 1867.7532763159866
    },
    "expected_spouse_attr": null
   },
@@ -4549,7 +4941,9 @@
     "addl_medicare": 1038.69,
     "amt": 0.0,
     "income_tax": 55628.667337096645,
-    "total_tax": 58274.24733709665
+    "total_tax": 58274.24733709665,
+    "amti": 289765.28057123604,
+    "qbi_deduction": 231.2744287639507
    },
    "expected_spouse_attr": null
   },
@@ -4575,7 +4969,9 @@
     "addl_medicare": 1786.725,
     "amt": 0.0,
     "income_tax": 76994.933,
-    "total_tax": 82798.88300000002
+    "total_tax": 82798.88300000002,
+    "amti": 378791.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4601,7 +4997,9 @@
     "addl_medicare": 3033.45,
     "amt": 0.0,
     "income_tax": 125123.47125,
-    "total_tax": 136191.37125000003
+    "total_tax": 136191.37125000003,
+    "amti": 526782.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4627,7 +5025,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 75077.0,
-    "total_tax": 76877.0
+    "total_tax": 76877.0,
+    "amti": 370800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4653,7 +5053,9 @@
     "addl_medicare": 2049.345,
     "amt": 0.0,
     "income_tax": 83500.44880000001,
-    "total_tax": 86353.23880000002
+    "total_tax": 86353.23880000002,
+    "amti": 400398.2775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4679,7 +5081,9 @@
     "addl_medicare": 2298.6899999999996,
     "amt": 0.0,
     "income_tax": 92971.8976,
-    "total_tax": 96877.4776
+    "total_tax": 96877.4776,
+    "amti": 429996.555,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4705,7 +5109,9 @@
     "addl_medicare": 3046.7249999999995,
     "amt": 0.0,
     "income_tax": 122326.48562499999,
-    "total_tax": 129390.435625
+    "total_tax": 129390.435625,
+    "amti": 518791.38749999995,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4731,7 +5137,9 @@
     "addl_medicare": 4293.45,
     "amt": 0.0,
     "income_tax": 174123.47125,
-    "total_tax": 186451.37125000003
+    "total_tax": 186451.37125000003,
+    "amti": 666782.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4757,7 +5165,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 6022.25,
-    "total_tax": 6022.25
+    "total_tax": 6022.25,
+    "amti": 60400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4783,7 +5193,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 11272.25,
-    "total_tax": 11272.25
+    "total_tax": 11272.25,
+    "amti": 95400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4809,7 +5221,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 32272.25,
-    "total_tax": 34172.25
+    "total_tax": 34172.25,
+    "amti": 235400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4835,7 +5249,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 8341.0,
-    "total_tax": 8341.0
+    "total_tax": 8341.0,
+    "amti": 60400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4861,7 +5277,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 12091.0,
-    "total_tax": 12091.0
+    "total_tax": 12091.0,
+    "amti": 85400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4887,7 +5305,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 17341.0,
-    "total_tax": 17341.0
+    "total_tax": 17341.0,
+    "amti": 120400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4913,7 +5333,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 38341.0,
-    "total_tax": 41191.0
+    "total_tax": 41191.0,
+    "amti": 260400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4939,7 +5361,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 16041.0,
-    "total_tax": 16041.0
+    "total_tax": 16041.0,
+    "amti": 95400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4965,7 +5389,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 19791.0,
-    "total_tax": 19791.0
+    "total_tax": 19791.0,
+    "amti": 120400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -4991,7 +5417,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 25041.0,
-    "total_tax": 25041.0
+    "total_tax": 25041.0,
+    "amti": 155400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5017,7 +5445,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 46041.0,
-    "total_tax": 50221.0
+    "total_tax": 50221.0,
+    "amti": 295400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5043,7 +5473,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 29288.5,
-    "total_tax": 29288.5
+    "total_tax": 29288.5,
+    "amti": 160400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5069,7 +5501,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 34538.5,
-    "total_tax": 34918.5
+    "total_tax": 34918.5,
+    "amti": 195400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5095,7 +5529,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 55538.5,
-    "total_tax": 61238.5
+    "total_tax": 61238.5,
+    "amti": 335400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5121,7 +5557,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 31538.5,
-    "total_tax": 31538.5
+    "total_tax": 31538.5,
+    "amti": 160400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5147,7 +5585,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 35288.5,
-    "total_tax": 35288.5
+    "total_tax": 35288.5,
+    "amti": 185400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5173,7 +5613,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 40538.5,
-    "total_tax": 41868.5
+    "total_tax": 41868.5,
+    "amti": 220400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5199,7 +5641,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 61538.5,
-    "total_tax": 68188.5
+    "total_tax": 68188.5,
+    "amti": 360400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5225,7 +5669,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 40214.5,
-    "total_tax": 40594.5
+    "total_tax": 40594.5,
+    "amti": 195400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5251,7 +5697,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 43964.5,
-    "total_tax": 45294.5
+    "total_tax": 45294.5,
+    "amti": 220400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5277,7 +5725,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 49214.5,
-    "total_tax": 51874.5
+    "total_tax": 51874.5,
+    "amti": 255400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5303,7 +5753,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 70214.5,
-    "total_tax": 78194.5
+    "total_tax": 78194.5,
+    "amti": 395400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5329,7 +5781,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 56764.5,
-    "total_tax": 58164.5
+    "total_tax": 58164.5,
+    "amti": 260400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5355,7 +5809,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 62014.5,
-    "total_tax": 64744.5
+    "total_tax": 64744.5,
+    "amti": 295400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5381,7 +5837,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 83014.5,
-    "total_tax": 91064.5
+    "total_tax": 91064.5,
+    "amti": 435400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5407,7 +5865,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 61514.75,
-    "total_tax": 62914.75
+    "total_tax": 62914.75,
+    "amti": 260400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5433,7 +5893,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 65264.75,
-    "total_tax": 67614.75
+    "total_tax": 67614.75,
+    "amti": 285400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5459,7 +5921,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 70514.75,
-    "total_tax": 74194.75
+    "total_tax": 74194.75,
+    "amti": 320400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5485,7 +5949,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 91514.75,
-    "total_tax": 100514.75
+    "total_tax": 100514.75,
+    "amti": 460400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5511,7 +5977,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 73764.75,
-    "total_tax": 76494.75
+    "total_tax": 76494.75,
+    "amti": 295400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5537,7 +6005,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 77514.75,
-    "total_tax": 81194.75
+    "total_tax": 81194.75,
+    "amti": 320400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5563,7 +6033,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 82764.75,
-    "total_tax": 87774.75
+    "total_tax": 87774.75,
+    "amti": 355400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5589,7 +6061,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 103764.75,
-    "total_tax": 114094.75
+    "total_tax": 114094.75,
+    "amti": 495400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5615,7 +6089,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 109014.75,
-    "total_tax": 111764.75
+    "total_tax": 111764.75,
+    "amti": 410400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5641,7 +6117,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 114264.75,
-    "total_tax": 118344.75
+    "total_tax": 118344.75,
+    "amti": 445400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5667,7 +6145,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 138589.75,
-    "total_tax": 147989.75
+    "total_tax": 147989.75,
+    "amti": 585400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5693,7 +6173,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 114014.75,
-    "total_tax": 116764.75
+    "total_tax": 116764.75,
+    "amti": 410400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5719,7 +6201,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 117764.75,
-    "total_tax": 121464.75
+    "total_tax": 121464.75,
+    "amti": 435400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5745,7 +6229,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 123014.75,
-    "total_tax": 128044.75
+    "total_tax": 128044.75,
+    "amti": 470400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5771,7 +6257,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 148589.75,
-    "total_tax": 158939.75
+    "total_tax": 158939.75,
+    "amti": 610400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5797,7 +6285,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 126264.75,
-    "total_tax": 130344.75
+    "total_tax": 130344.75,
+    "amti": 445400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5823,7 +6313,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 130014.75,
-    "total_tax": 135044.75
+    "total_tax": 135044.75,
+    "amti": 470400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5849,7 +6341,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 135264.75,
-    "total_tax": 141624.75
+    "total_tax": 141624.75,
+    "amti": 505400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5875,7 +6369,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 162589.75,
-    "total_tax": 174269.75
+    "total_tax": 174269.75,
+    "amti": 645400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -5901,7 +6397,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2080.0,
-    "total_tax": 2080.0
+    "total_tax": 2080.0,
+    "amti": 45800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 75000.0,
@@ -5911,7 +6409,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2080.0,
-    "total_tax": 2080.0
+    "total_tax": 2080.0,
+    "amti": 45800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -5936,7 +6436,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2080.0,
-    "total_tax": 2080.0
+    "total_tax": 2080.0,
+    "amti": 80800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 110000.0,
@@ -5946,7 +6448,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2080.0,
-    "total_tax": 2080.0
+    "total_tax": 2080.0,
+    "amti": 80800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -5971,7 +6475,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 21092.5,
-    "total_tax": 21092.5
+    "total_tax": 21092.5,
+    "amti": 220800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 250000.0,
@@ -5981,7 +6487,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 21092.5,
-    "total_tax": 21092.5
+    "total_tax": 21092.5,
+    "amti": 220800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6006,7 +6514,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5032.0,
-    "total_tax": 5032.0
+    "total_tax": 5032.0,
+    "amti": 45800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 75000.0,
@@ -6016,7 +6526,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5032.0,
-    "total_tax": 5032.0
+    "total_tax": 5032.0,
+    "amti": 45800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6041,7 +6553,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5032.0,
-    "total_tax": 5032.0
+    "total_tax": 5032.0,
+    "amti": 70800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 100000.0,
@@ -6051,7 +6565,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5032.0,
-    "total_tax": 5032.0
+    "total_tax": 5032.0,
+    "amti": 70800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6076,7 +6592,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 6794.5,
-    "total_tax": 6794.5
+    "total_tax": 6794.5,
+    "amti": 105800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 135000.0,
@@ -6086,7 +6604,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 6794.5,
-    "total_tax": 6794.5
+    "total_tax": 6794.5,
+    "amti": 105800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6111,7 +6631,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 27794.5,
-    "total_tax": 28744.5
+    "total_tax": 28744.5,
+    "amti": 245800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 275000.0,
@@ -6121,7 +6643,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 27794.5,
-    "total_tax": 28744.5
+    "total_tax": 28744.5,
+    "amti": 245800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6146,7 +6670,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 9232.0,
-    "total_tax": 9232.0
+    "total_tax": 9232.0,
+    "amti": 80800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 110000.0,
@@ -6156,7 +6682,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 9232.0,
-    "total_tax": 9232.0
+    "total_tax": 9232.0,
+    "amti": 80800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6181,7 +6709,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10994.5,
-    "total_tax": 10994.5
+    "total_tax": 10994.5,
+    "amti": 105800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 135000.0,
@@ -6191,7 +6721,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10994.5,
-    "total_tax": 10994.5
+    "total_tax": 10994.5,
+    "amti": 105800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6216,7 +6748,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 16244.5,
-    "total_tax": 16244.5
+    "total_tax": 16244.5,
+    "amti": 140800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 170000.0,
@@ -6226,7 +6760,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 16244.5,
-    "total_tax": 16244.5
+    "total_tax": 16244.5,
+    "amti": 140800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6251,7 +6787,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 37244.5,
-    "total_tax": 39524.5
+    "total_tax": 39524.5,
+    "amti": 280800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 310000.0,
@@ -6261,7 +6799,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 37244.5,
-    "total_tax": 39524.5
+    "total_tax": 39524.5,
+    "amti": 280800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6286,7 +6826,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 20432.0,
-    "total_tax": 20432.0
+    "total_tax": 20432.0,
+    "amti": 145800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 175000.0,
@@ -6296,7 +6838,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 20432.0,
-    "total_tax": 20432.0
+    "total_tax": 20432.0,
+    "amti": 145800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6321,7 +6865,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 25682.0,
-    "total_tax": 25682.0
+    "total_tax": 25682.0,
+    "amti": 180800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 210000.0,
@@ -6331,7 +6877,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 25682.0,
-    "total_tax": 25682.0
+    "total_tax": 25682.0,
+    "amti": 180800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6356,7 +6904,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 46682.0,
-    "total_tax": 50482.0
+    "total_tax": 50482.0,
+    "amti": 320800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 350000.0,
@@ -6366,7 +6916,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 46682.0,
-    "total_tax": 50482.0
+    "total_tax": 50482.0,
+    "amti": 320800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6391,7 +6943,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 22182.0,
-    "total_tax": 22182.0
+    "total_tax": 22182.0,
+    "amti": 145800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 175000.0,
@@ -6401,7 +6955,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 22182.0,
-    "total_tax": 22182.0
+    "total_tax": 22182.0,
+    "amti": 145800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6426,7 +6982,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 25932.0,
-    "total_tax": 25932.0
+    "total_tax": 25932.0,
+    "amti": 170800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 200000.0,
@@ -6436,7 +6994,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 25932.0,
-    "total_tax": 25932.0
+    "total_tax": 25932.0,
+    "amti": 170800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6461,7 +7021,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 31182.0,
-    "total_tax": 31182.0
+    "total_tax": 31182.0,
+    "amti": 205800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 235000.0,
@@ -6471,7 +7033,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 31182.0,
-    "total_tax": 31182.0
+    "total_tax": 31182.0,
+    "amti": 205800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6496,7 +7060,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 52182.0,
-    "total_tax": 56932.0
+    "total_tax": 56932.0,
+    "amti": 345800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 375000.0,
@@ -6506,7 +7072,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 52182.0,
-    "total_tax": 56932.0
+    "total_tax": 56932.0,
+    "amti": 345800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6531,7 +7099,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 29882.0,
-    "total_tax": 29882.0
+    "total_tax": 29882.0,
+    "amti": 180800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 210000.0,
@@ -6541,7 +7111,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 29882.0,
-    "total_tax": 29882.0
+    "total_tax": 29882.0,
+    "amti": 180800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6566,7 +7138,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 33632.0,
-    "total_tax": 33632.0
+    "total_tax": 33632.0,
+    "amti": 205800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 235000.0,
@@ -6576,7 +7150,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 33632.0,
-    "total_tax": 33632.0
+    "total_tax": 33632.0,
+    "amti": 205800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6601,7 +7177,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 38882.0,
-    "total_tax": 39642.0
+    "total_tax": 39642.0,
+    "amti": 240800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 270000.0,
@@ -6611,7 +7189,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 38882.0,
-    "total_tax": 39642.0
+    "total_tax": 39642.0,
+    "amti": 240800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6636,7 +7216,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 59882.0,
-    "total_tax": 65962.0
+    "total_tax": 65962.0,
+    "amti": 380800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 410000.0,
@@ -6646,7 +7228,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 59882.0,
-    "total_tax": 65962.0
+    "total_tax": 65962.0,
+    "amti": 380800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6671,7 +7255,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 42827.0,
-    "total_tax": 43777.0
+    "total_tax": 43777.0,
+    "amti": 245800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 275000.0,
@@ -6681,7 +7267,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 42827.0,
-    "total_tax": 43777.0
+    "total_tax": 43777.0,
+    "amti": 245800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6706,7 +7294,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 48077.0,
-    "total_tax": 50357.0
+    "total_tax": 50357.0,
+    "amti": 280800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 310000.0,
@@ -6716,7 +7306,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 48077.0,
-    "total_tax": 50357.0
+    "total_tax": 50357.0,
+    "amti": 280800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6741,7 +7333,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 69077.0,
-    "total_tax": 76677.0
+    "total_tax": 76677.0,
+    "amti": 420800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 450000.0,
@@ -6751,7 +7345,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 69077.0,
-    "total_tax": 76677.0
+    "total_tax": 76677.0,
+    "amti": 420800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6776,7 +7372,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 45077.0,
-    "total_tax": 46027.0
+    "total_tax": 46027.0,
+    "amti": 245800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 275000.0,
@@ -6786,7 +7384,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 45077.0,
-    "total_tax": 46027.0
+    "total_tax": 46027.0,
+    "amti": 245800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6811,7 +7411,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 48827.0,
-    "total_tax": 50727.0
+    "total_tax": 50727.0,
+    "amti": 270800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 300000.0,
@@ -6821,7 +7423,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 48827.0,
-    "total_tax": 50727.0
+    "total_tax": 50727.0,
+    "amti": 270800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6846,7 +7450,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 54077.0,
-    "total_tax": 57307.0
+    "total_tax": 57307.0,
+    "amti": 305800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 335000.0,
@@ -6856,7 +7462,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 54077.0,
-    "total_tax": 57307.0
+    "total_tax": 57307.0,
+    "amti": 305800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6881,7 +7489,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 75077.0,
-    "total_tax": 83627.0
+    "total_tax": 83627.0,
+    "amti": 445800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 475000.0,
@@ -6891,7 +7501,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 75077.0,
-    "total_tax": 83627.0
+    "total_tax": 83627.0,
+    "amti": 445800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6916,7 +7528,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 53477.0,
-    "total_tax": 55757.0
+    "total_tax": 55757.0,
+    "amti": 280800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 310000.0,
@@ -6926,7 +7540,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 53477.0,
-    "total_tax": 55757.0
+    "total_tax": 55757.0,
+    "amti": 280800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6951,7 +7567,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 57227.0,
-    "total_tax": 60457.0
+    "total_tax": 60457.0,
+    "amti": 305800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 335000.0,
@@ -6961,7 +7579,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 57227.0,
-    "total_tax": 60457.0
+    "total_tax": 60457.0,
+    "amti": 305800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -6986,7 +7606,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 62477.0,
-    "total_tax": 67037.0
+    "total_tax": 67037.0,
+    "amti": 340800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 370000.0,
@@ -6996,7 +7618,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 62477.0,
-    "total_tax": 67037.0
+    "total_tax": 67037.0,
+    "amti": 340800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -7021,7 +7645,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 83477.0,
-    "total_tax": 93357.0
+    "total_tax": 93357.0,
+    "amti": 480800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 510000.0,
@@ -7031,7 +7657,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 83477.0,
-    "total_tax": 93357.0
+    "total_tax": 93357.0,
+    "amti": 480800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -7056,7 +7684,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 78827.0,
-    "total_tax": 81127.0
+    "total_tax": 81127.0,
+    "amti": 395800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 425000.0,
@@ -7066,7 +7696,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 78827.0,
-    "total_tax": 81127.0
+    "total_tax": 81127.0,
+    "amti": 395800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -7091,7 +7723,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 84077.0,
-    "total_tax": 87707.0
+    "total_tax": 87707.0,
+    "amti": 430800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 460000.0,
@@ -7101,7 +7735,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 84077.0,
-    "total_tax": 87707.0
+    "total_tax": 87707.0,
+    "amti": 430800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -7126,7 +7762,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 105077.0,
-    "total_tax": 114027.0
+    "total_tax": 114027.0,
+    "amti": 570800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 600000.0,
@@ -7136,7 +7774,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 105077.0,
-    "total_tax": 114027.0
+    "total_tax": 114027.0,
+    "amti": 570800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -7161,7 +7801,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 82029.0,
-    "total_tax": 84329.0
+    "total_tax": 84329.0,
+    "amti": 395800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 425000.0,
@@ -7171,7 +7813,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 82029.0,
-    "total_tax": 84329.0
+    "total_tax": 84329.0,
+    "amti": 395800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -7196,7 +7840,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 85779.0,
-    "total_tax": 89029.0
+    "total_tax": 89029.0,
+    "amti": 420800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 450000.0,
@@ -7206,7 +7852,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 85779.0,
-    "total_tax": 89029.0
+    "total_tax": 89029.0,
+    "amti": 420800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -7231,7 +7879,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 91029.0,
-    "total_tax": 95609.0
+    "total_tax": 95609.0,
+    "amti": 455800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 485000.0,
@@ -7241,7 +7891,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 91029.0,
-    "total_tax": 95609.0
+    "total_tax": 95609.0,
+    "amti": 455800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -7266,7 +7918,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 112631.5,
-    "total_tax": 122531.5
+    "total_tax": 122531.5,
+    "amti": 595800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 625000.0,
@@ -7276,7 +7930,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 112631.5,
-    "total_tax": 122531.5
+    "total_tax": 122531.5,
+    "amti": 595800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -7301,7 +7957,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 93229.0,
-    "total_tax": 96859.0
+    "total_tax": 96859.0,
+    "amti": 430800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 460000.0,
@@ -7311,7 +7969,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 93229.0,
-    "total_tax": 96859.0
+    "total_tax": 96859.0,
+    "amti": 430800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -7336,7 +7996,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 96979.0,
-    "total_tax": 101559.0
+    "total_tax": 101559.0,
+    "amti": 455800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 485000.0,
@@ -7346,7 +8008,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 96979.0,
-    "total_tax": 101559.0
+    "total_tax": 101559.0,
+    "amti": 455800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -7371,7 +8035,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 102229.0,
-    "total_tax": 108139.0
+    "total_tax": 108139.0,
+    "amti": 490800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 520000.0,
@@ -7381,7 +8047,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 102229.0,
-    "total_tax": 108139.0
+    "total_tax": 108139.0,
+    "amti": 490800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -7406,7 +8074,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 125581.5,
-    "total_tax": 136811.5
+    "total_tax": 136811.5,
+    "amti": 630800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 660000.0,
@@ -7416,7 +8086,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 125581.5,
-    "total_tax": 136811.5
+    "total_tax": 136811.5,
+    "amti": 630800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -7441,7 +8113,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 6022.25,
-    "total_tax": 6022.25
+    "total_tax": 6022.25,
+    "amti": 60400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7467,7 +8141,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 11272.25,
-    "total_tax": 11272.25
+    "total_tax": 11272.25,
+    "amti": 95400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7493,7 +8169,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 32272.25,
-    "total_tax": 37022.25
+    "total_tax": 37022.25,
+    "amti": 235400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7519,7 +8197,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 8341.0,
-    "total_tax": 8341.0
+    "total_tax": 8341.0,
+    "amti": 60400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7545,7 +8225,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 12091.0,
-    "total_tax": 12091.0
+    "total_tax": 12091.0,
+    "amti": 85400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7571,7 +8253,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 17341.0,
-    "total_tax": 17721.0
+    "total_tax": 17721.0,
+    "amti": 120400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7597,7 +8281,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 38341.0,
-    "total_tax": 44041.0
+    "total_tax": 44041.0,
+    "amti": 260400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7623,7 +8309,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 16041.0,
-    "total_tax": 16041.0
+    "total_tax": 16041.0,
+    "amti": 95400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7649,7 +8337,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 19791.0,
-    "total_tax": 20171.0
+    "total_tax": 20171.0,
+    "amti": 120400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7675,7 +8365,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 25041.0,
-    "total_tax": 26751.0
+    "total_tax": 26751.0,
+    "amti": 155400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7701,7 +8393,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 46218.5,
-    "total_tax": 53248.5
+    "total_tax": 53248.5,
+    "amti": 295400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7727,7 +8421,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 29288.5,
-    "total_tax": 30463.5
+    "total_tax": 30463.5,
+    "amti": 160400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7753,7 +8449,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 34538.5,
-    "total_tax": 37043.5
+    "total_tax": 37043.5,
+    "amti": 195400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7779,7 +8477,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 57716.0,
-    "total_tax": 65541.0
+    "total_tax": 65541.0,
+    "amti": 335400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7805,7 +8505,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 31538.5,
-    "total_tax": 32713.5
+    "total_tax": 32713.5,
+    "amti": 160400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7831,7 +8533,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 35288.5,
-    "total_tax": 37413.5
+    "total_tax": 37413.5,
+    "amti": 185400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7857,7 +8561,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 40538.5,
-    "total_tax": 43993.5
+    "total_tax": 43993.5,
+    "amti": 220400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7883,7 +8589,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 64966.0,
-    "total_tax": 73741.0
+    "total_tax": 73741.0,
+    "amti": 360400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7909,7 +8617,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 40214.5,
-    "total_tax": 42719.5
+    "total_tax": 42719.5,
+    "amti": 195400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7935,7 +8645,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 43964.5,
-    "total_tax": 47419.5
+    "total_tax": 47419.5,
+    "amti": 220400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7961,7 +8673,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 49214.5,
-    "total_tax": 53999.5
+    "total_tax": 53999.5,
+    "amti": 255400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -7987,7 +8701,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 75392.0,
-    "total_tax": 85497.0
+    "total_tax": 85497.0,
+    "amti": 395400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8013,7 +8729,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 56764.5,
-    "total_tax": 58839.5
+    "total_tax": 58839.5,
+    "amti": 260400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8039,7 +8757,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 62192.0,
-    "total_tax": 65597.0
+    "total_tax": 65597.0,
+    "amti": 295400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8065,7 +8785,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 90192.0,
-    "total_tax": 98917.0
+    "total_tax": 98917.0,
+    "amti": 435400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8091,7 +8813,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 61514.75,
-    "total_tax": 63589.75
+    "total_tax": 63589.75,
+    "amti": 260400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8117,7 +8841,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 65264.75,
-    "total_tax": 68289.75
+    "total_tax": 68289.75,
+    "amti": 285400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8143,7 +8869,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 71942.25,
-    "total_tax": 76297.25
+    "total_tax": 76297.25,
+    "amti": 320400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8169,7 +8897,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 99942.25,
-    "total_tax": 109617.25
+    "total_tax": 109617.25,
+    "amti": 460400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8195,7 +8925,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 73764.75,
-    "total_tax": 77169.75
+    "total_tax": 77169.75,
+    "amti": 295400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8221,7 +8953,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 78764.75,
-    "total_tax": 83119.75
+    "total_tax": 83119.75,
+    "amti": 320400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8247,7 +8981,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 85764.75,
-    "total_tax": 91449.75
+    "total_tax": 91449.75,
+    "amti": 355400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8273,7 +9009,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 113764.75,
-    "total_tax": 124769.75
+    "total_tax": 124769.75,
+    "amti": 495400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8299,7 +9037,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 110660.75,
-    "total_tax": 114085.75
+    "total_tax": 114085.75,
+    "amti": 410400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8325,7 +9065,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 117660.75,
-    "total_tax": 122415.75
+    "total_tax": 122415.75,
+    "amti": 445400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8351,7 +9093,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 145660.75,
-    "total_tax": 155735.75
+    "total_tax": 155735.75,
+    "amti": 585400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8377,7 +9121,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 114910.75,
-    "total_tax": 118335.75
+    "total_tax": 118335.75,
+    "amti": 410400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8403,7 +9149,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 119910.75,
-    "total_tax": 124285.75
+    "total_tax": 124285.75,
+    "amti": 435400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8429,7 +9177,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 126910.75,
-    "total_tax": 132615.75
+    "total_tax": 132615.75,
+    "amti": 470400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8455,7 +9205,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 154910.75,
-    "total_tax": 165935.75
+    "total_tax": 165935.75,
+    "amti": 610400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8481,7 +9233,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 127860.75,
-    "total_tax": 132615.75
+    "total_tax": 132615.75,
+    "amti": 445400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8507,7 +9261,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 132860.75,
-    "total_tax": 138565.75
+    "total_tax": 138565.75,
+    "amti": 470400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8533,7 +9289,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 139860.75,
-    "total_tax": 146895.75
+    "total_tax": 146895.75,
+    "amti": 505400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8559,7 +9317,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 167860.75,
-    "total_tax": 180215.75
+    "total_tax": 180215.75,
+    "amti": 645400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8585,7 +9345,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 3041.0,
-    "total_tax": 3041.0
+    "total_tax": 3041.0,
+    "amti": 53100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8611,7 +9373,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 6806.0,
-    "total_tax": 6806.0
+    "total_tax": 6806.0,
+    "amti": 88100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8637,7 +9401,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 27806.0,
-    "total_tax": 29706.0
+    "total_tax": 29706.0,
+    "amti": 228100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8663,7 +9429,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 6041.0,
-    "total_tax": 6041.0
+    "total_tax": 6041.0,
+    "amti": 53100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8689,7 +9457,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 8306.0,
-    "total_tax": 8306.0
+    "total_tax": 8306.0,
+    "amti": 78100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8715,7 +9485,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 13556.0,
-    "total_tax": 13556.0
+    "total_tax": 13556.0,
+    "amti": 113100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8741,7 +9513,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 34556.0,
-    "total_tax": 37406.0
+    "total_tax": 37406.0,
+    "amti": 253100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8767,7 +9541,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 12741.0,
-    "total_tax": 12741.0
+    "total_tax": 12741.0,
+    "amti": 88100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8793,7 +9569,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 16491.0,
-    "total_tax": 16491.0
+    "total_tax": 16491.0,
+    "amti": 113100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8819,7 +9597,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 21741.0,
-    "total_tax": 21741.0
+    "total_tax": 21741.0,
+    "amti": 148100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8845,7 +9625,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 42741.0,
-    "total_tax": 46921.0
+    "total_tax": 46921.0,
+    "amti": 288100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8871,7 +9653,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 25843.0,
-    "total_tax": 25843.0
+    "total_tax": 25843.0,
+    "amti": 153100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8897,7 +9681,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 31093.0,
-    "total_tax": 31473.0
+    "total_tax": 31473.0,
+    "amti": 188100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8923,7 +9709,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 52093.0,
-    "total_tax": 57793.0
+    "total_tax": 57793.0,
+    "amti": 328100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8949,7 +9737,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 28093.0,
-    "total_tax": 28093.0
+    "total_tax": 28093.0,
+    "amti": 153100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -8975,7 +9765,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 31843.0,
-    "total_tax": 31843.0
+    "total_tax": 31843.0,
+    "amti": 178100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9001,7 +9793,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 37093.0,
-    "total_tax": 38423.0
+    "total_tax": 38423.0,
+    "amti": 213100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9027,7 +9821,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 58093.0,
-    "total_tax": 64743.0
+    "total_tax": 64743.0,
+    "amti": 353100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9053,7 +9849,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 36493.0,
-    "total_tax": 36873.0
+    "total_tax": 36873.0,
+    "amti": 188100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9079,7 +9877,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 40243.0,
-    "total_tax": 41573.0
+    "total_tax": 41573.0,
+    "amti": 213100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9105,7 +9905,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 45493.0,
-    "total_tax": 48153.0
+    "total_tax": 48153.0,
+    "amti": 248100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9131,7 +9933,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 66493.0,
-    "total_tax": 74473.0
+    "total_tax": 74473.0,
+    "amti": 388100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9157,7 +9961,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 52735.0,
-    "total_tax": 54135.0
+    "total_tax": 54135.0,
+    "amti": 253100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9183,7 +9989,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 57985.0,
-    "total_tax": 60715.0
+    "total_tax": 60715.0,
+    "amti": 288100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9209,7 +10017,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 78985.0,
-    "total_tax": 87035.0
+    "total_tax": 87035.0,
+    "amti": 428100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9235,7 +10045,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 57267.0,
-    "total_tax": 58667.0
+    "total_tax": 58667.0,
+    "amti": 253100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9261,7 +10073,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 61017.0,
-    "total_tax": 63367.0
+    "total_tax": 63367.0,
+    "amti": 278100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9287,7 +10101,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 66267.0,
-    "total_tax": 69947.0
+    "total_tax": 69947.0,
+    "amti": 313100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9313,7 +10129,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 87267.0,
-    "total_tax": 96267.0
+    "total_tax": 96267.0,
+    "amti": 453100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9339,7 +10157,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 69517.0,
-    "total_tax": 72247.0
+    "total_tax": 72247.0,
+    "amti": 288100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9365,7 +10185,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 73267.0,
-    "total_tax": 76947.0
+    "total_tax": 76947.0,
+    "amti": 313100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9391,7 +10213,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 78517.0,
-    "total_tax": 83527.0
+    "total_tax": 83527.0,
+    "amti": 348100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9417,7 +10241,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 99517.0,
-    "total_tax": 109847.0
+    "total_tax": 109847.0,
+    "amti": 488100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9443,7 +10269,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 104767.0,
-    "total_tax": 107517.0
+    "total_tax": 107517.0,
+    "amti": 403100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9469,7 +10297,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 110017.0,
-    "total_tax": 114097.0
+    "total_tax": 114097.0,
+    "amti": 438100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9495,7 +10325,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 132354.5,
-    "total_tax": 141754.5
+    "total_tax": 141754.5,
+    "amti": 578100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9521,7 +10353,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 109767.0,
-    "total_tax": 112517.0
+    "total_tax": 112517.0,
+    "amti": 403100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9547,7 +10381,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 113517.0,
-    "total_tax": 117217.0
+    "total_tax": 117217.0,
+    "amti": 428100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9573,7 +10409,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 118767.0,
-    "total_tax": 123797.0
+    "total_tax": 123797.0,
+    "amti": 463100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9599,7 +10437,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 142354.5,
-    "total_tax": 152704.5
+    "total_tax": 152704.5,
+    "amti": 603100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9625,7 +10465,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 122017.0,
-    "total_tax": 126097.0
+    "total_tax": 126097.0,
+    "amti": 438100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9651,7 +10493,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 125767.0,
-    "total_tax": 130797.0
+    "total_tax": 130797.0,
+    "amti": 463100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9677,7 +10521,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 131017.0,
-    "total_tax": 137377.0
+    "total_tax": 137377.0,
+    "amti": 498100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9703,7 +10549,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 156354.5,
-    "total_tax": 168034.5
+    "total_tax": 168034.5,
+    "amti": 638100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9729,7 +10577,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2080.0,
-    "total_tax": 2080.0
+    "total_tax": 2080.0,
+    "amti": 45800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9755,7 +10605,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2080.0,
-    "total_tax": 2080.0
+    "total_tax": 2080.0,
+    "amti": 80800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9781,7 +10633,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 21092.5,
-    "total_tax": 21092.5
+    "total_tax": 21092.5,
+    "amti": 220800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9807,7 +10661,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5032.0,
-    "total_tax": 5032.0
+    "total_tax": 5032.0,
+    "amti": 45800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9833,7 +10689,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5032.0,
-    "total_tax": 5032.0
+    "total_tax": 5032.0,
+    "amti": 70800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9859,7 +10717,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 6794.5,
-    "total_tax": 6794.5
+    "total_tax": 6794.5,
+    "amti": 105800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9885,7 +10745,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 27794.5,
-    "total_tax": 28744.5
+    "total_tax": 28744.5,
+    "amti": 245800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9911,7 +10773,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 9232.0,
-    "total_tax": 9232.0
+    "total_tax": 9232.0,
+    "amti": 80800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9937,7 +10801,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10994.5,
-    "total_tax": 10994.5
+    "total_tax": 10994.5,
+    "amti": 105800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9963,7 +10829,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 16244.5,
-    "total_tax": 16244.5
+    "total_tax": 16244.5,
+    "amti": 140800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -9989,7 +10857,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 37244.5,
-    "total_tax": 39524.5
+    "total_tax": 39524.5,
+    "amti": 280800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10015,7 +10885,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 20432.0,
-    "total_tax": 20432.0
+    "total_tax": 20432.0,
+    "amti": 145800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10041,7 +10913,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 25682.0,
-    "total_tax": 25682.0
+    "total_tax": 25682.0,
+    "amti": 180800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10067,7 +10941,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 46682.0,
-    "total_tax": 50482.0
+    "total_tax": 50482.0,
+    "amti": 320800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10093,7 +10969,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 22182.0,
-    "total_tax": 22182.0
+    "total_tax": 22182.0,
+    "amti": 145800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10119,7 +10997,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 25932.0,
-    "total_tax": 25932.0
+    "total_tax": 25932.0,
+    "amti": 170800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10145,7 +11025,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 31182.0,
-    "total_tax": 31182.0
+    "total_tax": 31182.0,
+    "amti": 205800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10171,7 +11053,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 52182.0,
-    "total_tax": 56932.0
+    "total_tax": 56932.0,
+    "amti": 345800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10197,7 +11081,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 29882.0,
-    "total_tax": 29882.0
+    "total_tax": 29882.0,
+    "amti": 180800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10223,7 +11109,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 33632.0,
-    "total_tax": 33632.0
+    "total_tax": 33632.0,
+    "amti": 205800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10249,7 +11137,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 38882.0,
-    "total_tax": 39642.0
+    "total_tax": 39642.0,
+    "amti": 240800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10275,7 +11165,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 59882.0,
-    "total_tax": 65962.0
+    "total_tax": 65962.0,
+    "amti": 380800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10301,7 +11193,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 42827.0,
-    "total_tax": 44227.0
+    "total_tax": 44227.0,
+    "amti": 245800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10327,7 +11221,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 48077.0,
-    "total_tax": 50807.0
+    "total_tax": 50807.0,
+    "amti": 280800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10353,7 +11249,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 69077.0,
-    "total_tax": 77127.0
+    "total_tax": 77127.0,
+    "amti": 420800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10379,7 +11277,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 45077.0,
-    "total_tax": 46477.0
+    "total_tax": 46477.0,
+    "amti": 245800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10405,7 +11305,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 48827.0,
-    "total_tax": 51177.0
+    "total_tax": 51177.0,
+    "amti": 270800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10431,7 +11333,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 54077.0,
-    "total_tax": 57757.0
+    "total_tax": 57757.0,
+    "amti": 305800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10457,7 +11361,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 75077.0,
-    "total_tax": 84077.0
+    "total_tax": 84077.0,
+    "amti": 445800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10483,7 +11389,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 53477.0,
-    "total_tax": 56207.0
+    "total_tax": 56207.0,
+    "amti": 280800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10509,7 +11417,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 57227.0,
-    "total_tax": 60907.0
+    "total_tax": 60907.0,
+    "amti": 305800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10535,7 +11445,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 62477.0,
-    "total_tax": 67487.0
+    "total_tax": 67487.0,
+    "amti": 340800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10561,7 +11473,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 83477.0,
-    "total_tax": 93807.0
+    "total_tax": 93807.0,
+    "amti": 480800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10587,7 +11501,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 78827.0,
-    "total_tax": 81577.0
+    "total_tax": 81577.0,
+    "amti": 395800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10613,7 +11529,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 84077.0,
-    "total_tax": 88157.0
+    "total_tax": 88157.0,
+    "amti": 430800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10639,7 +11557,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 105077.0,
-    "total_tax": 114477.0
+    "total_tax": 114477.0,
+    "amti": 570800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10665,7 +11585,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 82029.0,
-    "total_tax": 84779.0
+    "total_tax": 84779.0,
+    "amti": 395800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10691,7 +11613,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 85779.0,
-    "total_tax": 89479.0
+    "total_tax": 89479.0,
+    "amti": 420800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10717,7 +11641,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 91029.0,
-    "total_tax": 96059.0
+    "total_tax": 96059.0,
+    "amti": 455800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10743,7 +11669,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 112631.5,
-    "total_tax": 122981.5
+    "total_tax": 122981.5,
+    "amti": 595800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10769,7 +11697,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 93229.0,
-    "total_tax": 97309.0
+    "total_tax": 97309.0,
+    "amti": 430800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10795,7 +11725,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 96979.0,
-    "total_tax": 102009.0
+    "total_tax": 102009.0,
+    "amti": 455800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10821,7 +11753,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 102229.0,
-    "total_tax": 108589.0
+    "total_tax": 108589.0,
+    "amti": 490800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10847,7 +11781,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 125581.5,
-    "total_tax": 137261.5
+    "total_tax": 137261.5,
+    "amti": 630800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10873,7 +11809,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 9441.0,
-    "total_tax": 9441.0
+    "total_tax": 9441.0,
+    "amti": 65400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10899,7 +11837,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 8601.0,
-    "total_tax": 8601.0
+    "total_tax": 8601.0,
+    "amti": 65400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10925,7 +11865,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7972.25,
-    "total_tax": 7972.25
+    "total_tax": 7972.25,
+    "amti": 65400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10951,7 +11893,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 6772.25,
-    "total_tax": 6772.25
+    "total_tax": 6772.25,
+    "amti": 57400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -10977,7 +11921,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 12741.0,
-    "total_tax": 12741.0
+    "total_tax": 12741.0,
+    "amti": 80400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -11003,7 +11949,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 11901.0,
-    "total_tax": 11901.0
+    "total_tax": 11901.0,
+    "amti": 80400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -11029,7 +11977,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 11341.0,
-    "total_tax": 11341.0
+    "total_tax": 11341.0,
+    "amti": 80400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -11055,7 +12005,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10141.0,
-    "total_tax": 10141.0
+    "total_tax": 10141.0,
+    "amti": 72400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -11081,7 +12033,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 43414.5,
-    "total_tax": 44174.5
+    "total_tax": 44174.5,
+    "amti": 205400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -11107,7 +12061,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 41374.5,
-    "total_tax": 42134.5
+    "total_tax": 42134.5,
+    "amti": 205400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -11133,7 +12089,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 40538.5,
-    "total_tax": 41298.5
+    "total_tax": 41298.5,
+    "amti": 205400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -11159,7 +12117,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 39338.5,
-    "total_tax": 39794.5
+    "total_tax": 39794.5,
+    "amti": 197400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -11185,7 +12145,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 48214.5,
-    "total_tax": 49544.5
+    "total_tax": 49544.5,
+    "amti": 220400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -11211,7 +12173,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 46174.5,
-    "total_tax": 47504.5
+    "total_tax": 47504.5,
+    "amti": 220400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -11237,7 +12201,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 44814.5,
-    "total_tax": 46144.5
+    "total_tax": 46144.5,
+    "amti": 220400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -11263,7 +12229,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 43614.5,
-    "total_tax": 44640.5
+    "total_tax": 44640.5,
+    "amti": 212400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -11289,7 +12257,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 77264.75,
-    "total_tax": 78924.75
+    "total_tax": 78924.75,
+    "amti": 305400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -11315,7 +12285,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 74864.75,
-    "total_tax": 76524.75
+    "total_tax": 76524.75,
+    "amti": 305400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -11341,7 +12313,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 73264.75,
-    "total_tax": 74924.75
+    "total_tax": 74924.75,
+    "amti": 305400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -11367,7 +12341,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 72064.75,
-    "total_tax": 73420.75
+    "total_tax": 73420.75,
+    "amti": 297400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -11393,7 +12369,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 82514.75,
-    "total_tax": 84744.75
+    "total_tax": 84744.75,
+    "amti": 320400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -11419,7 +12397,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 80114.75,
-    "total_tax": 82344.75
+    "total_tax": 82344.75,
+    "amti": 320400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -11445,7 +12425,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 78514.75,
-    "total_tax": 80744.75
+    "total_tax": 80744.75,
+    "amti": 320400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -11471,7 +12453,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 77314.75,
-    "total_tax": 79240.75
+    "total_tax": 79240.75,
+    "amti": 312400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -11497,7 +12481,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5632.0,
-    "total_tax": 5632.0
+    "total_tax": 5632.0,
+    "amti": 50800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 80000.0,
@@ -11507,7 +12493,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5632.0,
-    "total_tax": 5632.0
+    "total_tax": 5632.0,
+    "amti": 50800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -11532,7 +12520,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 4192.0,
-    "total_tax": 4192.0
+    "total_tax": 4192.0,
+    "amti": 50800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 80000.0,
@@ -11542,7 +12532,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 4192.0,
-    "total_tax": 4192.0
+    "total_tax": 4192.0,
+    "amti": 50800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -11567,7 +12559,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 3232.0,
-    "total_tax": 3232.0
+    "total_tax": 3232.0,
+    "amti": 50800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 80000.0,
@@ -11577,7 +12571,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 3232.0,
-    "total_tax": 3232.0
+    "total_tax": 3232.0,
+    "amti": 50800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -11602,7 +12598,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 3232.0,
-    "total_tax": 3232.0
+    "total_tax": 3232.0,
+    "amti": 42800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 72000.0,
@@ -11612,7 +12610,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 3232.0,
-    "total_tax": 3232.0
+    "total_tax": 3232.0,
+    "amti": 42800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -11637,7 +12637,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7432.0,
-    "total_tax": 7432.0
+    "total_tax": 7432.0,
+    "amti": 65800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 95000.0,
@@ -11647,7 +12649,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7432.0,
-    "total_tax": 7432.0
+    "total_tax": 7432.0,
+    "amti": 65800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -11672,7 +12676,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5992.0,
-    "total_tax": 5992.0
+    "total_tax": 5992.0,
+    "amti": 65800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 95000.0,
@@ -11682,7 +12688,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5992.0,
-    "total_tax": 5992.0
+    "total_tax": 5992.0,
+    "amti": 65800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -11707,7 +12715,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5032.0,
-    "total_tax": 5032.0
+    "total_tax": 5032.0,
+    "amti": 65800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 95000.0,
@@ -11717,7 +12727,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5032.0,
-    "total_tax": 5032.0
+    "total_tax": 5032.0,
+    "amti": 65800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -11742,7 +12754,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5032.0,
-    "total_tax": 5032.0
+    "total_tax": 5032.0,
+    "amti": 57800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 87000.0,
@@ -11752,7 +12766,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5032.0,
-    "total_tax": 5032.0
+    "total_tax": 5032.0,
+    "amti": 57800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -11777,7 +12793,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 32082.0,
-    "total_tax": 32082.0
+    "total_tax": 32082.0,
+    "amti": 190800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 220000.0,
@@ -11787,7 +12805,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 32082.0,
-    "total_tax": 32082.0
+    "total_tax": 32082.0,
+    "amti": 190800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -11812,7 +12832,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 31242.0,
-    "total_tax": 31242.0
+    "total_tax": 31242.0,
+    "amti": 190800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 220000.0,
@@ -11822,7 +12844,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 31242.0,
-    "total_tax": 31242.0
+    "total_tax": 31242.0,
+    "amti": 190800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -11847,7 +12871,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 30682.0,
-    "total_tax": 30682.0
+    "total_tax": 30682.0,
+    "amti": 190800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 220000.0,
@@ -11857,7 +12883,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 30682.0,
-    "total_tax": 30682.0
+    "total_tax": 30682.0,
+    "amti": 190800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -11882,7 +12910,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 29482.0,
-    "total_tax": 29482.0
+    "total_tax": 29482.0,
+    "amti": 182800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 212000.0,
@@ -11892,7 +12922,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 29482.0,
-    "total_tax": 29482.0
+    "total_tax": 29482.0,
+    "amti": 182800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -11917,7 +12949,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 35477.0,
-    "total_tax": 35477.0
+    "total_tax": 35477.0,
+    "amti": 205800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 235000.0,
@@ -11927,7 +12961,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 35477.0,
-    "total_tax": 35477.0
+    "total_tax": 35477.0,
+    "amti": 205800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -11952,7 +12988,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 34542.0,
-    "total_tax": 34542.0
+    "total_tax": 34542.0,
+    "amti": 205800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 235000.0,
@@ -11962,7 +13000,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 34542.0,
-    "total_tax": 34542.0
+    "total_tax": 34542.0,
+    "amti": 205800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -11987,7 +13027,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 33982.0,
-    "total_tax": 33982.0
+    "total_tax": 33982.0,
+    "amti": 205800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 235000.0,
@@ -11997,7 +13039,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 33982.0,
-    "total_tax": 33982.0
+    "total_tax": 33982.0,
+    "amti": 205800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -12022,7 +13066,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 32782.0,
-    "total_tax": 32782.0
+    "total_tax": 32782.0,
+    "amti": 197800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 227000.0,
@@ -12032,7 +13078,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 32782.0,
-    "total_tax": 32782.0
+    "total_tax": 32782.0,
+    "amti": 197800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -12057,7 +13105,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 55877.0,
-    "total_tax": 57087.0
+    "total_tax": 57087.0,
+    "amti": 290800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 320000.0,
@@ -12067,7 +13117,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 55877.0,
-    "total_tax": 57087.0
+    "total_tax": 57087.0,
+    "amti": 290800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -12092,7 +13144,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 54797.0,
-    "total_tax": 56007.0
+    "total_tax": 56007.0,
+    "amti": 290800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 320000.0,
@@ -12102,7 +13156,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 54797.0,
-    "total_tax": 56007.0
+    "total_tax": 56007.0,
+    "amti": 290800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -12127,7 +13183,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 54077.0,
-    "total_tax": 55287.0
+    "total_tax": 55287.0,
+    "amti": 290800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 320000.0,
@@ -12137,7 +13195,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 54077.0,
-    "total_tax": 55287.0
+    "total_tax": 55287.0,
+    "amti": 290800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -12162,7 +13222,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 52877.0,
-    "total_tax": 53783.0
+    "total_tax": 53783.0,
+    "amti": 282800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 312000.0,
@@ -12172,7 +13234,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 52877.0,
-    "total_tax": 53783.0
+    "total_tax": 53783.0,
+    "amti": 282800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -12197,7 +13261,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 59477.0,
-    "total_tax": 61257.0
+    "total_tax": 61257.0,
+    "amti": 305800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 335000.0,
@@ -12207,7 +13273,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 59477.0,
-    "total_tax": 61257.0
+    "total_tax": 61257.0,
+    "amti": 305800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -12232,7 +13300,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 58397.0,
-    "total_tax": 60177.0
+    "total_tax": 60177.0,
+    "amti": 305800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 335000.0,
@@ -12242,7 +13312,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 58397.0,
-    "total_tax": 60177.0
+    "total_tax": 60177.0,
+    "amti": 305800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -12267,7 +13339,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 57677.0,
-    "total_tax": 59457.0
+    "total_tax": 59457.0,
+    "amti": 305800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 335000.0,
@@ -12277,7 +13351,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 57677.0,
-    "total_tax": 59457.0
+    "total_tax": 59457.0,
+    "amti": 305800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -12302,7 +13378,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 56477.0,
-    "total_tax": 57953.0
+    "total_tax": 57953.0,
+    "amti": 297800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 327000.0,
@@ -12312,7 +13390,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 56477.0,
-    "total_tax": 57953.0
+    "total_tax": 57953.0,
+    "amti": 297800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -12337,7 +13417,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 13841.0,
-    "total_tax": 13841.0
+    "total_tax": 13841.0,
+    "amti": 85400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -12363,7 +13445,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 8253.0,
-    "total_tax": 8253.0
+    "total_tax": 8253.0,
+    "amti": 60000.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -12389,7 +13473,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 70264.75,
-    "total_tax": 71164.75
+    "total_tax": 71164.75,
+    "amti": 285400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -12415,7 +13501,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 61374.75,
-    "total_tax": 62274.75
+    "total_tax": 62274.75,
+    "amti": 260000.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -12441,7 +13529,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 8032.0,
-    "total_tax": 8032.0
+    "total_tax": 8032.0,
+    "amti": 70800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 100000.0,
@@ -12451,7 +13541,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 8032.0,
-    "total_tax": 8032.0
+    "total_tax": 8032.0,
+    "amti": 70800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -12476,7 +13568,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 6736.0,
-    "total_tax": 6736.0
+    "total_tax": 6736.0,
+    "amti": 60000.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 100000.0,
@@ -12486,7 +13580,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 6736.0,
-    "total_tax": 6736.0
+    "total_tax": 6736.0,
+    "amti": 60000.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -12511,7 +13607,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 51077.0,
-    "total_tax": 51527.0
+    "total_tax": 51527.0,
+    "amti": 270800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 300000.0,
@@ -12521,7 +13619,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 51077.0,
-    "total_tax": 51527.0
+    "total_tax": 51527.0,
+    "amti": 270800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -12546,7 +13646,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 48485.0,
-    "total_tax": 48935.0
+    "total_tax": 48935.0,
+    "amti": 260000.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 300000.0,
@@ -12556,7 +13658,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 48485.0,
-    "total_tax": 48935.0
+    "total_tax": 48935.0,
+    "amti": 260000.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -12581,7 +13685,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1159.9,
-    "total_tax": 1159.9
+    "total_tax": 1159.9,
+    "amti": 11599.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -12607,7 +13713,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1160.12,
-    "total_tax": 1160.12
+    "total_tax": 1160.12,
+    "amti": 11601.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -12633,7 +13741,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5425.88,
-    "total_tax": 5425.88
+    "total_tax": 5425.88,
+    "amti": 47149.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -12659,7 +13769,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5426.22,
-    "total_tax": 5426.22
+    "total_tax": 5426.22,
+    "amti": 47151.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -12685,7 +13797,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 17168.28,
-    "total_tax": 17168.28
+    "total_tax": 17168.28,
+    "amti": 100524.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -12711,7 +13825,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 17168.74,
-    "total_tax": 17168.74
+    "total_tax": 17168.74,
+    "amti": 100526.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -12737,7 +13853,9 @@
     "addl_medicare": 58.940999999999995,
     "amt": 0.0,
     "income_tax": 39110.259999999995,
-    "total_tax": 39169.200999999994
+    "total_tax": 39169.200999999994,
+    "amti": 191949.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -12763,7 +13881,9 @@
     "addl_medicare": 58.958999999999996,
     "amt": 0.0,
     "income_tax": 39110.82,
-    "total_tax": 39169.779
+    "total_tax": 39169.779,
+    "amti": 191951.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -12789,7 +13909,9 @@
     "addl_medicare": 524.9159999999999,
     "amt": 0.0,
     "income_tax": 55678.18,
-    "total_tax": 56203.096
+    "total_tax": 56203.096,
+    "amti": 243724.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -12815,7 +13937,9 @@
     "addl_medicare": 524.934,
     "amt": 0.0,
     "income_tax": 55678.85,
-    "total_tax": 56203.784
+    "total_tax": 56203.784,
+    "amti": 243726.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -12841,7 +13965,9 @@
     "addl_medicare": 3815.5409999999997,
     "amt": 0.0,
     "income_tax": 183646.9,
-    "total_tax": 187462.441
+    "total_tax": 187462.441,
+    "amti": 609349.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -12867,7 +13993,9 @@
     "addl_medicare": 3815.5589999999997,
     "amt": 0.0,
     "income_tax": 183647.62,
-    "total_tax": 187463.179
+    "total_tax": 187463.179,
+    "amti": 609351.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -12893,7 +14021,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 17052.78,
-    "total_tax": 17052.78
+    "total_tax": 17052.78,
+    "amti": 99999.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -12919,7 +14049,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 17053.22,
-    "total_tax": 17053.22
+    "total_tax": 17053.22,
+    "amti": 100001.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -12945,7 +14077,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2319.9,
-    "total_tax": 2319.9
+    "total_tax": 2319.9,
+    "amti": 23199.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 52399.0,
@@ -12955,7 +14089,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2319.9,
-    "total_tax": 2319.9
+    "total_tax": 2319.9,
+    "amti": 23199.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -12980,7 +14116,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2320.12,
-    "total_tax": 2320.12
+    "total_tax": 2320.12,
+    "amti": 23201.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 52401.0,
@@ -12990,7 +14128,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2320.12,
-    "total_tax": 2320.12
+    "total_tax": 2320.12,
+    "amti": 23201.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -13015,7 +14155,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10851.88,
-    "total_tax": 10851.88
+    "total_tax": 10851.88,
+    "amti": 94299.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 123499.0,
@@ -13025,7 +14167,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10851.88,
-    "total_tax": 10851.88
+    "total_tax": 10851.88,
+    "amti": 94299.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -13050,7 +14194,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10852.22,
-    "total_tax": 10852.22
+    "total_tax": 10852.22,
+    "amti": 94301.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 123501.0,
@@ -13060,7 +14206,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10852.22,
-    "total_tax": 10852.22
+    "total_tax": 10852.22,
+    "amti": 94301.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -13085,7 +14233,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 34336.78,
-    "total_tax": 34336.78
+    "total_tax": 34336.78,
+    "amti": 201049.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 230249.0,
@@ -13095,7 +14245,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 34336.78,
-    "total_tax": 34336.78
+    "total_tax": 34336.78,
+    "amti": 201049.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -13120,7 +14272,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 34337.24,
-    "total_tax": 34337.24
+    "total_tax": 34337.24,
+    "amti": 201051.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 230251.0,
@@ -13130,7 +14284,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 34337.24,
-    "total_tax": 34337.24
+    "total_tax": 34337.24,
+    "amti": 201051.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -13155,7 +14311,9 @@
     "addl_medicare": 1467.8909999999998,
     "amt": 0.0,
     "income_tax": 78220.76,
-    "total_tax": 79688.651
+    "total_tax": 79688.651,
+    "amti": 383899.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 413099.0,
@@ -13165,7 +14323,9 @@
     "addl_medicare": 1467.8909999999998,
     "amt": 0.0,
     "income_tax": 78220.76,
-    "total_tax": 79688.651
+    "total_tax": 79688.651,
+    "amti": 383899.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -13190,7 +14350,9 @@
     "addl_medicare": 1467.9089999999999,
     "amt": 0.0,
     "income_tax": 78221.32,
-    "total_tax": 79689.229
+    "total_tax": 79689.229,
+    "amti": 383901.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 413101.0,
@@ -13200,7 +14362,9 @@
     "addl_medicare": 1467.9089999999999,
     "amt": 0.0,
     "income_tax": 78221.32,
-    "total_tax": 79689.229
+    "total_tax": 79689.229,
+    "amti": 383901.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -13225,7 +14389,9 @@
     "addl_medicare": 2399.841,
     "amt": 0.0,
     "income_tax": 111356.68,
-    "total_tax": 113756.521
+    "total_tax": 113756.521,
+    "amti": 487449.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 516649.0,
@@ -13235,7 +14401,9 @@
     "addl_medicare": 2399.841,
     "amt": 0.0,
     "income_tax": 111356.68,
-    "total_tax": 113756.521
+    "total_tax": 113756.521,
+    "amti": 487449.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -13260,7 +14428,9 @@
     "addl_medicare": 2399.859,
     "amt": 0.0,
     "income_tax": 111357.35,
-    "total_tax": 113757.209
+    "total_tax": 113757.209,
+    "amti": 487451.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 516651.0,
@@ -13270,7 +14440,9 @@
     "addl_medicare": 2399.859,
     "amt": 0.0,
     "income_tax": 111357.35,
-    "total_tax": 113757.209
+    "total_tax": 113757.209,
+    "amti": 487451.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -13295,7 +14467,9 @@
     "addl_medicare": 4593.590999999999,
     "amt": 0.0,
     "income_tax": 196669.15,
-    "total_tax": 201262.74099999998
+    "total_tax": 201262.74099999998,
+    "amti": 731199.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 760399.0,
@@ -13305,7 +14479,9 @@
     "addl_medicare": 4593.590999999999,
     "amt": 0.0,
     "income_tax": 196669.15,
-    "total_tax": 201262.74099999998
+    "total_tax": 201262.74099999998,
+    "amti": 731199.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -13330,7 +14506,9 @@
     "addl_medicare": 4593.6089999999995,
     "amt": 0.0,
     "income_tax": 196669.87,
-    "total_tax": 201263.479
+    "total_tax": 201263.479,
+    "amti": 731201.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 760401.0,
@@ -13340,7 +14518,9 @@
     "addl_medicare": 4593.6089999999995,
     "amt": 0.0,
     "income_tax": 196669.87,
-    "total_tax": 201263.479
+    "total_tax": 201263.479,
+    "amti": 731201.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -13365,7 +14545,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 12105.78,
-    "total_tax": 12105.78
+    "total_tax": 12105.78,
+    "amti": 99999.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 129199.0,
@@ -13375,7 +14557,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 12105.78,
-    "total_tax": 12105.78
+    "total_tax": 12105.78,
+    "amti": 99999.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -13400,7 +14584,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 12106.22,
-    "total_tax": 12106.22
+    "total_tax": 12106.22,
+    "amti": 100001.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 129201.0,
@@ -13410,7 +14596,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 12106.22,
-    "total_tax": 12106.22
+    "total_tax": 12106.22,
+    "amti": 100001.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -13435,7 +14623,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1159.9,
-    "total_tax": 1159.9
+    "total_tax": 1159.9,
+    "amti": 11599.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13461,7 +14651,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1160.12,
-    "total_tax": 1160.12
+    "total_tax": 1160.12,
+    "amti": 11601.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13487,7 +14679,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5425.88,
-    "total_tax": 5425.88
+    "total_tax": 5425.88,
+    "amti": 47149.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13513,7 +14707,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5426.22,
-    "total_tax": 5426.22
+    "total_tax": 5426.22,
+    "amti": 47151.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13539,7 +14735,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 17168.28,
-    "total_tax": 17168.28
+    "total_tax": 17168.28,
+    "amti": 100524.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13565,7 +14763,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 17168.74,
-    "total_tax": 17168.74
+    "total_tax": 17168.74,
+    "amti": 100526.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13591,7 +14791,9 @@
     "addl_medicare": 733.9409999999999,
     "amt": 0.0,
     "income_tax": 39110.259999999995,
-    "total_tax": 39844.200999999994
+    "total_tax": 39844.200999999994,
+    "amti": 191949.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13617,7 +14819,9 @@
     "addl_medicare": 733.959,
     "amt": 0.0,
     "income_tax": 39110.82,
-    "total_tax": 39844.779
+    "total_tax": 39844.779,
+    "amti": 191951.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13643,7 +14847,9 @@
     "addl_medicare": 1199.916,
     "amt": 0.0,
     "income_tax": 55678.18,
-    "total_tax": 56878.096
+    "total_tax": 56878.096,
+    "amti": 243724.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13669,7 +14875,9 @@
     "addl_medicare": 1199.934,
     "amt": 0.0,
     "income_tax": 55678.85,
-    "total_tax": 56878.784
+    "total_tax": 56878.784,
+    "amti": 243726.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13695,7 +14903,9 @@
     "addl_medicare": 2296.7909999999997,
     "amt": 0.0,
     "income_tax": 98334.4,
-    "total_tax": 100631.19099999999
+    "total_tax": 100631.19099999999,
+    "amti": 365599.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13721,7 +14931,9 @@
     "addl_medicare": 2296.8089999999997,
     "amt": 0.0,
     "income_tax": 98335.12,
-    "total_tax": 100631.92899999999
+    "total_tax": 100631.92899999999,
+    "amti": 365601.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13747,7 +14959,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 17052.78,
-    "total_tax": 17052.78
+    "total_tax": 17052.78,
+    "amti": 99999.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13773,7 +14987,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 17053.22,
-    "total_tax": 17053.22
+    "total_tax": 17053.22,
+    "amti": 100001.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13799,7 +15015,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1654.9,
-    "total_tax": 1654.9
+    "total_tax": 1654.9,
+    "amti": 16549.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13825,7 +15043,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1655.12,
-    "total_tax": 1655.12
+    "total_tax": 1655.12,
+    "amti": 16551.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13851,7 +15071,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7240.88,
-    "total_tax": 7240.88
+    "total_tax": 7240.88,
+    "amti": 63099.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13877,7 +15099,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7241.22,
-    "total_tax": 7241.22
+    "total_tax": 7241.22,
+    "amti": 63101.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13903,7 +15127,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 15468.78,
-    "total_tax": 15468.78
+    "total_tax": 15468.78,
+    "amti": 100499.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13929,7 +15155,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 15469.24,
-    "total_tax": 15469.24
+    "total_tax": 15469.24,
+    "amti": 100501.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13955,7 +15183,9 @@
     "addl_medicare": 124.64099999999999,
     "amt": 0.0,
     "income_tax": 37416.759999999995,
-    "total_tax": 37541.401
+    "total_tax": 37541.401,
+    "amti": 191949.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -13981,7 +15211,9 @@
     "addl_medicare": 124.65899999999999,
     "amt": 0.0,
     "income_tax": 37417.32,
-    "total_tax": 37541.979
+    "total_tax": 37541.979,
+    "amti": 191951.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14007,7 +15239,9 @@
     "addl_medicare": 590.391,
     "amt": 0.0,
     "income_tax": 53976.68,
-    "total_tax": 54567.071
+    "total_tax": 54567.071,
+    "amti": 243699.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14033,7 +15267,9 @@
     "addl_medicare": 590.409,
     "amt": 0.0,
     "income_tax": 53977.35,
-    "total_tax": 54567.759
+    "total_tax": 54567.759,
+    "amti": 243701.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14059,7 +15295,9 @@
     "addl_medicare": 3881.2409999999995,
     "amt": 0.0,
     "income_tax": 181954.15,
-    "total_tax": 185835.391
+    "total_tax": 185835.391,
+    "amti": 609349.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14085,7 +15323,9 @@
     "addl_medicare": 3881.2589999999996,
     "amt": 0.0,
     "income_tax": 181954.87,
-    "total_tax": 185836.129
+    "total_tax": 185836.129,
+    "amti": 609351.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14111,7 +15351,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 15358.779999999999,
-    "total_tax": 15358.779999999999
+    "total_tax": 15358.779999999999,
+    "amti": 99999.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14137,7 +15379,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 15359.220000000001,
-    "total_tax": 15359.220000000001
+    "total_tax": 15359.220000000001,
+    "amti": 100001.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14163,7 +15407,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2319.9,
-    "total_tax": 2319.9
+    "total_tax": 2319.9,
+    "amti": 23199.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14189,7 +15435,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2320.12,
-    "total_tax": 2320.12
+    "total_tax": 2320.12,
+    "amti": 23201.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14215,7 +15463,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10851.88,
-    "total_tax": 10851.88
+    "total_tax": 10851.88,
+    "amti": 94299.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14241,7 +15491,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10852.22,
-    "total_tax": 10852.22
+    "total_tax": 10852.22,
+    "amti": 94301.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14267,7 +15519,9 @@
     "addl_medicare": 272.241,
     "amt": 0.0,
     "income_tax": 34336.78,
-    "total_tax": 34609.021
+    "total_tax": 34609.021,
+    "amti": 201049.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14293,7 +15547,9 @@
     "addl_medicare": 272.25899999999996,
     "amt": 0.0,
     "income_tax": 34337.24,
-    "total_tax": 34609.498999999996
+    "total_tax": 34609.498999999996,
+    "amti": 201051.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14319,7 +15575,9 @@
     "addl_medicare": 1917.8909999999998,
     "amt": 0.0,
     "income_tax": 78220.76,
-    "total_tax": 80138.651
+    "total_tax": 80138.651,
+    "amti": 383899.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14345,7 +15603,9 @@
     "addl_medicare": 1917.9089999999999,
     "amt": 0.0,
     "income_tax": 78221.32,
-    "total_tax": 80139.229
+    "total_tax": 80139.229,
+    "amti": 383901.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14371,7 +15631,9 @@
     "addl_medicare": 2849.841,
     "amt": 0.0,
     "income_tax": 111356.68,
-    "total_tax": 114206.521
+    "total_tax": 114206.521,
+    "amti": 487449.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14397,7 +15659,9 @@
     "addl_medicare": 2849.859,
     "amt": 0.0,
     "income_tax": 111357.35,
-    "total_tax": 114207.209
+    "total_tax": 114207.209,
+    "amti": 487451.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14423,7 +15687,9 @@
     "addl_medicare": 5043.590999999999,
     "amt": 0.0,
     "income_tax": 196669.15,
-    "total_tax": 201712.74099999998
+    "total_tax": 201712.74099999998,
+    "amti": 731199.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14449,7 +15715,9 @@
     "addl_medicare": 5043.6089999999995,
     "amt": 0.0,
     "income_tax": 196669.87,
-    "total_tax": 201713.479
+    "total_tax": 201713.479,
+    "amti": 731201.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14475,7 +15743,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 12105.78,
-    "total_tax": 12105.78
+    "total_tax": 12105.78,
+    "amti": 99999.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14501,7 +15771,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 12106.22,
-    "total_tax": 12106.22
+    "total_tax": 12106.22,
+    "amti": 100001.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14527,7 +15799,9 @@
     "addl_medicare": 4950.0,
     "amt": 0.0,
     "income_tax": 230285.75,
-    "total_tax": 235235.75
+    "total_tax": 235235.75,
+    "amti": 735400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14553,7 +15827,9 @@
     "addl_medicare": 4950.0,
     "amt": 0.0,
     "income_tax": 270285.75,
-    "total_tax": 282835.75
+    "total_tax": 282835.75,
+    "amti": 935400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14579,7 +15855,9 @@
     "addl_medicare": 9000.0,
     "amt": 0.0,
     "income_tax": 396785.75,
-    "total_tax": 405785.75
+    "total_tax": 405785.75,
+    "amti": 1185400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14605,7 +15883,9 @@
     "addl_medicare": 9000.0,
     "amt": 0.0,
     "income_tax": 436785.75,
-    "total_tax": 453385.75
+    "total_tax": 453385.75,
+    "amti": 1385400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14631,7 +15911,9 @@
     "addl_medicare": 4500.0,
     "amt": 0.0,
     "income_tax": 193029.5,
-    "total_tax": 197529.5
+    "total_tax": 197529.5,
+    "amti": 720800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 750000.0,
@@ -14641,7 +15923,9 @@
     "addl_medicare": 4500.0,
     "amt": 0.0,
     "income_tax": 193029.5,
-    "total_tax": 197529.5
+    "total_tax": 197529.5,
+    "amti": 720800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -14666,7 +15950,9 @@
     "addl_medicare": 4500.0,
     "amt": 0.0,
     "income_tax": 233029.5,
-    "total_tax": 245129.5
+    "total_tax": 245129.5,
+    "amti": 920800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 950000.0,
@@ -14676,7 +15962,9 @@
     "addl_medicare": 4500.0,
     "amt": 0.0,
     "income_tax": 233029.5,
-    "total_tax": 245129.5
+    "total_tax": 245129.5,
+    "amti": 920800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -14701,7 +15989,9 @@
     "addl_medicare": 8550.0,
     "amt": 0.0,
     "income_tax": 359321.5,
-    "total_tax": 367871.5
+    "total_tax": 367871.5,
+    "amti": 1170800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 1200000.0,
@@ -14711,7 +16001,9 @@
     "addl_medicare": 8550.0,
     "amt": 0.0,
     "income_tax": 359321.5,
-    "total_tax": 367871.5
+    "total_tax": 367871.5,
+    "amti": 1170800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -14736,7 +16028,9 @@
     "addl_medicare": 8550.0,
     "amt": 0.0,
     "income_tax": 399321.5,
-    "total_tax": 415471.5
+    "total_tax": 415471.5,
+    "amti": 1370800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 1400000.0,
@@ -14746,7 +16040,9 @@
     "addl_medicare": 8550.0,
     "amt": 0.0,
     "income_tax": 399321.5,
-    "total_tax": 415471.5
+    "total_tax": 415471.5,
+    "amti": 1370800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -14771,7 +16067,9 @@
     "addl_medicare": 5625.0,
     "amt": 0.0,
     "income_tax": 235160.75,
-    "total_tax": 240785.75
+    "total_tax": 240785.75,
+    "amti": 735400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14797,7 +16095,9 @@
     "addl_medicare": 5625.0,
     "amt": 0.0,
     "income_tax": 275160.75,
-    "total_tax": 288385.75
+    "total_tax": 288385.75,
+    "amti": 935400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14823,7 +16123,9 @@
     "addl_medicare": 9675.0,
     "amt": 0.0,
     "income_tax": 401660.75,
-    "total_tax": 411335.75
+    "total_tax": 411335.75,
+    "amti": 1185400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14849,7 +16151,9 @@
     "addl_medicare": 9675.0,
     "amt": 0.0,
     "income_tax": 441660.75,
-    "total_tax": 458935.75
+    "total_tax": 458935.75,
+    "amti": 1385400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14875,7 +16179,9 @@
     "addl_medicare": 4950.0,
     "amt": 0.0,
     "income_tax": 225892.0,
-    "total_tax": 230842.0
+    "total_tax": 230842.0,
+    "amti": 728100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14901,7 +16207,9 @@
     "addl_medicare": 4950.0,
     "amt": 0.0,
     "income_tax": 265892.0,
-    "total_tax": 278442.0
+    "total_tax": 278442.0,
+    "amti": 928100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14927,7 +16235,9 @@
     "addl_medicare": 9000.0,
     "amt": 0.0,
     "income_tax": 392392.0,
-    "total_tax": 401392.0
+    "total_tax": 401392.0,
+    "amti": 1178100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14953,7 +16263,9 @@
     "addl_medicare": 9000.0,
     "amt": 0.0,
     "income_tax": 432392.0,
-    "total_tax": 448992.0
+    "total_tax": 448992.0,
+    "amti": 1378100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -14979,7 +16291,9 @@
     "addl_medicare": 4950.0,
     "amt": 0.0,
     "income_tax": 193029.5,
-    "total_tax": 197979.5
+    "total_tax": 197979.5,
+    "amti": 720800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -15005,7 +16319,9 @@
     "addl_medicare": 4950.0,
     "amt": 0.0,
     "income_tax": 233029.5,
-    "total_tax": 245579.5
+    "total_tax": 245579.5,
+    "amti": 920800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -15031,7 +16347,9 @@
     "addl_medicare": 9000.0,
     "amt": 0.0,
     "income_tax": 359321.5,
-    "total_tax": 368321.5
+    "total_tax": 368321.5,
+    "amti": 1170800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -15057,7 +16375,9 @@
     "addl_medicare": 9000.0,
     "amt": 0.0,
     "income_tax": 399321.5,
-    "total_tax": 415921.5
+    "total_tax": 415921.5,
+    "amti": 1370800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -15083,7 +16403,9 @@
     "addl_medicare": 0.0,
     "amt": 383.5,
     "income_tax": 25922.0,
-    "total_tax": 25922.0
+    "total_tax": 25922.0,
+    "amti": 185400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -15109,7 +16431,9 @@
     "addl_medicare": 0.0,
     "amt": 39725.5,
     "income_tax": 65264.0,
-    "total_tax": 65264.0
+    "total_tax": 65264.0,
+    "amti": 335400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -15135,7 +16459,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 70264.75,
-    "total_tax": 71164.75
+    "total_tax": 71164.75,
+    "amti": 335400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -15161,7 +16487,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 36999.25,
     "income_tax": 107264.0,
-    "total_tax": 108164.0
+    "total_tax": 108164.0,
+    "amti": 485400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -15187,7 +16515,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 16682.0,
-    "total_tax": 16682.0
+    "total_tax": 16682.0,
+    "amti": 170800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 150000.0,
@@ -15197,7 +16527,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 16682.0,
-    "total_tax": 16682.0
+    "total_tax": 16682.0,
+    "amti": 170800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -15222,7 +16554,9 @@
     "addl_medicare": 0.0,
     "amt": 32068.0,
     "income_tax": 48750.0,
-    "total_tax": 48750.0
+    "total_tax": 48750.0,
+    "amti": 320800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 150000.0,
@@ -15232,7 +16566,9 @@
     "addl_medicare": 0.0,
     "amt": 32068.0,
     "income_tax": 48750.0,
-    "total_tax": 48750.0
+    "total_tax": 48750.0,
+    "amti": 320800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -15257,7 +16593,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 51077.0,
-    "total_tax": 51527.0
+    "total_tax": 51527.0,
+    "amti": 320800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 300000.0,
@@ -15267,7 +16605,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 51077.0,
-    "total_tax": 51527.0
+    "total_tax": 51527.0,
+    "amti": 320800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -15292,7 +16632,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 38771.0,
     "income_tax": 89848.0,
-    "total_tax": 90298.0
+    "total_tax": 90298.0,
+    "amti": 470800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 300000.0,
@@ -15302,7 +16644,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 38771.0,
     "income_tax": 89848.0,
-    "total_tax": 90298.0
+    "total_tax": 90298.0,
+    "amti": 470800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -15327,7 +16671,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 5385.5,
     "income_tax": 30924.0,
-    "total_tax": 31149.0
+    "total_tax": 31149.0,
+    "amti": 185400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -15353,7 +16699,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 47385.5,
     "income_tax": 72924.0,
-    "total_tax": 73149.0
+    "total_tax": 73149.0,
+    "amti": 335400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -15379,7 +16727,9 @@
     "addl_medicare": 1574.9999999999998,
     "amt": 2659.25,
     "income_tax": 72924.0,
-    "total_tax": 74499.0
+    "total_tax": 74499.0,
+    "amti": 335400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -15405,7 +16755,216 @@
     "addl_medicare": 1574.9999999999998,
     "amt": 44659.25,
     "income_tax": 114924.0,
-    "total_tax": 116499.0
+    "total_tax": 116499.0,
+    "amti": 485400.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2024,
+   "tag": "L_amt_floor",
+   "status": "Single",
+   "w2": 0.0,
+   "se": 0.0,
+   "stcg": 0.0,
+   "ltcg": 0.0,
+   "interest": 0.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 200000.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 0.0,
+    "taxable_income": 0.0,
+    "se_tax": 0.0,
+    "niit": 0.0,
+    "addl_medicare": 0.0,
+    "amt": 25922.0,
+    "income_tax": 25922.0,
+    "total_tax": 25922.0,
+    "amti": 185400.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2024,
+   "tag": "L_amt_floor",
+   "status": "Married/Joint",
+   "w2": 0.0,
+   "se": 0.0,
+   "stcg": 0.0,
+   "ltcg": 0.0,
+   "interest": 0.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 200000.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 0.0,
+    "taxable_income": 0.0,
+    "se_tax": 0.0,
+    "niit": 0.0,
+    "addl_medicare": 0.0,
+    "amt": 9750.0,
+    "income_tax": 9750.0,
+    "total_tax": 9750.0,
+    "amti": 170800.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": {
+    "agi": 0.0,
+    "taxable_income": 0.0,
+    "se_tax": 0.0,
+    "niit": 0.0,
+    "addl_medicare": 0.0,
+    "amt": 9750.0,
+    "income_tax": 9750.0,
+    "total_tax": 9750.0,
+    "amti": 170800.0,
+    "qbi_deduction": 0.0
+   }
+  },
+  {
+   "year": 2024,
+   "tag": "L_amt_floor",
+   "status": "Married/Sep",
+   "w2": 0.0,
+   "se": 0.0,
+   "stcg": 0.0,
+   "ltcg": 0.0,
+   "interest": 0.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 200000.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 0.0,
+    "taxable_income": 0.0,
+    "se_tax": 0.0,
+    "niit": 0.0,
+    "addl_medicare": 0.0,
+    "amt": 30924.0,
+    "income_tax": 30924.0,
+    "total_tax": 30924.0,
+    "amti": 185400.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2024,
+   "tag": "L_amt_floor",
+   "status": "Head_of_House",
+   "w2": 0.0,
+   "se": 0.0,
+   "stcg": 0.0,
+   "ltcg": 0.0,
+   "interest": 0.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 200000.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 0.0,
+    "taxable_income": 0.0,
+    "se_tax": 0.0,
+    "niit": 0.0,
+    "addl_medicare": 0.0,
+    "amt": 24024.0,
+    "income_tax": 24024.0,
+    "total_tax": 24024.0,
+    "amti": 178100.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2024,
+   "tag": "L_amt_floor",
+   "status": "Widow(er)",
+   "w2": 0.0,
+   "se": 0.0,
+   "stcg": 0.0,
+   "ltcg": 0.0,
+   "interest": 0.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 200000.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 0.0,
+    "taxable_income": 0.0,
+    "se_tax": 0.0,
+    "niit": 0.0,
+    "addl_medicare": 0.0,
+    "amt": 9750.0,
+    "income_tax": 9750.0,
+    "total_tax": 9750.0,
+    "amti": 170800.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2024,
+   "tag": "M_amt_mfs",
+   "status": "Married/Sep",
+   "w2": 750000.0,
+   "se": 0.0,
+   "stcg": 0.0,
+   "ltcg": 0.0,
+   "interest": 0.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 300000.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 750000.0,
+    "taxable_income": 735400.0,
+    "se_tax": 0.0,
+    "niit": 0.0,
+    "addl_medicare": 5625.0,
+    "amt": 52425.25,
+    "income_tax": 287586.0,
+    "total_tax": 293211.0,
+    "amti": 1035400.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2024,
+   "tag": "O_amt_itemized_floor",
+   "status": "Married/Sep",
+   "w2": 0.0,
+   "se": 0.0,
+   "stcg": -211156.0,
+   "ltcg": 33745.0,
+   "interest": 15079.0,
+   "ord_div": 33112.0,
+   "qual_div": 16556.0,
+   "itemized": 50061.0,
+   "iso": 300000.0,
+   "std_or_item": "Itemized",
+   "expected": {
+    "agi": 46691.0,
+    "taxable_income": 0.0,
+    "se_tax": 0.0,
+    "niit": 0.0,
+    "addl_medicare": 0.0,
+    "amt": 57432.72000000001,
+    "income_tax": 57432.72000000001,
+    "total_tax": 57432.72000000001,
+    "amti": 296630.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -15431,7 +16990,9 @@
     "addl_medicare": 240.34499999999997,
     "amt": 0.0,
     "income_tax": 45106.97556587777,
-    "total_tax": 46150.76556587777
+    "total_tax": 46150.76556587777,
+    "amti": 210688.98614336803,
+    "qbi_deduction": 3309.2913566319758
    },
    "expected_spouse_attr": null
   },
@@ -15457,7 +17018,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 41798.5,
-    "total_tax": 42900.5
+    "total_tax": 42900.5,
+    "amti": 214400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -15483,7 +17046,9 @@
     "addl_medicare": 258.34499999999997,
     "amt": 0.0,
     "income_tax": 45822.747156277765,
-    "total_tax": 46884.537156277765
+    "total_tax": 46884.537156277765,
+    "amti": 212925.772363368,
+    "qbi_deduction": 3072.505136631976
    },
    "expected_spouse_attr": null
   },
@@ -15509,7 +17074,9 @@
     "addl_medicare": 9.0,
     "amt": 0.0,
     "income_tax": 42278.5,
-    "total_tax": 43427.5
+    "total_tax": 43427.5,
+    "amti": 216400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -15535,7 +17102,9 @@
     "addl_medicare": 240.34499999999997,
     "amt": 0.0,
     "income_tax": 44519.869280000006,
-    "total_tax": 45563.65928000001
+    "total_tax": 45563.65928000001,
+    "amti": 243478.62200000003,
+    "qbi_deduction": 5919.655500000001
    },
    "expected_spouse_attr": {
     "agi": 276880.5675,
@@ -15545,7 +17114,9 @@
     "addl_medicare": 240.34499999999997,
     "amt": 0.0,
     "income_tax": 44190.06896,
-    "total_tax": 48669.278959999996
+    "total_tax": 48669.278959999996,
+    "amti": 242104.45400000003,
+    "qbi_deduction": 5576.1135
    }
   },
   {
@@ -15570,7 +17141,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 43337.0,
-    "total_tax": 44439.0
+    "total_tax": 44439.0,
+    "amti": 249800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 279000.0,
@@ -15580,7 +17153,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 43337.0,
-    "total_tax": 44439.0
+    "total_tax": 44439.0,
+    "amti": 249800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -15605,7 +17180,9 @@
     "addl_medicare": 258.34499999999997,
     "amt": 0.0,
     "income_tax": 44999.869280000006,
-    "total_tax": 46061.65928000001
+    "total_tax": 46061.65928000001,
+    "amti": 245478.62200000003,
+    "qbi_deduction": 5919.655500000001
    },
    "expected_spouse_attr": {
     "agi": 278880.5675,
@@ -15615,7 +17192,9 @@
     "addl_medicare": 258.34499999999997,
     "amt": 0.0,
     "income_tax": 44670.06896,
-    "total_tax": 49167.278959999996
+    "total_tax": 49167.278959999996,
+    "amti": 244104.45400000003,
+    "qbi_deduction": 5576.1135
    }
   },
   {
@@ -15640,7 +17219,9 @@
     "addl_medicare": 9.0,
     "amt": 0.0,
     "income_tax": 43817.0,
-    "total_tax": 44966.0
+    "total_tax": 44966.0,
+    "amti": 251800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 281000.0,
@@ -15650,7 +17231,9 @@
     "addl_medicare": 9.0,
     "amt": 0.0,
     "income_tax": 43817.0,
-    "total_tax": 44966.0
+    "total_tax": 44966.0,
+    "amti": 251800.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -15675,7 +17258,9 @@
     "addl_medicare": 240.34499999999997,
     "amt": 0.0,
     "income_tax": 24651.56896,
-    "total_tax": 29130.778960000003
+    "total_tax": 29130.778960000003,
+    "amti": 131704.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": null
   },
@@ -15701,7 +17286,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 23798.5,
-    "total_tax": 24900.5
+    "total_tax": 24900.5,
+    "amti": 139400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -15727,7 +17314,9 @@
     "addl_medicare": 258.34499999999997,
     "amt": 0.0,
     "income_tax": 25131.56896,
-    "total_tax": 29628.778960000003
+    "total_tax": 29628.778960000003,
+    "amti": 133704.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": null
   },
@@ -15753,7 +17342,9 @@
     "addl_medicare": 9.0,
     "amt": 0.0,
     "income_tax": 24278.5,
-    "total_tax": 25427.5
+    "total_tax": 25427.5,
+    "amti": 141400.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -15779,7 +17370,9 @@
     "addl_medicare": 240.34499999999997,
     "amt": 0.0,
     "income_tax": 40800.90926091776,
-    "total_tax": 41844.69926091776
+    "total_tax": 41844.69926091776,
+    "amti": 202524.716440368,
+    "qbi_deduction": 4173.561059631977
    },
    "expected_spouse_attr": null
   },
@@ -15805,7 +17398,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 38353.0,
-    "total_tax": 39455.0
+    "total_tax": 39455.0,
+    "amti": 207100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -15831,7 +17426,9 @@
     "addl_medicare": 258.34499999999997,
     "amt": 0.0,
     "income_tax": 41516.68085131777,
-    "total_tax": 42578.47085131777
+    "total_tax": 42578.47085131777,
+    "amti": 204761.50266036802,
+    "qbi_deduction": 3936.7748396319757
    },
    "expected_spouse_attr": null
   },
@@ -15857,7 +17454,9 @@
     "addl_medicare": 9.0,
     "amt": 0.0,
     "income_tax": 38833.0,
-    "total_tax": 39982.0
+    "total_tax": 39982.0,
+    "amti": 209100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -15883,7 +17482,9 @@
     "addl_medicare": 240.34499999999997,
     "amt": 0.0,
     "income_tax": 32768.297561110485,
-    "total_tax": 33812.087561110486
+    "total_tax": 33812.087561110486,
+    "amti": 193919.53436868402,
+    "qbi_deduction": 5478.743131315989
    },
    "expected_spouse_attr": null
   },
@@ -15909,7 +17510,9 @@
     "addl_medicare": 440.99999999999994,
     "amt": 0.0,
     "income_tax": 43337.0,
-    "total_tax": 44880.0
+    "total_tax": 44880.0,
+    "amti": 249800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -15935,7 +17538,9 @@
     "addl_medicare": 258.34499999999997,
     "amt": 0.0,
     "income_tax": 33234.34404531048,
-    "total_tax": 34296.13404531048
+    "total_tax": 34296.13404531048,
+    "amti": 196037.927478684,
+    "qbi_deduction": 5360.350021315989
    },
    "expected_spouse_attr": null
   },
@@ -15961,7 +17566,9 @@
     "addl_medicare": 458.99999999999994,
     "amt": 0.0,
     "income_tax": 43817.0,
-    "total_tax": 45416.0
+    "total_tax": 45416.0,
+    "amti": 251800.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -15987,7 +17594,9 @@
     "addl_medicare": 484.91999999999996,
     "amt": 0.0,
     "income_tax": 68389.809,
-    "total_tax": 73677.249
+    "total_tax": 73677.249,
+    "amti": 314328.74,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16013,7 +17622,9 @@
     "addl_medicare": 34.919999999999995,
     "amt": 0.0,
     "income_tax": 48831.31807999999,
-    "total_tax": 53668.758079999985
+    "total_tax": 53668.758079999985,
+    "amti": 283942.99199999997,
+    "qbi_deduction": 15785.748000000001
    },
    "expected_spouse_attr": {
     "agi": 324348.18,
@@ -16023,7 +17634,9 @@
     "addl_medicare": 34.919999999999995,
     "amt": 0.0,
     "income_tax": 47951.850560000006,
-    "total_tax": 61950.410560000004
+    "total_tax": 61950.410560000004,
+    "amti": 280278.544,
+    "qbi_deduction": 14869.635999999999
    }
   },
   {
@@ -16048,7 +17661,9 @@
     "addl_medicare": 1159.9199999999998,
     "amt": 0.0,
     "income_tax": 69513.746,
-    "total_tax": 75476.186
+    "total_tax": 75476.186,
+    "amti": 314328.74,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16074,7 +17689,9 @@
     "addl_medicare": 484.91999999999996,
     "amt": 0.0,
     "income_tax": 64142.058999999994,
-    "total_tax": 69429.499
+    "total_tax": 69429.499,
+    "amti": 307028.74,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16100,7 +17717,261 @@
     "addl_medicare": 484.91999999999996,
     "amt": 0.0,
     "income_tax": 52619.8976,
-    "total_tax": 57907.33759999999
+    "total_tax": 57907.33759999999,
+    "amti": 299728.74,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2024,
+   "tag": "J_loss",
+   "status": "Single",
+   "w2": 300000.0,
+   "se": 0.0,
+   "stcg": -1000.0,
+   "ltcg": 0.0,
+   "interest": 100000.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 0.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 399000.0,
+    "taxable_income": 384400.0,
+    "se_tax": 0.0,
+    "niit": 3762.0,
+    "addl_medicare": 899.9999999999999,
+    "amt": 0.0,
+    "income_tax": 104914.75,
+    "total_tax": 109576.75,
+    "amti": 384400.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2024,
+   "tag": "J_loss",
+   "status": "Single",
+   "w2": 300000.0,
+   "se": 0.0,
+   "stcg": -3000.0,
+   "ltcg": 0.0,
+   "interest": 100000.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 0.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 397000.0,
+    "taxable_income": 382400.0,
+    "se_tax": 0.0,
+    "niit": 3686.0,
+    "addl_medicare": 899.9999999999999,
+    "amt": 0.0,
+    "income_tax": 104214.75,
+    "total_tax": 108800.75,
+    "amti": 382400.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2024,
+   "tag": "J_loss",
+   "status": "Single",
+   "w2": 300000.0,
+   "se": 0.0,
+   "stcg": -50000.0,
+   "ltcg": 0.0,
+   "interest": 100000.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 0.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 397000.0,
+    "taxable_income": 382400.0,
+    "se_tax": 0.0,
+    "niit": 3686.0,
+    "addl_medicare": 899.9999999999999,
+    "amt": 0.0,
+    "income_tax": 104214.75,
+    "total_tax": 108800.75,
+    "amti": 382400.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2024,
+   "tag": "J_loss",
+   "status": "Single",
+   "w2": 300000.0,
+   "se": 0.0,
+   "stcg": -50000.0,
+   "ltcg": 10000.0,
+   "interest": 100000.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 0.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 397000.0,
+    "taxable_income": 382400.0,
+    "se_tax": 0.0,
+    "niit": 3686.0,
+    "addl_medicare": 899.9999999999999,
+    "amt": 0.0,
+    "income_tax": 104214.75,
+    "total_tax": 108800.75,
+    "amti": 382400.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2024,
+   "tag": "J_loss",
+   "status": "Married/Sep",
+   "w2": 300000.0,
+   "se": 0.0,
+   "stcg": -1000.0,
+   "ltcg": 0.0,
+   "interest": 100000.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 0.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 399000.0,
+    "taxable_income": 384400.0,
+    "se_tax": 0.0,
+    "niit": 3762.0,
+    "addl_medicare": 1574.9999999999998,
+    "amt": 0.0,
+    "income_tax": 105290.75,
+    "total_tax": 110627.75,
+    "amti": 384400.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2024,
+   "tag": "J_loss",
+   "status": "Married/Sep",
+   "w2": 300000.0,
+   "se": 0.0,
+   "stcg": -3000.0,
+   "ltcg": 0.0,
+   "interest": 100000.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 0.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 398500.0,
+    "taxable_income": 383900.0,
+    "se_tax": 0.0,
+    "niit": 3743.0,
+    "addl_medicare": 1574.9999999999998,
+    "amt": 0.0,
+    "income_tax": 105105.75,
+    "total_tax": 110423.75,
+    "amti": 383900.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2024,
+   "tag": "J_loss",
+   "status": "Married/Sep",
+   "w2": 300000.0,
+   "se": 0.0,
+   "stcg": -50000.0,
+   "ltcg": 0.0,
+   "interest": 100000.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 0.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 398500.0,
+    "taxable_income": 383900.0,
+    "se_tax": 0.0,
+    "niit": 3743.0,
+    "addl_medicare": 1574.9999999999998,
+    "amt": 0.0,
+    "income_tax": 105105.75,
+    "total_tax": 110423.75,
+    "amti": 383900.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2024,
+   "tag": "J_loss",
+   "status": "Married/Sep",
+   "w2": 300000.0,
+   "se": 0.0,
+   "stcg": -50000.0,
+   "ltcg": 10000.0,
+   "interest": 100000.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 0.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 398500.0,
+    "taxable_income": 383900.0,
+    "se_tax": 0.0,
+    "niit": 3743.0,
+    "addl_medicare": 1574.9999999999998,
+    "amt": 0.0,
+    "income_tax": 105105.75,
+    "total_tax": 110423.75,
+    "amti": 383900.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2024,
+   "tag": "K_deduction",
+   "status": "Head_of_House",
+   "w2": 0.0,
+   "se": 0.0,
+   "stcg": 0.0,
+   "ltcg": 60000.0,
+   "interest": 0.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 50000.0,
+   "iso": 0.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 60000.0,
+    "taxable_income": 38100.0,
+    "se_tax": 0.0,
+    "niit": 0.0,
+    "addl_medicare": 0.0,
+    "amt": 0.0,
+    "income_tax": 0.0,
+    "total_tax": 0.0,
+    "amti": 38100.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16126,7 +17997,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 970.4454000000005,
-    "total_tax": 5209.3104
+    "total_tax": 5209.3104,
+    "amti": 9704.454000000002,
+    "qbi_deduction": 2426.1135000000004
    },
    "expected_spouse_attr": null
   },
@@ -16152,7 +18025,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 3602.5689600000005,
-    "total_tax": 12080.29896
+    "total_tax": 12080.29896,
+    "amti": 32008.908000000003,
+    "qbi_deduction": 8002.227000000001
    },
    "expected_spouse_attr": null
   },
@@ -16178,7 +18053,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 16676.899399999995,
-    "total_tax": 37871.22439999999
+    "total_tax": 37871.22439999999,
+    "amti": 98922.26999999999,
+    "qbi_deduction": 24730.5675
    },
    "expected_spouse_attr": null
   },
@@ -16204,7 +18081,9 @@
     "addl_medicare": 693.4499999999999,
     "amt": 0.0,
     "income_tax": 63807.35125000001,
-    "total_tax": 94371.65125000001
+    "total_tax": 94371.65125000001,
+    "amti": 269314.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16230,7 +18109,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 3871.5,
-    "total_tax": 3871.5
+    "total_tax": 3871.5,
+    "amti": 34250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16256,7 +18137,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7355.979880000001,
-    "total_tax": 11594.84488
+    "total_tax": 11594.84488,
+    "amti": 56554.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": null
   },
@@ -16282,7 +18165,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 12262.959759999998,
-    "total_tax": 20740.689759999997
+    "total_tax": 20740.689759999997,
+    "amti": 78858.908,
+    "qbi_deduction": 11152.227
    },
    "expected_spouse_attr": null
   },
@@ -16308,7 +18193,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 27980.251999999993,
-    "total_tax": 47633.87699999999
+    "total_tax": 47633.87699999999,
+    "amti": 146388.55,
+    "qbi_deduction": 28034.6375
    },
    "expected_spouse_attr": null
   },
@@ -16334,7 +18221,9 @@
     "addl_medicare": 1143.4499999999998,
     "amt": 0.0,
     "income_tax": 82392.35125,
-    "total_tax": 107206.65125000001
+    "total_tax": 107206.65125000001,
+    "amti": 322414.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16360,7 +18249,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 17867.0,
-    "total_tax": 17867.0
+    "total_tax": 17867.0,
+    "amti": 104250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16386,7 +18277,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 23220.068960000004,
-    "total_tax": 27458.933960000002
+    "total_tax": 27458.933960000002,
+    "amti": 126554.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": null
   },
@@ -16412,7 +18305,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 28573.137920000005,
-    "total_tax": 37050.867920000004
+    "total_tax": 37050.867920000004,
+    "amti": 148858.908,
+    "qbi_deduction": 11152.227
    },
    "expected_spouse_attr": null
   },
@@ -16438,7 +18333,9 @@
     "addl_medicare": 526.7249999999999,
     "amt": 0.0,
     "income_tax": 56667.22000000001,
-    "total_tax": 68167.57
+    "total_tax": 68167.57,
+    "amti": 248763.1875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16464,7 +18361,9 @@
     "addl_medicare": 1773.4499999999998,
     "amt": 0.0,
     "income_tax": 108411.35125,
-    "total_tax": 125175.65125000001
+    "total_tax": 125175.65125000001,
+    "amti": 396754.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16490,7 +18389,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 31331.0,
-    "total_tax": 31331.0
+    "total_tax": 31331.0,
+    "amti": 160350.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16516,7 +18417,9 @@
     "addl_medicare": 34.245,
     "amt": 0.0,
     "income_tax": 37013.86928,
-    "total_tax": 37851.55928
+    "total_tax": 37851.55928,
+    "amti": 184028.622,
+    "qbi_deduction": 5919.655500000001
    },
    "expected_spouse_attr": null
   },
@@ -16542,7 +18445,9 @@
     "addl_medicare": 283.59,
     "amt": 0.0,
     "income_tax": 45214.97493327107,
-    "total_tax": 47105.45493327107
+    "total_tax": 47105.45493327107,
+    "amti": 212974.9216664721,
+    "qbi_deduction": 6571.633333527902
    },
    "expected_spouse_attr": null
   },
@@ -16568,7 +18473,9 @@
     "addl_medicare": 1031.625,
     "amt": 0.0,
     "income_tax": 77466.735625,
-    "total_tax": 82515.585625
+    "total_tax": 82515.585625,
+    "amti": 308341.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16594,7 +18501,9 @@
     "addl_medicare": 2278.35,
     "amt": 0.0,
     "income_tax": 129263.72124999999,
-    "total_tax": 139576.52125
+    "total_tax": 139576.52125,
+    "amti": 456332.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16620,7 +18529,9 @@
     "addl_medicare": 67.5,
     "amt": 0.0,
     "income_tax": 38867.0,
-    "total_tax": 38934.5
+    "total_tax": 38934.5,
+    "amti": 191750.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16646,7 +18557,9 @@
     "addl_medicare": 316.84499999999997,
     "amt": 0.0,
     "income_tax": 46911.247156277765,
-    "total_tax": 48031.537156277765
+    "total_tax": 48031.537156277765,
+    "amti": 218275.772363368,
+    "qbi_deduction": 3072.505136631976
    },
    "expected_spouse_attr": null
   },
@@ -16672,7 +18585,9 @@
     "addl_medicare": 566.1899999999999,
     "amt": 0.0,
     "income_tax": 57378.54425,
-    "total_tax": 59551.62425
+    "total_tax": 59551.62425,
+    "amti": 250946.555,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16698,7 +18613,9 @@
     "addl_medicare": 1314.225,
     "amt": 0.0,
     "income_tax": 88456.735625,
-    "total_tax": 93788.18562500001
+    "total_tax": 93788.18562500001,
+    "amti": 339741.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16724,7 +18641,9 @@
     "addl_medicare": 2560.95,
     "amt": 0.0,
     "income_tax": 140253.72125,
-    "total_tax": 150849.12125000003
+    "total_tax": 150849.12125000003,
+    "amti": 487732.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16750,7 +18669,9 @@
     "addl_medicare": 540.0,
     "amt": 0.0,
     "income_tax": 55223.0,
-    "total_tax": 55763.0
+    "total_tax": 55763.0,
+    "amti": 244250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16776,7 +18697,9 @@
     "addl_medicare": 789.345,
     "amt": 0.0,
     "income_tax": 65394.14712500001,
-    "total_tax": 66986.93712500001
+    "total_tax": 66986.93712500001,
+    "amti": 273848.2775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16802,7 +18725,9 @@
     "addl_medicare": 1038.69,
     "amt": 0.0,
     "income_tax": 75753.54424999999,
-    "total_tax": 78399.12425
+    "total_tax": 78399.12425,
+    "amti": 303446.555,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16828,7 +18753,9 @@
     "addl_medicare": 1786.725,
     "amt": 0.0,
     "income_tax": 106831.735625,
-    "total_tax": 112635.68562500001
+    "total_tax": 112635.68562500001,
+    "amti": 392241.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16854,7 +18781,9 @@
     "addl_medicare": 3033.45,
     "amt": 0.0,
     "income_tax": 158628.72125,
-    "total_tax": 169696.62125000003
+    "total_tax": 169696.62125000003,
+    "amti": 540232.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16880,7 +18809,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 104034.75,
-    "total_tax": 105834.75
+    "total_tax": 105834.75,
+    "amti": 384250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16906,7 +18837,9 @@
     "addl_medicare": 2049.345,
     "amt": 0.0,
     "income_tax": 114394.147125,
-    "total_tax": 117246.93712500001
+    "total_tax": 117246.93712500001,
+    "amti": 413848.2775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16932,7 +18865,9 @@
     "addl_medicare": 2298.6899999999996,
     "amt": 0.0,
     "income_tax": 124753.54424999999,
-    "total_tax": 128659.12425
+    "total_tax": 128659.12425,
+    "amti": 443446.555,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16958,7 +18893,9 @@
     "addl_medicare": 3046.7249999999995,
     "amt": 0.0,
     "income_tax": 155831.73562499997,
-    "total_tax": 162895.68562499998
+    "total_tax": 162895.68562499998,
+    "amti": 532241.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -16984,7 +18921,9 @@
     "addl_medicare": 4293.45,
     "amt": 0.0,
     "income_tax": 208706.37675,
-    "total_tax": 221034.27675000002
+    "total_tax": 221034.27675000002,
+    "amti": 680232.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -17010,7 +18949,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 0.0,
-    "total_tax": 4238.865
+    "total_tax": 4238.865,
+    "amti": -3619.432499999999,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 27880.5675,
@@ -17020,7 +18961,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 0.0,
-    "total_tax": 4238.865
+    "total_tax": 4238.865,
+    "amti": -3619.432499999999,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -17045,7 +18988,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1940.890800000001,
-    "total_tax": 10418.6208
+    "total_tax": 10418.6208,
+    "amti": 19408.908000000003,
+    "qbi_deduction": 4852.227000000001
    },
    "expected_spouse_attr": {
     "agi": 55761.135,
@@ -17055,7 +19000,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1940.890800000001,
-    "total_tax": 10418.6208
+    "total_tax": 10418.6208,
+    "amti": 19408.908000000003,
+    "qbi_deduction": 4852.227000000001
    }
   },
   {
@@ -17080,7 +19027,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 9881.6724,
-    "total_tax": 31075.997399999997
+    "total_tax": 31075.997399999997,
+    "amti": 86322.26999999999,
+    "qbi_deduction": 21580.5675
    },
    "expected_spouse_attr": {
     "agi": 139402.8375,
@@ -17090,7 +19039,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 9881.6724,
-    "total_tax": 31075.997399999997
+    "total_tax": 31075.997399999997,
+    "amti": 86322.26999999999,
+    "qbi_deduction": 21580.5675
    }
   },
   {
@@ -17115,7 +19066,9 @@
     "addl_medicare": 243.45,
     "amt": 0.0,
     "income_tax": 34455.3652,
-    "total_tax": 64569.6652
+    "total_tax": 64569.6652,
+    "amti": 202851.66,
+    "qbi_deduction": 50712.91500000001
    },
    "expected_spouse_attr": {
     "agi": 285064.575,
@@ -17125,7 +19078,9 @@
     "addl_medicare": 243.45,
     "amt": 0.0,
     "income_tax": 34455.3652,
-    "total_tax": 64569.6652
+    "total_tax": 64569.6652,
+    "amti": 202851.66,
+    "qbi_deduction": 50712.91500000001
    }
   },
   {
@@ -17150,7 +19105,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1850.0,
-    "total_tax": 1850.0
+    "total_tax": 1850.0,
+    "amti": 18500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 50000.0,
@@ -17160,7 +19117,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1850.0,
-    "total_tax": 1850.0
+    "total_tax": 1850.0,
+    "amti": 18500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -17185,7 +19144,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 4419.53448,
-    "total_tax": 8658.39948
+    "total_tax": 8658.39948,
+    "amti": 40804.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": {
     "agi": 77880.5675,
@@ -17195,7 +19156,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 4419.53448,
-    "total_tax": 8658.39948
+    "total_tax": 8658.39948,
+    "amti": 40804.454,
+    "qbi_deduction": 5576.1135
    }
   },
   {
@@ -17220,7 +19183,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7096.0689600000005,
-    "total_tax": 15573.79896
+    "total_tax": 15573.79896,
+    "amti": 63108.907999999996,
+    "qbi_deduction": 11152.227
    },
    "expected_spouse_attr": {
     "agi": 105761.135,
@@ -17230,7 +19195,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7096.0689600000005,
-    "total_tax": 15573.79896
+    "total_tax": 15573.79896,
+    "amti": 63108.907999999996,
+    "qbi_deduction": 11152.227
    }
   },
   {
@@ -17255,7 +19222,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 18568.481,
-    "total_tax": 38222.106
+    "total_tax": 38222.106,
+    "amti": 130638.54999999999,
+    "qbi_deduction": 28034.6375
    },
    "expected_spouse_attr": {
     "agi": 189402.8375,
@@ -17265,7 +19234,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 18432.899399999995,
-    "total_tax": 39627.22439999999
+    "total_tax": 39627.22439999999,
+    "amti": 130022.26999999999,
+    "qbi_deduction": 27880.5675
    }
   },
   {
@@ -17290,7 +19261,9 @@
     "addl_medicare": 693.4499999999999,
     "amt": 0.0,
     "income_tax": 45461.5984,
-    "total_tax": 69825.89839999999
+    "total_tax": 69825.89839999999,
+    "amti": 249031.66000000003,
+    "qbi_deduction": 57632.91500000001
    },
    "expected_spouse_attr": {
     "agi": 335064.575,
@@ -17300,7 +19273,9 @@
     "addl_medicare": 693.4499999999999,
     "amt": 0.0,
     "income_tax": 44866.39839999999,
-    "total_tax": 75430.6984
+    "total_tax": 75430.6984,
+    "amti": 246551.66000000003,
+    "qbi_deduction": 57012.91500000001
    }
   },
   {
@@ -17325,7 +19300,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10143.0,
-    "total_tax": 10143.0
+    "total_tax": 10143.0,
+    "amti": 88500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 120000.0,
@@ -17335,7 +19312,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10143.0,
-    "total_tax": 10143.0
+    "total_tax": 10143.0,
+    "amti": 88500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -17360,7 +19339,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 14204.979879999997,
-    "total_tax": 18443.844879999997
+    "total_tax": 18443.844879999997,
+    "amti": 110804.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": {
     "agi": 147880.5675,
@@ -17370,7 +19351,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 14204.979879999997,
-    "total_tax": 18443.844879999997
+    "total_tax": 18443.844879999997,
+    "amti": 110804.454,
+    "qbi_deduction": 5576.1135
    }
   },
   {
@@ -17395,7 +19378,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 19111.959759999998,
-    "total_tax": 27589.689759999997
+    "total_tax": 27589.689759999997,
+    "amti": 133108.908,
+    "qbi_deduction": 11152.227
    },
    "expected_spouse_attr": {
     "agi": 175761.135,
@@ -17405,7 +19390,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 19111.959759999998,
-    "total_tax": 27589.689759999997
+    "total_tax": 27589.689759999997,
+    "amti": 133108.908,
+    "qbi_deduction": 11152.227
    }
   },
   {
@@ -17430,7 +19417,9 @@
     "addl_medicare": 76.725,
     "amt": 0.0,
     "income_tax": 34732.320999999996,
-    "total_tax": 45782.670999999995
+    "total_tax": 45782.670999999995,
+    "amti": 204110.55,
+    "qbi_deduction": 28902.6375
    },
    "expected_spouse_attr": {
     "agi": 259402.8375,
@@ -17440,7 +19429,9 @@
     "addl_medicare": 76.725,
     "amt": 0.0,
     "income_tax": 33832.899399999995,
-    "total_tax": 55103.94939999999
+    "total_tax": 55103.94939999999,
+    "amti": 200022.27,
+    "qbi_deduction": 27880.5675
    }
   },
   {
@@ -17465,7 +19456,9 @@
     "addl_medicare": 1323.4499999999998,
     "amt": 0.0,
     "income_tax": 63094.8784,
-    "total_tax": 79409.1784
+    "total_tax": 79409.1784,
+    "amti": 322503.66000000003,
+    "qbi_deduction": 58500.91500000001
    },
    "expected_spouse_attr": {
     "agi": 405064.575,
@@ -17475,7 +19468,9 @@
     "addl_medicare": 1323.4499999999998,
     "amt": 0.0,
     "income_tax": 61666.398400000005,
-    "total_tax": 92860.69840000001
+    "total_tax": 92860.69840000001,
+    "amti": 316551.66000000003,
+    "qbi_deduction": 57012.91500000001
    }
   },
   {
@@ -17500,7 +19495,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 21640.0,
-    "total_tax": 21640.0
+    "total_tax": 21640.0,
+    "amti": 144600.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 176100.0,
@@ -17510,7 +19507,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 21640.0,
-    "total_tax": 21640.0
+    "total_tax": 21640.0,
+    "amti": 144600.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -17535,7 +19534,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 26849.296840000003,
-    "total_tax": 27652.741840000002
+    "total_tax": 27652.741840000002,
+    "amti": 168278.622,
+    "qbi_deduction": 5919.655500000001
    },
    "expected_spouse_attr": {
     "agi": 203980.5675,
@@ -17545,7 +19546,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 26546.97988,
-    "total_tax": 30785.844879999997
+    "total_tax": 30785.844879999997,
+    "amti": 166904.454,
+    "qbi_deduction": 5576.1135
    }
   },
   {
@@ -17570,7 +19573,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 32058.593680000005,
-    "total_tax": 33665.483680000005
+    "total_tax": 33665.483680000005,
+    "amti": 191957.244,
+    "qbi_deduction": 11839.311000000002
    },
    "expected_spouse_attr": {
     "agi": 231861.135,
@@ -17580,7 +19585,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 31453.959759999994,
-    "total_tax": 39931.689759999994
+    "total_tax": 39931.689759999994,
+    "amti": 189208.908,
+    "qbi_deduction": 11152.227
    }
   },
   {
@@ -17605,7 +19612,9 @@
     "addl_medicare": 581.625,
     "amt": 0.0,
     "income_tax": 48812.346399999995,
-    "total_tax": 53411.19639999999
+    "total_tax": 53411.19639999999,
+    "amti": 262993.11,
+    "qbi_deduction": 29598.277500000004
    },
    "expected_spouse_attr": {
     "agi": 315502.8375,
@@ -17615,7 +19624,9 @@
     "addl_medicare": 581.625,
     "amt": 0.0,
     "income_tax": 47163.344800000006,
-    "total_tax": 68939.2948
+    "total_tax": 68939.2948,
+    "amti": 256122.27000000002,
+    "qbi_deduction": 27880.5675
    }
   },
   {
@@ -17640,7 +19651,9 @@
     "addl_medicare": 1828.35,
     "amt": 0.0,
     "income_tax": 84880.06038188841,
-    "total_tax": 94742.86038188841
+    "total_tax": 94742.86038188841,
+    "amti": 408606.4386934013,
+    "qbi_deduction": 31976.33630659874
    },
    "expected_spouse_attr": {
     "agi": 461164.575,
@@ -17650,7 +19663,9 @@
     "addl_medicare": 1828.35,
     "amt": 0.0,
     "income_tax": 79928.31912156669,
-    "total_tax": 111627.5191215667
+    "total_tax": 111627.5191215667,
+    "amti": 392642.99633986125,
+    "qbi_deduction": 37021.57866013875
    }
   },
   {
@@ -17675,7 +19690,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 28548.0,
-    "total_tax": 28548.0
+    "total_tax": 28548.0,
+    "amti": 176000.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 207500.0,
@@ -17685,7 +19702,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 28548.0,
-    "total_tax": 28548.0
+    "total_tax": 28548.0,
+    "amti": 176000.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -17710,7 +19729,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 33757.296839999995,
-    "total_tax": 34560.741839999995
+    "total_tax": 34560.741839999995,
+    "amti": 199678.622,
+    "qbi_deduction": 5919.655500000001
    },
    "expected_spouse_attr": {
     "agi": 235380.5675,
@@ -17720,7 +19741,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 33454.97988,
-    "total_tax": 37693.84488
+    "total_tax": 37693.84488,
+    "amti": 198304.454,
+    "qbi_deduction": 5576.1135
    }
   },
   {
@@ -17745,7 +19768,9 @@
     "addl_medicare": 116.19,
     "amt": 0.0,
     "income_tax": 39299.73856,
-    "total_tax": 41022.81856
+    "total_tax": 41022.81856,
+    "amti": 223357.244,
+    "qbi_deduction": 11839.311000000002
    },
    "expected_spouse_attr": {
     "agi": 263261.135,
@@ -17755,7 +19780,9 @@
     "addl_medicare": 116.19,
     "amt": 0.0,
     "income_tax": 38640.13792,
-    "total_tax": 47234.05792000001
+    "total_tax": 47234.05792000001,
+    "amti": 220608.908,
+    "qbi_deduction": 11152.227
    }
   },
   {
@@ -17780,7 +19807,9 @@
     "addl_medicare": 864.2249999999999,
     "amt": 0.0,
     "income_tax": 56348.346399999995,
-    "total_tax": 61229.79639999999
+    "total_tax": 61229.79639999999,
+    "amti": 294393.11,
+    "qbi_deduction": 29598.277500000004
    },
    "expected_spouse_attr": {
     "agi": 346902.8375,
@@ -17790,7 +19819,9 @@
     "addl_medicare": 864.2249999999999,
     "amt": 0.0,
     "income_tax": 54699.34480000001,
-    "total_tax": 76757.89480000001
+    "total_tax": 76757.89480000001,
+    "amti": 287522.27,
+    "qbi_deduction": 27880.5675
    }
   },
   {
@@ -17815,7 +19846,9 @@
     "addl_medicare": 2110.95,
     "amt": 0.0,
     "income_tax": 100876.13022828841,
-    "total_tax": 111021.53022828841
+    "total_tax": 111021.53022828841,
+    "amti": 458594.1569634013,
+    "qbi_deduction": 13388.618036598738
    },
    "expected_spouse_attr": {
     "agi": 492564.575,
@@ -17825,7 +19858,9 @@
     "addl_medicare": 2110.95,
     "amt": 0.0,
     "income_tax": 95548.4165279556,
-    "total_tax": 127530.2165279556
+    "total_tax": 127530.2165279556,
+    "amti": 441945.05164986127,
+    "qbi_deduction": 19119.52335013874
    }
   },
   {
@@ -17850,7 +19885,9 @@
     "addl_medicare": 90.0,
     "amt": 0.0,
     "income_tax": 40534.0,
-    "total_tax": 40624.0
+    "total_tax": 40624.0,
+    "amti": 228500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 260000.0,
@@ -17860,7 +19897,9 @@
     "addl_medicare": 90.0,
     "amt": 0.0,
     "income_tax": 40534.0,
-    "total_tax": 40624.0
+    "total_tax": 40624.0,
+    "amti": 228500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -17885,7 +19924,9 @@
     "addl_medicare": 339.34499999999997,
     "amt": 0.0,
     "income_tax": 46216.869280000006,
-    "total_tax": 47359.65928000001
+    "total_tax": 47359.65928000001,
+    "amti": 252178.62200000003,
+    "qbi_deduction": 5919.655500000001
    },
    "expected_spouse_attr": {
     "agi": 287880.5675,
@@ -17895,7 +19936,9 @@
     "addl_medicare": 339.34499999999997,
     "amt": 0.0,
     "income_tax": 45887.06896,
-    "total_tax": 50465.278959999996
+    "total_tax": 50465.278959999996,
+    "amti": 250804.45400000003,
+    "qbi_deduction": 5576.1135
    }
   },
   {
@@ -17920,7 +19963,9 @@
     "addl_medicare": 588.6899999999999,
     "amt": 0.0,
     "income_tax": 51899.73856,
-    "total_tax": 54095.31856
+    "total_tax": 54095.31856,
+    "amti": 275857.244,
+    "qbi_deduction": 11839.311000000002
    },
    "expected_spouse_attr": {
     "agi": 315761.135,
@@ -17930,7 +19975,9 @@
     "addl_medicare": 588.6899999999999,
     "amt": 0.0,
     "income_tax": 51240.13792,
-    "total_tax": 60306.55792000001
+    "total_tax": 60306.55792000001,
+    "amti": 273108.908,
+    "qbi_deduction": 11152.227
    }
   },
   {
@@ -17955,7 +20002,9 @@
     "addl_medicare": 1336.725,
     "amt": 0.0,
     "income_tax": 68948.3464,
-    "total_tax": 74302.2964
+    "total_tax": 74302.2964,
+    "amti": 346893.11,
+    "qbi_deduction": 29598.277500000004
    },
    "expected_spouse_attr": {
     "agi": 399402.8375,
@@ -17965,7 +20014,9 @@
     "addl_medicare": 1336.725,
     "amt": 0.0,
     "income_tax": 67299.34480000002,
-    "total_tax": 89830.39480000002
+    "total_tax": 89830.39480000002,
+    "amti": 340022.27,
+    "qbi_deduction": 27880.5675
    }
   },
   {
@@ -17990,7 +20041,9 @@
     "addl_medicare": 2583.45,
     "amt": 0.0,
     "income_tax": 122663.47125,
-    "total_tax": 133281.37125
+    "total_tax": 133281.37125,
+    "amti": 524482.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 545064.575,
@@ -18000,7 +20053,9 @@
     "addl_medicare": 2583.45,
     "amt": 0.0,
     "income_tax": 118842.10124999999,
-    "total_tax": 151296.40125
+    "total_tax": 151296.40125,
+    "amti": 513564.57499999995,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -18025,7 +20080,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 74134.0,
-    "total_tax": 75484.0
+    "total_tax": 75484.0,
+    "amti": 368500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 400000.0,
@@ -18035,7 +20092,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 74134.0,
-    "total_tax": 75484.0
+    "total_tax": 75484.0,
+    "amti": 368500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -18060,7 +20119,9 @@
     "addl_medicare": 1599.345,
     "amt": 0.0,
     "income_tax": 79866.56991434417,
-    "total_tax": 82269.35991434418
+    "total_tax": 82269.35991434418,
+    "amti": 392385.70797643403,
+    "qbi_deduction": 5712.569523565987
    },
    "expected_spouse_attr": {
     "agi": 427880.5675,
@@ -18070,7 +20131,9 @@
     "addl_medicare": 1599.345,
     "amt": 0.0,
     "income_tax": 79510.89771153858,
-    "total_tax": 85349.10771153859
+    "total_tax": 85349.10771153859,
+    "amti": 390903.7404647441,
+    "qbi_deduction": 5476.8270352558875
    }
   },
   {
@@ -18095,7 +20158,9 @@
     "addl_medicare": 1848.69,
     "amt": 0.0,
     "income_tax": 88454.20738455553,
-    "total_tax": 91909.78738455553
+    "total_tax": 91909.78738455553,
+    "amti": 419775.648076736,
+    "qbi_deduction": 7920.906923263952
    },
    "expected_spouse_attr": {
     "agi": 455761.135,
@@ -18105,7 +20170,9 @@
     "addl_medicare": 1848.69,
     "amt": 0.0,
     "income_tax": 87379.37123391246,
-    "total_tax": 97705.79123391246
+    "total_tax": 97705.79123391246,
+    "amti": 416416.78510597645,
+    "qbi_deduction": 7844.3498940235495
    }
   },
   {
@@ -18130,7 +20197,9 @@
     "addl_medicare": 2596.725,
     "amt": 0.0,
     "income_tax": 119866.48562499999,
-    "total_tax": 126480.435625
+    "total_tax": 126480.435625,
+    "amti": 516491.38749999995,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 539402.8375,
@@ -18140,7 +20209,9 @@
     "addl_medicare": 2596.725,
     "amt": 0.0,
     "income_tax": 116860.49312500001,
-    "total_tax": 140651.543125
+    "total_tax": 140651.543125,
+    "amti": 507902.8375,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -18165,7 +20236,9 @@
     "addl_medicare": 3843.45,
     "amt": 0.0,
     "income_tax": 171663.47125,
-    "total_tax": 183541.37125000003
+    "total_tax": 183541.37125000003,
+    "amti": 664482.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 685064.575,
@@ -18175,7 +20248,9 @@
     "addl_medicare": 3843.45,
     "amt": 0.0,
     "income_tax": 167842.10125,
-    "total_tax": 201556.40125000002
+    "total_tax": 201556.40125000002,
+    "amti": 653564.575,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -18200,7 +20275,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 970.4454000000005,
-    "total_tax": 5209.3104
+    "total_tax": 5209.3104,
+    "amti": 9704.454000000002,
+    "qbi_deduction": 2426.1135000000004
    },
    "expected_spouse_attr": null
   },
@@ -18226,7 +20303,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 3602.5689600000005,
-    "total_tax": 12080.29896
+    "total_tax": 12080.29896,
+    "amti": 32008.908000000003,
+    "qbi_deduction": 8002.227000000001
    },
    "expected_spouse_attr": null
   },
@@ -18252,7 +20331,9 @@
     "addl_medicare": 121.725,
     "amt": 0.0,
     "income_tax": 16676.899400000002,
-    "total_tax": 37992.9494
+    "total_tax": 37992.9494,
+    "amti": 98922.26999999999,
+    "qbi_deduction": 24730.5675
    },
    "expected_spouse_attr": null
   },
@@ -18278,7 +20359,9 @@
     "addl_medicare": 1368.4499999999998,
     "amt": 0.0,
     "income_tax": 63807.35125000001,
-    "total_tax": 95046.65125000001
+    "total_tax": 95046.65125000001,
+    "amti": 269314.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -18304,7 +20387,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 3871.5,
-    "total_tax": 3871.5
+    "total_tax": 3871.5,
+    "amti": 34250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -18330,7 +20415,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7355.979880000001,
-    "total_tax": 11594.84488
+    "total_tax": 11594.84488,
+    "amti": 56554.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": null
   },
@@ -18356,7 +20443,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 12262.959759999998,
-    "total_tax": 20740.689759999997
+    "total_tax": 20740.689759999997,
+    "amti": 78858.908,
+    "qbi_deduction": 11152.227
    },
    "expected_spouse_attr": null
   },
@@ -18382,7 +20471,9 @@
     "addl_medicare": 571.7249999999999,
     "amt": 0.0,
     "income_tax": 27980.252,
-    "total_tax": 48205.602
+    "total_tax": 48205.602,
+    "amti": 146388.55,
+    "qbi_deduction": 28034.6375
    },
    "expected_spouse_attr": null
   },
@@ -18408,7 +20499,9 @@
     "addl_medicare": 1818.4499999999998,
     "amt": 0.0,
     "income_tax": 82392.35125,
-    "total_tax": 107881.65125000001
+    "total_tax": 107881.65125000001,
+    "amti": 322414.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -18434,7 +20527,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 17867.0,
-    "total_tax": 17867.0
+    "total_tax": 17867.0,
+    "amti": 104250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -18460,7 +20555,9 @@
     "addl_medicare": 204.34499999999997,
     "amt": 0.0,
     "income_tax": 23220.06896,
-    "total_tax": 27663.278960000003
+    "total_tax": 27663.278960000003,
+    "amti": 126554.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": null
   },
@@ -18486,7 +20583,9 @@
     "addl_medicare": 453.68999999999994,
     "amt": 0.0,
     "income_tax": 28573.13792,
-    "total_tax": 37504.55792000001
+    "total_tax": 37504.55792000001,
+    "amti": 148858.908,
+    "qbi_deduction": 11152.227
    },
    "expected_spouse_attr": null
   },
@@ -18512,7 +20611,9 @@
     "addl_medicare": 1201.725,
     "amt": 0.0,
     "income_tax": 56667.22000000001,
-    "total_tax": 68842.57
+    "total_tax": 68842.57,
+    "amti": 248763.1875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -18538,7 +20639,9 @@
     "addl_medicare": 2448.45,
     "amt": 0.0,
     "income_tax": 108830.44275,
-    "total_tax": 126269.74275
+    "total_tax": 126269.74275,
+    "amti": 396754.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -18564,7 +20667,9 @@
     "addl_medicare": 459.9,
     "amt": 0.0,
     "income_tax": 31331.0,
-    "total_tax": 31790.9
+    "total_tax": 31790.9,
+    "amti": 160350.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -18590,7 +20695,9 @@
     "addl_medicare": 709.2449999999999,
     "amt": 0.0,
     "income_tax": 37013.86928,
-    "total_tax": 38526.55928
+    "total_tax": 38526.55928,
+    "amti": 184028.622,
+    "qbi_deduction": 5919.655500000001
    },
    "expected_spouse_attr": null
   },
@@ -18616,7 +20723,9 @@
     "addl_medicare": 958.5899999999999,
     "amt": 0.0,
     "income_tax": 45214.97493327107,
-    "total_tax": 47780.45493327107
+    "total_tax": 47780.45493327107,
+    "amti": 212974.9216664721,
+    "qbi_deduction": 6571.633333527902
    },
    "expected_spouse_attr": null
   },
@@ -18642,7 +20751,9 @@
     "addl_medicare": 1706.625,
     "amt": 0.0,
     "income_tax": 77466.735625,
-    "total_tax": 83190.585625
+    "total_tax": 83190.585625,
+    "amti": 308341.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -18668,7 +20779,9 @@
     "addl_medicare": 2953.35,
     "amt": 0.0,
     "income_tax": 130874.37675000001,
-    "total_tax": 141862.17675
+    "total_tax": 141862.17675,
+    "amti": 456332.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -18694,7 +20807,9 @@
     "addl_medicare": 742.5,
     "amt": 0.0,
     "income_tax": 38867.0,
-    "total_tax": 39609.5
+    "total_tax": 39609.5,
+    "amti": 191750.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -18720,7 +20835,9 @@
     "addl_medicare": 991.845,
     "amt": 0.0,
     "income_tax": 46911.247156277765,
-    "total_tax": 48706.537156277765
+    "total_tax": 48706.537156277765,
+    "amti": 218275.772363368,
+    "qbi_deduction": 3072.505136631976
    },
    "expected_spouse_attr": null
   },
@@ -18746,7 +20863,9 @@
     "addl_medicare": 1241.19,
     "amt": 0.0,
     "income_tax": 57378.54425,
-    "total_tax": 60226.62425
+    "total_tax": 60226.62425,
+    "amti": 250946.555,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -18772,7 +20891,9 @@
     "addl_medicare": 1989.225,
     "amt": 0.0,
     "income_tax": 88456.735625,
-    "total_tax": 94463.18562500001
+    "total_tax": 94463.18562500001,
+    "amti": 339741.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -18798,7 +20919,9 @@
     "addl_medicare": 3235.95,
     "amt": 0.0,
     "income_tax": 142492.37675,
-    "total_tax": 153762.77675000002
+    "total_tax": 153762.77675000002,
+    "amti": 487732.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -18824,7 +20947,9 @@
     "addl_medicare": 1215.0,
     "amt": 0.0,
     "income_tax": 55223.0,
-    "total_tax": 56438.0
+    "total_tax": 56438.0,
+    "amti": 244250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -18850,7 +20975,9 @@
     "addl_medicare": 1464.345,
     "amt": 0.0,
     "income_tax": 65394.14712500001,
-    "total_tax": 67661.93712500001
+    "total_tax": 67661.93712500001,
+    "amti": 273848.2775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -18876,7 +21003,9 @@
     "addl_medicare": 1713.69,
     "amt": 0.0,
     "income_tax": 75753.54424999999,
-    "total_tax": 79074.12425
+    "total_tax": 79074.12425,
+    "amti": 303446.555,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -18902,7 +21031,9 @@
     "addl_medicare": 2461.725,
     "amt": 0.0,
     "income_tax": 107160.563375,
-    "total_tax": 113639.51337500001
+    "total_tax": 113639.51337500001,
+    "amti": 392241.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -18928,7 +21059,9 @@
     "addl_medicare": 3708.45,
     "amt": 0.0,
     "income_tax": 161917.37675,
-    "total_tax": 173660.27675000002
+    "total_tax": 173660.27675000002,
+    "amti": 540232.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -18954,7 +21087,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 104203.75,
-    "total_tax": 106678.75
+    "total_tax": 106678.75,
+    "amti": 384250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -18980,7 +21115,9 @@
     "addl_medicare": 2724.345,
     "amt": 0.0,
     "income_tax": 115155.11267500001,
-    "total_tax": 118682.90267500002
+    "total_tax": 118682.90267500002,
+    "amti": 413848.2775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19006,7 +21143,9 @@
     "addl_medicare": 2973.69,
     "amt": 0.0,
     "income_tax": 126106.47535,
-    "total_tax": 130687.05535
+    "total_tax": 130687.05535,
+    "amti": 443446.555,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19032,7 +21171,9 @@
     "addl_medicare": 3721.725,
     "amt": 0.0,
     "income_tax": 158960.56337499997,
-    "total_tax": 166699.51337499998
+    "total_tax": 166699.51337499998,
+    "amti": 532241.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19058,7 +21199,9 @@
     "addl_medicare": 4968.45,
     "amt": 0.0,
     "income_tax": 213717.37675,
-    "total_tax": 226720.27675000002
+    "total_tax": 226720.27675000002,
+    "amti": 680232.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19084,7 +21227,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 340.4454000000005,
-    "total_tax": 4579.3104
+    "total_tax": 4579.3104,
+    "amti": 3404.4540000000015,
+    "qbi_deduction": 851.1135000000003
    },
    "expected_spouse_attr": null
   },
@@ -19110,7 +21255,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2745.0689600000005,
-    "total_tax": 11222.79896
+    "total_tax": 11222.79896,
+    "amti": 25708.908000000003,
+    "qbi_deduction": 6427.227000000001
    },
    "expected_spouse_attr": null
   },
@@ -19136,7 +21283,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 13551.899399999995,
-    "total_tax": 34746.22439999999
+    "total_tax": 34746.22439999999,
+    "amti": 92622.26999999999,
+    "qbi_deduction": 23155.5675
    },
    "expected_spouse_attr": null
   },
@@ -19162,7 +21311,9 @@
     "addl_medicare": 693.4499999999999,
     "amt": 0.0,
     "income_tax": 59312.85125000001,
-    "total_tax": 89877.15125000001
+    "total_tax": 89877.15125000001,
+    "amti": 261439.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19188,7 +21339,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2825.0,
-    "total_tax": 2825.0
+    "total_tax": 2825.0,
+    "amti": 26375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19214,7 +21367,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5501.53448,
-    "total_tax": 9740.39948
+    "total_tax": 9740.39948,
+    "amti": 48679.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": null
   },
@@ -19240,7 +21395,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 8791.459760000002,
-    "total_tax": 17269.18976
+    "total_tax": 17269.18976,
+    "amti": 70983.908,
+    "qbi_deduction": 11152.227
    },
    "expected_spouse_attr": null
   },
@@ -19266,7 +21423,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 24351.251999999993,
-    "total_tax": 44004.87699999999
+    "total_tax": 44004.87699999999,
+    "amti": 138513.55,
+    "qbi_deduction": 28034.6375
    },
    "expected_spouse_attr": null
   },
@@ -19292,7 +21451,9 @@
     "addl_medicare": 1143.4499999999998,
     "amt": 0.0,
     "income_tax": 77897.85125,
-    "total_tax": 102712.15125000001
+    "total_tax": 102712.15125000001,
+    "amti": 314539.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19318,7 +21479,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 14377.5,
-    "total_tax": 14377.5
+    "total_tax": 14377.5,
+    "amti": 96375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19344,7 +21507,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 19591.068960000004,
-    "total_tax": 23829.933960000002
+    "total_tax": 23829.933960000002,
+    "amti": 118679.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": null
   },
@@ -19370,7 +21535,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 24944.137920000005,
-    "total_tax": 33421.867920000004
+    "total_tax": 33421.867920000004,
+    "amti": 140983.908,
+    "qbi_deduction": 11152.227
    },
    "expected_spouse_attr": null
   },
@@ -19396,7 +21563,9 @@
     "addl_medicare": 526.7249999999999,
     "amt": 0.0,
     "income_tax": 51222.182928605,
-    "total_tax": 62722.532928605
+    "total_tax": 62722.532928605,
+    "amti": 237181.8216518906,
+    "qbi_deduction": 3706.365848109377
    },
    "expected_spouse_attr": null
   },
@@ -19422,7 +21591,9 @@
     "addl_medicare": 1773.4499999999998,
     "amt": 0.0,
     "income_tax": 103916.85125,
-    "total_tax": 120681.15125000001
+    "total_tax": 120681.15125000001,
+    "amti": 388879.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19448,7 +21619,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 27702.0,
-    "total_tax": 27702.0
+    "total_tax": 27702.0,
+    "amti": 152475.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19474,7 +21647,9 @@
     "addl_medicare": 34.245,
     "amt": 0.0,
     "income_tax": 33384.86928,
-    "total_tax": 34222.55928
+    "total_tax": 34222.55928,
+    "amti": 176153.622,
+    "qbi_deduction": 5919.655500000001
    },
    "expected_spouse_attr": null
   },
@@ -19500,7 +21675,9 @@
     "addl_medicare": 283.59,
     "amt": 0.0,
     "income_tax": 40359.273658871076,
-    "total_tax": 42249.75365887107
+    "total_tax": 42249.75365887107,
+    "amti": 203235.2301839721,
+    "qbi_deduction": 8436.324816027904
    },
    "expected_spouse_attr": null
   },
@@ -19526,7 +21703,9 @@
     "addl_medicare": 1031.625,
     "amt": 0.0,
     "income_tax": 72972.235625,
-    "total_tax": 78021.085625
+    "total_tax": 78021.085625,
+    "amti": 300466.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19552,7 +21731,9 @@
     "addl_medicare": 2278.35,
     "amt": 0.0,
     "income_tax": 124769.22124999999,
-    "total_tax": 135082.02125
+    "total_tax": 135082.02125,
+    "amti": 448457.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19578,7 +21759,9 @@
     "addl_medicare": 67.5,
     "amt": 0.0,
     "income_tax": 35238.0,
-    "total_tax": 35305.5
+    "total_tax": 35305.5,
+    "amti": 183875.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19604,7 +21787,9 @@
     "addl_medicare": 316.84499999999997,
     "amt": 0.0,
     "income_tax": 42353.89651907777,
-    "total_tax": 43474.18651907777
+    "total_tax": 43474.18651907777,
+    "amti": 209468.42662211802,
+    "qbi_deduction": 4004.850877881976
    },
    "expected_spouse_attr": null
   },
@@ -19630,7 +21815,9 @@
     "addl_medicare": 566.1899999999999,
     "amt": 0.0,
     "income_tax": 52786.501597431066,
-    "total_tax": 54959.58159743107
+    "total_tax": 54959.58159743107,
+    "amti": 242070.31749197212,
+    "qbi_deduction": 1001.2375080279016
    },
    "expected_spouse_attr": null
   },
@@ -19656,7 +21843,9 @@
     "addl_medicare": 1314.225,
     "amt": 0.0,
     "income_tax": 83962.235625,
-    "total_tax": 89293.68562500001
+    "total_tax": 89293.68562500001,
+    "amti": 331866.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19682,7 +21871,9 @@
     "addl_medicare": 2560.95,
     "amt": 0.0,
     "income_tax": 135759.22125,
-    "total_tax": 146354.62125000003
+    "total_tax": 146354.62125000003,
+    "amti": 479857.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19708,7 +21899,9 @@
     "addl_medicare": 540.0,
     "amt": 0.0,
     "income_tax": 50964.0,
-    "total_tax": 51504.0
+    "total_tax": 51504.0,
+    "amti": 236375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19734,7 +21927,9 @@
     "addl_medicare": 789.345,
     "amt": 0.0,
     "income_tax": 60899.64712500001,
-    "total_tax": 62492.43712500001
+    "total_tax": 62492.43712500001,
+    "amti": 265973.2775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19760,7 +21955,9 @@
     "addl_medicare": 1038.69,
     "amt": 0.0,
     "income_tax": 71259.04424999999,
-    "total_tax": 73904.62425
+    "total_tax": 73904.62425,
+    "amti": 295571.555,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19786,7 +21983,9 @@
     "addl_medicare": 1786.725,
     "amt": 0.0,
     "income_tax": 102337.235625,
-    "total_tax": 108141.18562500001
+    "total_tax": 108141.18562500001,
+    "amti": 384366.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19812,7 +22011,9 @@
     "addl_medicare": 3033.45,
     "amt": 0.0,
     "income_tax": 154134.22125,
-    "total_tax": 165202.12125000003
+    "total_tax": 165202.12125000003,
+    "amti": 532357.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19838,7 +22039,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 99540.25,
-    "total_tax": 101340.25
+    "total_tax": 101340.25,
+    "amti": 376375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19864,7 +22067,9 @@
     "addl_medicare": 2049.345,
     "amt": 0.0,
     "income_tax": 109899.647125,
-    "total_tax": 112752.43712500001
+    "total_tax": 112752.43712500001,
+    "amti": 405973.2775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19890,7 +22095,9 @@
     "addl_medicare": 2298.6899999999996,
     "amt": 0.0,
     "income_tax": 120259.04424999999,
-    "total_tax": 124164.62425
+    "total_tax": 124164.62425,
+    "amti": 435571.555,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19916,7 +22123,9 @@
     "addl_medicare": 3046.7249999999995,
     "amt": 0.0,
     "income_tax": 151337.23562499997,
-    "total_tax": 158401.18562499998
+    "total_tax": 158401.18562499998,
+    "amti": 524366.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19942,7 +22151,9 @@
     "addl_medicare": 4293.45,
     "amt": 0.0,
     "income_tax": 204054.37675,
-    "total_tax": 216382.27675000002
+    "total_tax": 216382.27675000002,
+    "amti": 672357.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19968,7 +22179,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 0.0,
-    "total_tax": 4238.865
+    "total_tax": 4238.865,
+    "amti": -3619.432499999999,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -19994,7 +22207,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1940.890800000001,
-    "total_tax": 10418.6208
+    "total_tax": 10418.6208,
+    "amti": 19408.908000000003,
+    "qbi_deduction": 4852.227000000001
    },
    "expected_spouse_attr": null
   },
@@ -20020,7 +22235,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 9881.6724,
-    "total_tax": 31075.997399999997
+    "total_tax": 31075.997399999997,
+    "amti": 86322.26999999999,
+    "qbi_deduction": 21580.5675
    },
    "expected_spouse_attr": null
   },
@@ -20046,7 +22263,9 @@
     "addl_medicare": 693.4499999999999,
     "amt": 0.0,
     "income_tax": 40565.13623676672,
-    "total_tax": 71129.43623676672
+    "total_tax": 71129.43623676672,
+    "amti": 228629.73431986128,
+    "qbi_deduction": 24934.840680138743
    },
    "expected_spouse_attr": null
   },
@@ -20072,7 +22291,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1850.0,
-    "total_tax": 1850.0
+    "total_tax": 1850.0,
+    "amti": 18500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20098,7 +22319,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 4419.53448,
-    "total_tax": 8658.39948
+    "total_tax": 8658.39948,
+    "amti": 40804.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": null
   },
@@ -20124,7 +22347,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7096.0689600000005,
-    "total_tax": 15573.79896
+    "total_tax": 15573.79896,
+    "amti": 63108.907999999996,
+    "qbi_deduction": 11152.227
    },
    "expected_spouse_attr": null
   },
@@ -20150,7 +22375,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 18568.481,
-    "total_tax": 38222.106
+    "total_tax": 38222.106,
+    "amti": 130638.54999999999,
+    "qbi_deduction": 28034.6375
    },
    "expected_spouse_attr": null
   },
@@ -20176,7 +22403,9 @@
     "addl_medicare": 1143.4499999999998,
     "amt": 0.0,
     "income_tax": 59293.49800000001,
-    "total_tax": 84107.798
+    "total_tax": 84107.798,
+    "amti": 306664.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20202,7 +22431,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10143.0,
-    "total_tax": 10143.0
+    "total_tax": 10143.0,
+    "amti": 88500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20228,7 +22459,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 14204.979879999997,
-    "total_tax": 18443.844879999997
+    "total_tax": 18443.844879999997,
+    "amti": 110804.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": null
   },
@@ -20254,7 +22487,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 19111.959759999998,
-    "total_tax": 27589.689759999997
+    "total_tax": 27589.689759999997,
+    "amti": 133108.908,
+    "qbi_deduction": 11152.227
    },
    "expected_spouse_attr": null
   },
@@ -20280,7 +22515,9 @@
     "addl_medicare": 526.7249999999999,
     "amt": 0.0,
     "income_tax": 37157.82474947688,
-    "total_tax": 48658.17474947688
+    "total_tax": 48658.17474947688,
+    "amti": 214432.60312282032,
+    "qbi_deduction": 18580.584377179686
    },
    "expected_spouse_attr": null
   },
@@ -20306,7 +22543,9 @@
     "addl_medicare": 1773.4499999999998,
     "amt": 0.0,
     "income_tax": 77135.098,
-    "total_tax": 93899.398
+    "total_tax": 93899.398,
+    "amti": 381004.575,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20332,7 +22571,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 21640.0,
-    "total_tax": 21640.0
+    "total_tax": 21640.0,
+    "amti": 144600.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20358,7 +22599,9 @@
     "addl_medicare": 34.245,
     "amt": 0.0,
     "income_tax": 26849.296840000003,
-    "total_tax": 27686.98684
+    "total_tax": 27686.98684,
+    "amti": 168278.622,
+    "qbi_deduction": 5919.655500000001
    },
    "expected_spouse_attr": null
   },
@@ -20384,7 +22627,9 @@
     "addl_medicare": 283.59,
     "amt": 0.0,
     "income_tax": 32227.80609716193,
-    "total_tax": 34118.28609716193
+    "total_tax": 34118.28609716193,
+    "amti": 192726.39135073603,
+    "qbi_deduction": 11070.163649263952
    },
    "expected_spouse_attr": null
   },
@@ -20410,7 +22655,9 @@
     "addl_medicare": 1031.625,
     "amt": 0.0,
     "income_tax": 55581.45263340408,
-    "total_tax": 60630.30263340408
+    "total_tax": 60630.30263340408,
+    "amti": 291197.71930585033,
+    "qbi_deduction": 1393.6681941496827
    },
    "expected_spouse_attr": null
   },
@@ -20436,7 +22683,9 @@
     "addl_medicare": 2278.35,
     "amt": 0.0,
     "income_tax": 95112.48800000001,
-    "total_tax": 105425.28800000002
+    "total_tax": 105425.28800000002,
+    "amti": 440582.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20462,7 +22711,9 @@
     "addl_medicare": 67.5,
     "amt": 0.0,
     "income_tax": 28548.0,
-    "total_tax": 28615.5
+    "total_tax": 28615.5,
+    "amti": 176000.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20488,7 +22739,9 @@
     "addl_medicare": 316.84499999999997,
     "amt": 0.0,
     "income_tax": 33865.36731689548,
-    "total_tax": 34985.65731689548
+    "total_tax": 34985.65731689548,
+    "amti": 200169.851440434,
+    "qbi_deduction": 5428.426059565988
    },
    "expected_spouse_attr": null
   },
@@ -20514,7 +22767,9 @@
     "addl_medicare": 566.1899999999999,
     "amt": 0.0,
     "income_tax": 40376.54440113665,
-    "total_tax": 42549.62440113665
+    "total_tax": 42549.62440113665,
+    "amti": 227843.93500473603,
+    "qbi_deduction": 7352.619995263952
    },
    "expected_spouse_attr": null
   },
@@ -20540,7 +22795,9 @@
     "addl_medicare": 1314.225,
     "amt": 0.0,
     "income_tax": 63451.933000000005,
-    "total_tax": 68783.38300000002
+    "total_tax": 68783.38300000002,
+    "amti": 323991.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20566,7 +22823,9 @@
     "addl_medicare": 2560.95,
     "amt": 0.0,
     "income_tax": 105160.48800000001,
-    "total_tax": 115755.888
+    "total_tax": 115755.888,
+    "amti": 471982.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20592,7 +22851,9 @@
     "addl_medicare": 540.0,
     "amt": 0.0,
     "income_tax": 40534.0,
-    "total_tax": 41074.0
+    "total_tax": 41074.0,
+    "amti": 228500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20618,7 +22879,9 @@
     "addl_medicare": 789.345,
     "amt": 0.0,
     "income_tax": 47080.64093870417,
-    "total_tax": 48673.43093870417
+    "total_tax": 48673.43093870417,
+    "amti": 255777.670577934,
+    "qbi_deduction": 2320.606922065986
    },
    "expected_spouse_attr": null
   },
@@ -20644,7 +22907,9 @@
     "addl_medicare": 1038.69,
     "amt": 0.0,
     "income_tax": 54468.29758713665,
-    "total_tax": 57113.87758713665
+    "total_tax": 57113.87758713665,
+    "amti": 286559.57327973604,
+    "qbi_deduction": 1136.9817202639515
    },
    "expected_spouse_attr": null
   },
@@ -20670,7 +22935,9 @@
     "addl_medicare": 1786.725,
     "amt": 0.0,
     "income_tax": 76051.933,
-    "total_tax": 81855.88300000002
+    "total_tax": 81855.88300000002,
+    "amti": 376491.3875,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20696,7 +22963,9 @@
     "addl_medicare": 3033.45,
     "amt": 0.0,
     "income_tax": 122663.47125,
-    "total_tax": 133731.37125
+    "total_tax": 133731.37125,
+    "amti": 524482.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20722,7 +22991,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 74134.0,
-    "total_tax": 75934.0
+    "total_tax": 75934.0,
+    "amti": 368500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20748,7 +23019,9 @@
     "addl_medicare": 2049.345,
     "amt": 0.0,
     "income_tax": 81517.44880000001,
-    "total_tax": 84370.23880000002
+    "total_tax": 84370.23880000002,
+    "amti": 398098.2775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20774,7 +23047,9 @@
     "addl_medicare": 2298.6899999999996,
     "amt": 0.0,
     "income_tax": 90988.8976,
-    "total_tax": 94894.4776
+    "total_tax": 94894.4776,
+    "amti": 427696.555,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20800,7 +23075,9 @@
     "addl_medicare": 3046.7249999999995,
     "amt": 0.0,
     "income_tax": 119866.48562499999,
-    "total_tax": 126930.435625
+    "total_tax": 126930.435625,
+    "amti": 516491.38749999995,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20826,7 +23103,9 @@
     "addl_medicare": 4293.45,
     "amt": 0.0,
     "income_tax": 171663.47125,
-    "total_tax": 183991.37125000003
+    "total_tax": 183991.37125000003,
+    "amti": 664482.775,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20852,7 +23131,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5506.5,
-    "total_tax": 5506.5
+    "total_tax": 5506.5,
+    "amti": 59250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20878,7 +23159,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10756.5,
-    "total_tax": 10756.5
+    "total_tax": 10756.5,
+    "amti": 94250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20904,7 +23187,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 31756.5,
-    "total_tax": 33656.5
+    "total_tax": 33656.5,
+    "amti": 234250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20930,7 +23215,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7949.0,
-    "total_tax": 7949.0
+    "total_tax": 7949.0,
+    "amti": 59250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20956,7 +23243,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 11699.0,
-    "total_tax": 11699.0
+    "total_tax": 11699.0,
+    "amti": 84250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -20982,7 +23271,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 16949.0,
-    "total_tax": 16949.0
+    "total_tax": 16949.0,
+    "amti": 119250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21008,7 +23299,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 37949.0,
-    "total_tax": 40799.0
+    "total_tax": 40799.0,
+    "amti": 259250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21034,7 +23327,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 15649.0,
-    "total_tax": 15649.0
+    "total_tax": 15649.0,
+    "amti": 94250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21060,7 +23355,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 19399.0,
-    "total_tax": 19399.0
+    "total_tax": 19399.0,
+    "amti": 119250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21086,7 +23383,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 24649.0,
-    "total_tax": 24649.0
+    "total_tax": 24649.0,
+    "amti": 154250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21112,7 +23411,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 45649.0,
-    "total_tax": 49829.0
+    "total_tax": 49829.0,
+    "amti": 294250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21138,7 +23439,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 28817.0,
-    "total_tax": 28817.0
+    "total_tax": 28817.0,
+    "amti": 159250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21164,7 +23467,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 34067.0,
-    "total_tax": 34447.0
+    "total_tax": 34447.0,
+    "amti": 194250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21190,7 +23495,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 55067.0,
-    "total_tax": 60767.0
+    "total_tax": 60767.0,
+    "amti": 334250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21216,7 +23523,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 31067.0,
-    "total_tax": 31067.0
+    "total_tax": 31067.0,
+    "amti": 159250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21242,7 +23551,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 34817.0,
-    "total_tax": 34817.0
+    "total_tax": 34817.0,
+    "amti": 184250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21268,7 +23579,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 40067.0,
-    "total_tax": 41397.0
+    "total_tax": 41397.0,
+    "amti": 219250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21294,7 +23607,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 61067.0,
-    "total_tax": 67717.0
+    "total_tax": 67717.0,
+    "amti": 359250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21320,7 +23635,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 39467.0,
-    "total_tax": 39847.0
+    "total_tax": 39847.0,
+    "amti": 194250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21346,7 +23663,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 43217.0,
-    "total_tax": 44547.0
+    "total_tax": 44547.0,
+    "amti": 219250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21372,7 +23691,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 48467.0,
-    "total_tax": 51127.0
+    "total_tax": 51127.0,
+    "amti": 254250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21398,7 +23719,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 69467.0,
-    "total_tax": 77447.0
+    "total_tax": 77447.0,
+    "amti": 394250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21424,7 +23747,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 55773.0,
-    "total_tax": 57173.0
+    "total_tax": 57173.0,
+    "amti": 259250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21450,7 +23775,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 61023.0,
-    "total_tax": 63753.0
+    "total_tax": 63753.0,
+    "amti": 294250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21476,7 +23803,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 82023.0,
-    "total_tax": 90073.0
+    "total_tax": 90073.0,
+    "amti": 434250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21502,7 +23831,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 60284.75,
-    "total_tax": 61684.75
+    "total_tax": 61684.75,
+    "amti": 259250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21528,7 +23859,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 64034.75,
-    "total_tax": 66384.75
+    "total_tax": 66384.75,
+    "amti": 284250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21554,7 +23887,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 69284.75,
-    "total_tax": 72964.75
+    "total_tax": 72964.75,
+    "amti": 319250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21580,7 +23915,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 90284.75,
-    "total_tax": 99284.75
+    "total_tax": 99284.75,
+    "amti": 459250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21606,7 +23943,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 72534.75,
-    "total_tax": 75264.75
+    "total_tax": 75264.75,
+    "amti": 294250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21632,7 +23971,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 76284.75,
-    "total_tax": 79964.75
+    "total_tax": 79964.75,
+    "amti": 319250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21658,7 +23999,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 81534.75,
-    "total_tax": 86544.75
+    "total_tax": 86544.75,
+    "amti": 354250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21684,7 +24027,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 102534.75,
-    "total_tax": 112864.75
+    "total_tax": 112864.75,
+    "amti": 494250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21710,7 +24055,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 107784.75,
-    "total_tax": 110534.75
+    "total_tax": 110534.75,
+    "amti": 409250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21736,7 +24083,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 113034.75,
-    "total_tax": 117114.75
+    "total_tax": 117114.75,
+    "amti": 444250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21762,7 +24111,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 136577.25,
-    "total_tax": 145977.25
+    "total_tax": 145977.25,
+    "amti": 584250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21788,7 +24139,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 112784.75,
-    "total_tax": 115534.75
+    "total_tax": 115534.75,
+    "amti": 409250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21814,7 +24167,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 116534.75,
-    "total_tax": 120234.75
+    "total_tax": 120234.75,
+    "amti": 434250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21840,7 +24195,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 121784.75,
-    "total_tax": 126814.75
+    "total_tax": 126814.75,
+    "amti": 469250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21866,7 +24223,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 146577.25,
-    "total_tax": 156927.25
+    "total_tax": 156927.25,
+    "amti": 609250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21892,7 +24251,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 125034.75,
-    "total_tax": 129114.75
+    "total_tax": 129114.75,
+    "amti": 444250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21918,7 +24279,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 128784.75,
-    "total_tax": 133814.75
+    "total_tax": 133814.75,
+    "amti": 469250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21944,7 +24307,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 134034.75,
-    "total_tax": 140394.75
+    "total_tax": 140394.75,
+    "amti": 504250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21970,7 +24335,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 160577.25,
-    "total_tax": 172257.25
+    "total_tax": 172257.25,
+    "amti": 644250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -21996,7 +24363,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1850.0,
-    "total_tax": 1850.0
+    "total_tax": 1850.0,
+    "amti": 43500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 75000.0,
@@ -22006,7 +24375,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1850.0,
-    "total_tax": 1850.0
+    "total_tax": 1850.0,
+    "amti": 43500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22031,7 +24402,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1850.0,
-    "total_tax": 1850.0
+    "total_tax": 1850.0,
+    "amti": 78500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 110000.0,
@@ -22041,7 +24414,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1850.0,
-    "total_tax": 1850.0
+    "total_tax": 1850.0,
+    "amti": 78500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22066,7 +24441,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 20120.0,
-    "total_tax": 20120.0
+    "total_tax": 20120.0,
+    "amti": 218500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 250000.0,
@@ -22076,7 +24453,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 20120.0,
-    "total_tax": 20120.0
+    "total_tax": 20120.0,
+    "amti": 218500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22101,7 +24480,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 4743.0,
-    "total_tax": 4743.0
+    "total_tax": 4743.0,
+    "amti": 43500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 75000.0,
@@ -22111,7 +24492,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 4743.0,
-    "total_tax": 4743.0
+    "total_tax": 4743.0,
+    "amti": 43500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22136,7 +24519,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 4743.0,
-    "total_tax": 4743.0
+    "total_tax": 4743.0,
+    "amti": 68500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 100000.0,
@@ -22146,7 +24531,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 4743.0,
-    "total_tax": 4743.0
+    "total_tax": 4743.0,
+    "amti": 68500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22171,7 +24558,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5763.0,
-    "total_tax": 5763.0
+    "total_tax": 5763.0,
+    "amti": 103500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 135000.0,
@@ -22181,7 +24570,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5763.0,
-    "total_tax": 5763.0
+    "total_tax": 5763.0,
+    "amti": 103500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22206,7 +24597,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 26763.0,
-    "total_tax": 27713.0
+    "total_tax": 27713.0,
+    "amti": 243500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 275000.0,
@@ -22216,7 +24609,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 26763.0,
-    "total_tax": 27713.0
+    "total_tax": 27713.0,
+    "amti": 243500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22241,7 +24636,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 8943.0,
-    "total_tax": 8943.0
+    "total_tax": 8943.0,
+    "amti": 78500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 110000.0,
@@ -22251,7 +24648,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 8943.0,
-    "total_tax": 8943.0
+    "total_tax": 8943.0,
+    "amti": 78500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22276,7 +24675,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 9963.0,
-    "total_tax": 9963.0
+    "total_tax": 9963.0,
+    "amti": 103500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 135000.0,
@@ -22286,7 +24687,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 9963.0,
-    "total_tax": 9963.0
+    "total_tax": 9963.0,
+    "amti": 103500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22311,7 +24714,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 15213.0,
-    "total_tax": 15213.0
+    "total_tax": 15213.0,
+    "amti": 138500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 170000.0,
@@ -22321,7 +24726,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 15213.0,
-    "total_tax": 15213.0
+    "total_tax": 15213.0,
+    "amti": 138500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22346,7 +24753,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 36213.0,
-    "total_tax": 38493.0
+    "total_tax": 38493.0,
+    "amti": 278500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 310000.0,
@@ -22356,7 +24765,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 36213.0,
-    "total_tax": 38493.0
+    "total_tax": 38493.0,
+    "amti": 278500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22381,7 +24792,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 19648.0,
-    "total_tax": 19648.0
+    "total_tax": 19648.0,
+    "amti": 143500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 175000.0,
@@ -22391,7 +24804,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 19648.0,
-    "total_tax": 19648.0
+    "total_tax": 19648.0,
+    "amti": 143500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22416,7 +24831,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 24898.0,
-    "total_tax": 24898.0
+    "total_tax": 24898.0,
+    "amti": 178500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 210000.0,
@@ -22426,7 +24843,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 24898.0,
-    "total_tax": 24898.0
+    "total_tax": 24898.0,
+    "amti": 178500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22451,7 +24870,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 45898.0,
-    "total_tax": 49698.0
+    "total_tax": 49698.0,
+    "amti": 318500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 350000.0,
@@ -22461,7 +24882,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 45898.0,
-    "total_tax": 49698.0
+    "total_tax": 49698.0,
+    "amti": 318500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22486,7 +24909,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 21398.0,
-    "total_tax": 21398.0
+    "total_tax": 21398.0,
+    "amti": 143500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 175000.0,
@@ -22496,7 +24921,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 21398.0,
-    "total_tax": 21398.0
+    "total_tax": 21398.0,
+    "amti": 143500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22521,7 +24948,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 25148.0,
-    "total_tax": 25148.0
+    "total_tax": 25148.0,
+    "amti": 168500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 200000.0,
@@ -22531,7 +24960,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 25148.0,
-    "total_tax": 25148.0
+    "total_tax": 25148.0,
+    "amti": 168500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22556,7 +24987,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 30398.0,
-    "total_tax": 30398.0
+    "total_tax": 30398.0,
+    "amti": 203500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 235000.0,
@@ -22566,7 +24999,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 30398.0,
-    "total_tax": 30398.0
+    "total_tax": 30398.0,
+    "amti": 203500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22591,7 +25026,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 51398.0,
-    "total_tax": 56148.0
+    "total_tax": 56148.0,
+    "amti": 343500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 375000.0,
@@ -22601,7 +25038,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 51398.0,
-    "total_tax": 56148.0
+    "total_tax": 56148.0,
+    "amti": 343500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22626,7 +25065,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 29098.0,
-    "total_tax": 29098.0
+    "total_tax": 29098.0,
+    "amti": 178500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 210000.0,
@@ -22636,7 +25077,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 29098.0,
-    "total_tax": 29098.0
+    "total_tax": 29098.0,
+    "amti": 178500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22661,7 +25104,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 32848.0,
-    "total_tax": 32848.0
+    "total_tax": 32848.0,
+    "amti": 203500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 235000.0,
@@ -22671,7 +25116,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 32848.0,
-    "total_tax": 32848.0
+    "total_tax": 32848.0,
+    "amti": 203500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22696,7 +25143,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 38098.0,
-    "total_tax": 38858.0
+    "total_tax": 38858.0,
+    "amti": 238500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 270000.0,
@@ -22706,7 +25155,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 38098.0,
-    "total_tax": 38858.0
+    "total_tax": 38858.0,
+    "amti": 238500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22731,7 +25182,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 59098.0,
-    "total_tax": 65178.0
+    "total_tax": 65178.0,
+    "amti": 378500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 410000.0,
@@ -22741,7 +25194,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 59098.0,
-    "total_tax": 65178.0
+    "total_tax": 65178.0,
+    "amti": 378500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22766,7 +25221,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 41884.0,
-    "total_tax": 42834.0
+    "total_tax": 42834.0,
+    "amti": 243500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 275000.0,
@@ -22776,7 +25233,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 41884.0,
-    "total_tax": 42834.0
+    "total_tax": 42834.0,
+    "amti": 243500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22801,7 +25260,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 47134.0,
-    "total_tax": 49414.0
+    "total_tax": 49414.0,
+    "amti": 278500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 310000.0,
@@ -22811,7 +25272,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 47134.0,
-    "total_tax": 49414.0
+    "total_tax": 49414.0,
+    "amti": 278500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22836,7 +25299,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 68134.0,
-    "total_tax": 75734.0
+    "total_tax": 75734.0,
+    "amti": 418500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 450000.0,
@@ -22846,7 +25311,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 68134.0,
-    "total_tax": 75734.0
+    "total_tax": 75734.0,
+    "amti": 418500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22871,7 +25338,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 44134.0,
-    "total_tax": 45084.0
+    "total_tax": 45084.0,
+    "amti": 243500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 275000.0,
@@ -22881,7 +25350,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 44134.0,
-    "total_tax": 45084.0
+    "total_tax": 45084.0,
+    "amti": 243500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22906,7 +25377,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 47884.0,
-    "total_tax": 49784.0
+    "total_tax": 49784.0,
+    "amti": 268500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 300000.0,
@@ -22916,7 +25389,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 47884.0,
-    "total_tax": 49784.0
+    "total_tax": 49784.0,
+    "amti": 268500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22941,7 +25416,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 53134.0,
-    "total_tax": 56364.0
+    "total_tax": 56364.0,
+    "amti": 303500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 335000.0,
@@ -22951,7 +25428,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 53134.0,
-    "total_tax": 56364.0
+    "total_tax": 56364.0,
+    "amti": 303500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -22976,7 +25455,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 74134.0,
-    "total_tax": 82684.0
+    "total_tax": 82684.0,
+    "amti": 443500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 475000.0,
@@ -22986,7 +25467,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 74134.0,
-    "total_tax": 82684.0
+    "total_tax": 82684.0,
+    "amti": 443500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -23011,7 +25494,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 52534.0,
-    "total_tax": 54814.0
+    "total_tax": 54814.0,
+    "amti": 278500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 310000.0,
@@ -23021,7 +25506,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 52534.0,
-    "total_tax": 54814.0
+    "total_tax": 54814.0,
+    "amti": 278500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -23046,7 +25533,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 56284.0,
-    "total_tax": 59514.0
+    "total_tax": 59514.0,
+    "amti": 303500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 335000.0,
@@ -23056,7 +25545,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 56284.0,
-    "total_tax": 59514.0
+    "total_tax": 59514.0,
+    "amti": 303500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -23081,7 +25572,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 61534.0,
-    "total_tax": 66094.0
+    "total_tax": 66094.0,
+    "amti": 338500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 370000.0,
@@ -23091,7 +25584,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 61534.0,
-    "total_tax": 66094.0
+    "total_tax": 66094.0,
+    "amti": 338500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -23116,7 +25611,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 82534.0,
-    "total_tax": 92414.0
+    "total_tax": 92414.0,
+    "amti": 478500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 510000.0,
@@ -23126,7 +25623,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 82534.0,
-    "total_tax": 92414.0
+    "total_tax": 92414.0,
+    "amti": 478500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -23151,7 +25650,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 77884.0,
-    "total_tax": 80184.0
+    "total_tax": 80184.0,
+    "amti": 393500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 425000.0,
@@ -23161,7 +25662,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 77884.0,
-    "total_tax": 80184.0
+    "total_tax": 80184.0,
+    "amti": 393500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -23186,7 +25689,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 83134.0,
-    "total_tax": 86764.0
+    "total_tax": 86764.0,
+    "amti": 428500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 460000.0,
@@ -23196,7 +25701,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 83134.0,
-    "total_tax": 86764.0
+    "total_tax": 86764.0,
+    "amti": 428500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -23221,7 +25728,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 104134.0,
-    "total_tax": 113084.0
+    "total_tax": 113084.0,
+    "amti": 568500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 600000.0,
@@ -23231,7 +25740,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 104134.0,
-    "total_tax": 113084.0
+    "total_tax": 113084.0,
+    "amti": 568500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -23256,7 +25767,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 80134.0,
-    "total_tax": 82434.0
+    "total_tax": 82434.0,
+    "amti": 393500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 425000.0,
@@ -23266,7 +25779,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 80134.0,
-    "total_tax": 82434.0
+    "total_tax": 82434.0,
+    "amti": 393500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -23291,7 +25806,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 83884.0,
-    "total_tax": 87134.0
+    "total_tax": 87134.0,
+    "amti": 418500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 450000.0,
@@ -23301,7 +25818,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 83884.0,
-    "total_tax": 87134.0
+    "total_tax": 87134.0,
+    "amti": 418500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -23326,7 +25845,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 89134.0,
-    "total_tax": 93714.0
+    "total_tax": 93714.0,
+    "amti": 453500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 485000.0,
@@ -23336,7 +25857,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 89134.0,
-    "total_tax": 93714.0
+    "total_tax": 93714.0,
+    "amti": 453500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -23361,7 +25884,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 110134.0,
-    "total_tax": 120034.0
+    "total_tax": 120034.0,
+    "amti": 593500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 625000.0,
@@ -23371,7 +25896,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 110134.0,
-    "total_tax": 120034.0
+    "total_tax": 120034.0,
+    "amti": 593500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -23396,7 +25923,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 91246.0,
-    "total_tax": 94876.0
+    "total_tax": 94876.0,
+    "amti": 428500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 460000.0,
@@ -23406,7 +25935,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 91246.0,
-    "total_tax": 94876.0
+    "total_tax": 94876.0,
+    "amti": 428500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -23431,7 +25962,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 94996.0,
-    "total_tax": 99576.0
+    "total_tax": 99576.0,
+    "amti": 453500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 485000.0,
@@ -23441,7 +25974,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 94996.0,
-    "total_tax": 99576.0
+    "total_tax": 99576.0,
+    "amti": 453500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -23466,7 +26001,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 100246.0,
-    "total_tax": 106156.0
+    "total_tax": 106156.0,
+    "amti": 488500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 520000.0,
@@ -23476,7 +26013,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 100246.0,
-    "total_tax": 106156.0
+    "total_tax": 106156.0,
+    "amti": 488500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -23501,7 +26040,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 122668.5,
-    "total_tax": 133898.5
+    "total_tax": 133898.5,
+    "amti": 628500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 660000.0,
@@ -23511,7 +26052,9 @@
     "addl_medicare": 1350.0,
     "amt": 0.0,
     "income_tax": 122668.5,
-    "total_tax": 133898.5
+    "total_tax": 133898.5,
+    "amti": 628500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -23536,7 +26079,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5506.5,
-    "total_tax": 5506.5
+    "total_tax": 5506.5,
+    "amti": 59250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -23562,7 +26107,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10756.5,
-    "total_tax": 10756.5
+    "total_tax": 10756.5,
+    "amti": 94250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -23588,7 +26135,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 31756.5,
-    "total_tax": 36506.5
+    "total_tax": 36506.5,
+    "amti": 234250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -23614,7 +26163,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7949.0,
-    "total_tax": 7949.0
+    "total_tax": 7949.0,
+    "amti": 59250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -23640,7 +26191,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 11699.0,
-    "total_tax": 11699.0
+    "total_tax": 11699.0,
+    "amti": 84250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -23666,7 +26219,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 16949.0,
-    "total_tax": 17329.0
+    "total_tax": 17329.0,
+    "amti": 119250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -23692,7 +26247,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 37949.0,
-    "total_tax": 43649.0
+    "total_tax": 43649.0,
+    "amti": 259250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -23718,7 +26275,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 15649.0,
-    "total_tax": 15649.0
+    "total_tax": 15649.0,
+    "amti": 94250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -23744,7 +26303,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 19399.0,
-    "total_tax": 19779.0
+    "total_tax": 19779.0,
+    "amti": 119250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -23770,7 +26331,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 24649.0,
-    "total_tax": 26359.0
+    "total_tax": 26359.0,
+    "amti": 154250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -23796,7 +26359,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 45649.0,
-    "total_tax": 52679.0
+    "total_tax": 52679.0,
+    "amti": 294250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -23822,7 +26387,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 28817.0,
-    "total_tax": 29992.0
+    "total_tax": 29992.0,
+    "amti": 159250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -23848,7 +26415,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 34067.0,
-    "total_tax": 36572.0
+    "total_tax": 36572.0,
+    "amti": 194250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -23874,7 +26443,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 56779.5,
-    "total_tax": 64604.5
+    "total_tax": 64604.5,
+    "amti": 334250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -23900,7 +26471,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 31067.0,
-    "total_tax": 32242.0
+    "total_tax": 32242.0,
+    "amti": 159250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -23926,7 +26499,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 34817.0,
-    "total_tax": 36942.0
+    "total_tax": 36942.0,
+    "amti": 184250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -23952,7 +26527,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 40067.0,
-    "total_tax": 43522.0
+    "total_tax": 43522.0,
+    "amti": 219250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -23978,7 +26555,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 64029.5,
-    "total_tax": 72804.5
+    "total_tax": 72804.5,
+    "amti": 359250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24004,7 +26583,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 39467.0,
-    "total_tax": 41972.0
+    "total_tax": 41972.0,
+    "amti": 194250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24030,7 +26611,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 43217.0,
-    "total_tax": 46672.0
+    "total_tax": 46672.0,
+    "amti": 219250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24056,7 +26639,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 48467.0,
-    "total_tax": 53252.0
+    "total_tax": 53252.0,
+    "amti": 254250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24082,7 +26667,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 0.0,
     "income_tax": 74179.5,
-    "total_tax": 84284.5
+    "total_tax": 84284.5,
+    "amti": 394250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24108,7 +26695,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 55773.0,
-    "total_tax": 57848.0
+    "total_tax": 57848.0,
+    "amti": 259250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24134,7 +26723,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 61023.0,
-    "total_tax": 64428.0
+    "total_tax": 64428.0,
+    "amti": 294250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24160,7 +26751,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 88735.5,
-    "total_tax": 97460.5
+    "total_tax": 97460.5,
+    "amti": 434250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24186,7 +26779,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 60284.75,
-    "total_tax": 62359.75
+    "total_tax": 62359.75,
+    "amti": 259250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24212,7 +26807,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 64034.75,
-    "total_tax": 67059.75
+    "total_tax": 67059.75,
+    "amti": 284250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24238,7 +26835,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 70247.25,
-    "total_tax": 74602.25
+    "total_tax": 74602.25,
+    "amti": 319250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24264,7 +26863,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 98247.25,
-    "total_tax": 107922.25
+    "total_tax": 107922.25,
+    "amti": 459250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24290,7 +26891,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 72534.75,
-    "total_tax": 75939.75
+    "total_tax": 75939.75,
+    "amti": 294250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24316,7 +26919,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 77247.25,
-    "total_tax": 81602.25
+    "total_tax": 81602.25,
+    "amti": 319250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24342,7 +26947,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 84247.25,
-    "total_tax": 89932.25
+    "total_tax": 89932.25,
+    "amti": 354250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24368,7 +26975,9 @@
     "addl_medicare": 1125.0,
     "amt": 0.0,
     "income_tax": 112247.25,
-    "total_tax": 123252.25
+    "total_tax": 123252.25,
+    "amti": 494250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24394,7 +27003,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 109203.75,
-    "total_tax": 112628.75
+    "total_tax": 112628.75,
+    "amti": 409250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24420,7 +27031,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 116203.75,
-    "total_tax": 120958.75
+    "total_tax": 120958.75,
+    "amti": 444250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24446,7 +27059,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 144203.75,
-    "total_tax": 154278.75
+    "total_tax": 154278.75,
+    "amti": 584250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24472,7 +27087,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 113453.75,
-    "total_tax": 116878.75
+    "total_tax": 116878.75,
+    "amti": 409250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24498,7 +27115,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 118453.75,
-    "total_tax": 122828.75
+    "total_tax": 122828.75,
+    "amti": 434250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24524,7 +27143,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 125453.75,
-    "total_tax": 131158.75
+    "total_tax": 131158.75,
+    "amti": 469250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24550,7 +27171,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 153453.75,
-    "total_tax": 164478.75
+    "total_tax": 164478.75,
+    "amti": 609250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24576,7 +27199,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 126403.75,
-    "total_tax": 131158.75
+    "total_tax": 131158.75,
+    "amti": 444250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24602,7 +27227,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 131403.75,
-    "total_tax": 137108.75
+    "total_tax": 137108.75,
+    "amti": 469250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24628,7 +27255,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 138403.75,
-    "total_tax": 145438.75
+    "total_tax": 145438.75,
+    "amti": 504250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24654,7 +27283,9 @@
     "addl_medicare": 2475.0,
     "amt": 0.0,
     "income_tax": 166403.75,
-    "total_tax": 178758.75
+    "total_tax": 178758.75,
+    "amti": 644250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24680,7 +27311,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2825.0,
-    "total_tax": 2825.0
+    "total_tax": 2825.0,
+    "amti": 51375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24706,7 +27339,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 6068.75,
-    "total_tax": 6068.75
+    "total_tax": 6068.75,
+    "amti": 86375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24732,7 +27367,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 27068.75,
-    "total_tax": 28968.75
+    "total_tax": 28968.75,
+    "amti": 226375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24758,7 +27395,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5825.0,
-    "total_tax": 5825.0
+    "total_tax": 5825.0,
+    "amti": 51375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24784,7 +27423,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7568.75,
-    "total_tax": 7568.75
+    "total_tax": 7568.75,
+    "amti": 76375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24810,7 +27451,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 12818.75,
-    "total_tax": 12818.75
+    "total_tax": 12818.75,
+    "amti": 111375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24836,7 +27479,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 33818.75,
-    "total_tax": 36668.75
+    "total_tax": 36668.75,
+    "amti": 251375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24862,7 +27507,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 12177.5,
-    "total_tax": 12177.5
+    "total_tax": 12177.5,
+    "amti": 86375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24888,7 +27535,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 15927.5,
-    "total_tax": 15927.5
+    "total_tax": 15927.5,
+    "amti": 111375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24914,7 +27563,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 21177.5,
-    "total_tax": 21177.5
+    "total_tax": 21177.5,
+    "amti": 146375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24940,7 +27591,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 42177.5,
-    "total_tax": 46357.5
+    "total_tax": 46357.5,
+    "amti": 286375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24966,7 +27619,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 25188.0,
-    "total_tax": 25188.0
+    "total_tax": 25188.0,
+    "amti": 151375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -24992,7 +27647,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 30438.0,
-    "total_tax": 30818.0
+    "total_tax": 30818.0,
+    "amti": 186375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25018,7 +27675,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 51438.0,
-    "total_tax": 57138.0
+    "total_tax": 57138.0,
+    "amti": 326375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25044,7 +27703,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 27438.0,
-    "total_tax": 27438.0
+    "total_tax": 27438.0,
+    "amti": 151375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25070,7 +27731,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 31188.0,
-    "total_tax": 31188.0
+    "total_tax": 31188.0,
+    "amti": 176375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25096,7 +27759,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 36438.0,
-    "total_tax": 37768.0
+    "total_tax": 37768.0,
+    "amti": 211375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25122,7 +27787,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 57438.0,
-    "total_tax": 64088.0
+    "total_tax": 64088.0,
+    "amti": 351375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25148,7 +27815,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 35838.0,
-    "total_tax": 36218.0
+    "total_tax": 36218.0,
+    "amti": 186375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25174,7 +27843,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 39588.0,
-    "total_tax": 40918.0
+    "total_tax": 40918.0,
+    "amti": 211375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25200,7 +27871,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 44838.0,
-    "total_tax": 47498.0
+    "total_tax": 47498.0,
+    "amti": 246375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25226,7 +27899,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 65838.0,
-    "total_tax": 73818.0
+    "total_tax": 73818.0,
+    "amti": 386375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25252,7 +27927,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 51514.0,
-    "total_tax": 52914.0
+    "total_tax": 52914.0,
+    "amti": 251375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25278,7 +27955,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 56764.0,
-    "total_tax": 59494.0
+    "total_tax": 59494.0,
+    "amti": 286375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25304,7 +27983,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 77764.0,
-    "total_tax": 85814.0
+    "total_tax": 85814.0,
+    "amti": 426375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25330,7 +28011,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 55790.25,
-    "total_tax": 57190.25
+    "total_tax": 57190.25,
+    "amti": 251375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25356,7 +28039,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 59540.25,
-    "total_tax": 61890.25
+    "total_tax": 61890.25,
+    "amti": 276375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25382,7 +28067,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 64790.25,
-    "total_tax": 68470.25
+    "total_tax": 68470.25,
+    "amti": 311375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25408,7 +28095,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 85790.25,
-    "total_tax": 94790.25
+    "total_tax": 94790.25,
+    "amti": 451375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25434,7 +28123,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 68040.25,
-    "total_tax": 70770.25
+    "total_tax": 70770.25,
+    "amti": 286375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25460,7 +28151,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 71790.25,
-    "total_tax": 75470.25
+    "total_tax": 75470.25,
+    "amti": 311375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25486,7 +28179,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 77040.25,
-    "total_tax": 82050.25
+    "total_tax": 82050.25,
+    "amti": 346375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25512,7 +28207,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 98040.25,
-    "total_tax": 108370.25
+    "total_tax": 108370.25,
+    "amti": 486375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25538,7 +28235,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 103290.25,
-    "total_tax": 106040.25
+    "total_tax": 106040.25,
+    "amti": 401375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25564,7 +28263,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 108540.25,
-    "total_tax": 112620.25
+    "total_tax": 112620.25,
+    "amti": 436375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25590,7 +28291,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 130024.0,
-    "total_tax": 139424.0
+    "total_tax": 139424.0,
+    "amti": 576375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25616,7 +28319,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 108290.25,
-    "total_tax": 111040.25
+    "total_tax": 111040.25,
+    "amti": 401375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25642,7 +28347,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 112040.25,
-    "total_tax": 115740.25
+    "total_tax": 115740.25,
+    "amti": 426375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25668,7 +28375,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 117290.25,
-    "total_tax": 122320.25
+    "total_tax": 122320.25,
+    "amti": 461375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25694,7 +28403,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 140024.0,
-    "total_tax": 150374.0
+    "total_tax": 150374.0,
+    "amti": 601375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25720,7 +28431,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 120540.25,
-    "total_tax": 124620.25
+    "total_tax": 124620.25,
+    "amti": 436375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25746,7 +28459,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 124290.25,
-    "total_tax": 129320.25
+    "total_tax": 129320.25,
+    "amti": 461375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25772,7 +28487,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 129540.25,
-    "total_tax": 135900.25
+    "total_tax": 135900.25,
+    "amti": 496375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25798,7 +28515,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 154024.0,
-    "total_tax": 165704.0
+    "total_tax": 165704.0,
+    "amti": 636375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25824,7 +28543,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1850.0,
-    "total_tax": 1850.0
+    "total_tax": 1850.0,
+    "amti": 43500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25850,7 +28571,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1850.0,
-    "total_tax": 1850.0
+    "total_tax": 1850.0,
+    "amti": 78500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25876,7 +28599,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 20120.0,
-    "total_tax": 20120.0
+    "total_tax": 20120.0,
+    "amti": 218500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25902,7 +28627,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 4743.0,
-    "total_tax": 4743.0
+    "total_tax": 4743.0,
+    "amti": 43500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25928,7 +28655,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 4743.0,
-    "total_tax": 4743.0
+    "total_tax": 4743.0,
+    "amti": 68500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25954,7 +28683,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5763.0,
-    "total_tax": 5763.0
+    "total_tax": 5763.0,
+    "amti": 103500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -25980,7 +28711,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 26763.0,
-    "total_tax": 27713.0
+    "total_tax": 27713.0,
+    "amti": 243500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26006,7 +28739,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 8943.0,
-    "total_tax": 8943.0
+    "total_tax": 8943.0,
+    "amti": 78500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26032,7 +28767,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 9963.0,
-    "total_tax": 9963.0
+    "total_tax": 9963.0,
+    "amti": 103500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26058,7 +28795,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 15213.0,
-    "total_tax": 15213.0
+    "total_tax": 15213.0,
+    "amti": 138500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26084,7 +28823,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 36213.0,
-    "total_tax": 38493.0
+    "total_tax": 38493.0,
+    "amti": 278500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26110,7 +28851,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 19648.0,
-    "total_tax": 19648.0
+    "total_tax": 19648.0,
+    "amti": 143500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26136,7 +28879,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 24898.0,
-    "total_tax": 24898.0
+    "total_tax": 24898.0,
+    "amti": 178500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26162,7 +28907,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 45898.0,
-    "total_tax": 49698.0
+    "total_tax": 49698.0,
+    "amti": 318500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26188,7 +28935,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 21398.0,
-    "total_tax": 21398.0
+    "total_tax": 21398.0,
+    "amti": 143500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26214,7 +28963,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 25148.0,
-    "total_tax": 25148.0
+    "total_tax": 25148.0,
+    "amti": 168500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26240,7 +28991,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 30398.0,
-    "total_tax": 30398.0
+    "total_tax": 30398.0,
+    "amti": 203500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26266,7 +29019,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 51398.0,
-    "total_tax": 56148.0
+    "total_tax": 56148.0,
+    "amti": 343500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26292,7 +29047,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 29098.0,
-    "total_tax": 29098.0
+    "total_tax": 29098.0,
+    "amti": 178500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26318,7 +29075,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 32848.0,
-    "total_tax": 32848.0
+    "total_tax": 32848.0,
+    "amti": 203500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26344,7 +29103,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 38098.0,
-    "total_tax": 38858.0
+    "total_tax": 38858.0,
+    "amti": 238500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26370,7 +29131,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 59098.0,
-    "total_tax": 65178.0
+    "total_tax": 65178.0,
+    "amti": 378500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26396,7 +29159,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 41884.0,
-    "total_tax": 43284.0
+    "total_tax": 43284.0,
+    "amti": 243500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26422,7 +29187,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 47134.0,
-    "total_tax": 49864.0
+    "total_tax": 49864.0,
+    "amti": 278500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26448,7 +29215,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 68134.0,
-    "total_tax": 76184.0
+    "total_tax": 76184.0,
+    "amti": 418500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26474,7 +29243,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 44134.0,
-    "total_tax": 45534.0
+    "total_tax": 45534.0,
+    "amti": 243500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26500,7 +29271,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 47884.0,
-    "total_tax": 50234.0
+    "total_tax": 50234.0,
+    "amti": 268500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26526,7 +29299,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 53134.0,
-    "total_tax": 56814.0
+    "total_tax": 56814.0,
+    "amti": 303500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26552,7 +29327,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 74134.0,
-    "total_tax": 83134.0
+    "total_tax": 83134.0,
+    "amti": 443500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26578,7 +29355,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 52534.0,
-    "total_tax": 55264.0
+    "total_tax": 55264.0,
+    "amti": 278500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26604,7 +29383,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 56284.0,
-    "total_tax": 59964.0
+    "total_tax": 59964.0,
+    "amti": 303500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26630,7 +29411,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 61534.0,
-    "total_tax": 66544.0
+    "total_tax": 66544.0,
+    "amti": 338500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26656,7 +29439,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 82534.0,
-    "total_tax": 92864.0
+    "total_tax": 92864.0,
+    "amti": 478500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26682,7 +29467,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 77884.0,
-    "total_tax": 80634.0
+    "total_tax": 80634.0,
+    "amti": 393500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26708,7 +29495,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 83134.0,
-    "total_tax": 87214.0
+    "total_tax": 87214.0,
+    "amti": 428500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26734,7 +29523,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 104134.0,
-    "total_tax": 113534.0
+    "total_tax": 113534.0,
+    "amti": 568500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26760,7 +29551,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 80134.0,
-    "total_tax": 82884.0
+    "total_tax": 82884.0,
+    "amti": 393500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26786,7 +29579,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 83884.0,
-    "total_tax": 87584.0
+    "total_tax": 87584.0,
+    "amti": 418500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26812,7 +29607,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 89134.0,
-    "total_tax": 94164.0
+    "total_tax": 94164.0,
+    "amti": 453500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26838,7 +29635,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 110134.0,
-    "total_tax": 120484.0
+    "total_tax": 120484.0,
+    "amti": 593500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26864,7 +29663,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 91246.0,
-    "total_tax": 95326.0
+    "total_tax": 95326.0,
+    "amti": 428500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26890,7 +29691,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 94996.0,
-    "total_tax": 100026.0
+    "total_tax": 100026.0,
+    "amti": 453500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26916,7 +29719,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 100246.0,
-    "total_tax": 106606.0
+    "total_tax": 106606.0,
+    "amti": 488500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26942,7 +29747,9 @@
     "addl_medicare": 1799.9999999999998,
     "amt": 0.0,
     "income_tax": 122668.5,
-    "total_tax": 134348.5
+    "total_tax": 134348.5,
+    "amti": 628500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26968,7 +29775,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 9049.0,
-    "total_tax": 9049.0
+    "total_tax": 9049.0,
+    "amti": 64250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -26994,7 +29803,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 8209.0,
-    "total_tax": 8209.0
+    "total_tax": 8209.0,
+    "amti": 64250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27020,7 +29831,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7456.5,
-    "total_tax": 7456.5
+    "total_tax": 7456.5,
+    "amti": 64250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27046,7 +29859,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 6256.5,
-    "total_tax": 6256.5
+    "total_tax": 6256.5,
+    "amti": 56250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27072,7 +29887,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 12349.0,
-    "total_tax": 12349.0
+    "total_tax": 12349.0,
+    "amti": 79250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27098,7 +29915,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 11509.0,
-    "total_tax": 11509.0
+    "total_tax": 11509.0,
+    "amti": 79250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27124,7 +29943,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 10949.0,
-    "total_tax": 10949.0
+    "total_tax": 10949.0,
+    "amti": 79250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27150,7 +29971,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 9749.0,
-    "total_tax": 9749.0
+    "total_tax": 9749.0,
+    "amti": 71250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27176,7 +29999,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 42423.0,
-    "total_tax": 43183.0
+    "total_tax": 43183.0,
+    "amti": 204250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27202,7 +30027,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 40787.0,
-    "total_tax": 41547.0
+    "total_tax": 41547.0,
+    "amti": 204250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27228,7 +30055,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 40067.0,
-    "total_tax": 40827.0
+    "total_tax": 40827.0,
+    "amti": 204250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27254,7 +30083,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 38867.0,
-    "total_tax": 39323.0
+    "total_tax": 39323.0,
+    "amti": 196250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27280,7 +30111,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 47223.0,
-    "total_tax": 48553.0
+    "total_tax": 48553.0,
+    "amti": 219250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27306,7 +30139,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 45183.0,
-    "total_tax": 46513.0
+    "total_tax": 46513.0,
+    "amti": 219250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27332,7 +30167,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 43823.0,
-    "total_tax": 45153.0
+    "total_tax": 45153.0,
+    "amti": 219250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27358,7 +30195,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 42623.0,
-    "total_tax": 43649.0
+    "total_tax": 43649.0,
+    "amti": 211250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27384,7 +30223,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 76034.75,
-    "total_tax": 77694.75
+    "total_tax": 77694.75,
+    "amti": 304250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27410,7 +30251,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 73634.75,
-    "total_tax": 75294.75
+    "total_tax": 75294.75,
+    "amti": 304250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27436,7 +30279,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 72034.75,
-    "total_tax": 73694.75
+    "total_tax": 73694.75,
+    "amti": 304250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27462,7 +30307,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 70834.75,
-    "total_tax": 72190.75
+    "total_tax": 72190.75,
+    "amti": 296250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27488,7 +30335,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 81284.75,
-    "total_tax": 83514.75
+    "total_tax": 83514.75,
+    "amti": 319250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27514,7 +30363,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 78884.75,
-    "total_tax": 81114.75
+    "total_tax": 81114.75,
+    "amti": 319250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27540,7 +30391,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 77284.75,
-    "total_tax": 79514.75
+    "total_tax": 79514.75,
+    "amti": 319250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27566,7 +30419,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 76084.75,
-    "total_tax": 78010.75
+    "total_tax": 78010.75,
+    "amti": 311250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -27592,7 +30447,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5343.0,
-    "total_tax": 5343.0
+    "total_tax": 5343.0,
+    "amti": 48500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 80000.0,
@@ -27602,7 +30459,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5343.0,
-    "total_tax": 5343.0
+    "total_tax": 5343.0,
+    "amti": 48500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -27627,7 +30486,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 3903.0,
-    "total_tax": 3903.0
+    "total_tax": 3903.0,
+    "amti": 48500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 80000.0,
@@ -27637,7 +30498,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 3903.0,
-    "total_tax": 3903.0
+    "total_tax": 3903.0,
+    "amti": 48500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -27662,7 +30525,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2943.0,
-    "total_tax": 2943.0
+    "total_tax": 2943.0,
+    "amti": 48500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 80000.0,
@@ -27672,7 +30537,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2943.0,
-    "total_tax": 2943.0
+    "total_tax": 2943.0,
+    "amti": 48500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -27697,7 +30564,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2943.0,
-    "total_tax": 2943.0
+    "total_tax": 2943.0,
+    "amti": 40500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 72000.0,
@@ -27707,7 +30576,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2943.0,
-    "total_tax": 2943.0
+    "total_tax": 2943.0,
+    "amti": 40500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -27732,7 +30603,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7143.0,
-    "total_tax": 7143.0
+    "total_tax": 7143.0,
+    "amti": 63500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 95000.0,
@@ -27742,7 +30615,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7143.0,
-    "total_tax": 7143.0
+    "total_tax": 7143.0,
+    "amti": 63500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -27767,7 +30642,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5703.0,
-    "total_tax": 5703.0
+    "total_tax": 5703.0,
+    "amti": 63500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 95000.0,
@@ -27777,7 +30654,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5703.0,
-    "total_tax": 5703.0
+    "total_tax": 5703.0,
+    "amti": 63500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -27802,7 +30681,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 4743.0,
-    "total_tax": 4743.0
+    "total_tax": 4743.0,
+    "amti": 63500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 95000.0,
@@ -27812,7 +30693,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 4743.0,
-    "total_tax": 4743.0
+    "total_tax": 4743.0,
+    "amti": 63500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -27837,7 +30720,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 4743.0,
-    "total_tax": 4743.0
+    "total_tax": 4743.0,
+    "amti": 55500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 87000.0,
@@ -27847,7 +30732,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 4743.0,
-    "total_tax": 4743.0
+    "total_tax": 4743.0,
+    "amti": 55500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -27872,7 +30759,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 31298.0,
-    "total_tax": 31298.0
+    "total_tax": 31298.0,
+    "amti": 188500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 220000.0,
@@ -27882,7 +30771,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 31298.0,
-    "total_tax": 31298.0
+    "total_tax": 31298.0,
+    "amti": 188500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -27907,7 +30798,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 30458.0,
-    "total_tax": 30458.0
+    "total_tax": 30458.0,
+    "amti": 188500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 220000.0,
@@ -27917,7 +30810,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 30458.0,
-    "total_tax": 30458.0
+    "total_tax": 30458.0,
+    "amti": 188500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -27942,7 +30837,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 29898.0,
-    "total_tax": 29898.0
+    "total_tax": 29898.0,
+    "amti": 188500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 220000.0,
@@ -27952,7 +30849,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 29898.0,
-    "total_tax": 29898.0
+    "total_tax": 29898.0,
+    "amti": 188500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -27977,7 +30876,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 28698.0,
-    "total_tax": 28698.0
+    "total_tax": 28698.0,
+    "amti": 180500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 212000.0,
@@ -27987,7 +30888,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 28698.0,
-    "total_tax": 28698.0
+    "total_tax": 28698.0,
+    "amti": 180500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -28012,7 +30915,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 34598.0,
-    "total_tax": 34598.0
+    "total_tax": 34598.0,
+    "amti": 203500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 235000.0,
@@ -28022,7 +30927,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 34598.0,
-    "total_tax": 34598.0
+    "total_tax": 34598.0,
+    "amti": 203500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -28047,7 +30954,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 33758.0,
-    "total_tax": 33758.0
+    "total_tax": 33758.0,
+    "amti": 203500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 235000.0,
@@ -28057,7 +30966,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 33758.0,
-    "total_tax": 33758.0
+    "total_tax": 33758.0,
+    "amti": 203500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -28082,7 +30993,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 33198.0,
-    "total_tax": 33198.0
+    "total_tax": 33198.0,
+    "amti": 203500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 235000.0,
@@ -28092,7 +31005,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 33198.0,
-    "total_tax": 33198.0
+    "total_tax": 33198.0,
+    "amti": 203500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -28117,7 +31032,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 31998.0,
-    "total_tax": 31998.0
+    "total_tax": 31998.0,
+    "amti": 195500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 227000.0,
@@ -28127,7 +31044,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 31998.0,
-    "total_tax": 31998.0
+    "total_tax": 31998.0,
+    "amti": 195500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -28152,7 +31071,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 54934.0,
-    "total_tax": 56144.0
+    "total_tax": 56144.0,
+    "amti": 288500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 320000.0,
@@ -28162,7 +31083,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 54934.0,
-    "total_tax": 56144.0
+    "total_tax": 56144.0,
+    "amti": 288500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -28187,7 +31110,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 53854.0,
-    "total_tax": 55064.0
+    "total_tax": 55064.0,
+    "amti": 288500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 320000.0,
@@ -28197,7 +31122,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 53854.0,
-    "total_tax": 55064.0
+    "total_tax": 55064.0,
+    "amti": 288500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -28222,7 +31149,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 53134.0,
-    "total_tax": 54344.0
+    "total_tax": 54344.0,
+    "amti": 288500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 320000.0,
@@ -28232,7 +31161,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 53134.0,
-    "total_tax": 54344.0
+    "total_tax": 54344.0,
+    "amti": 288500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -28257,7 +31188,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 51934.0,
-    "total_tax": 52840.0
+    "total_tax": 52840.0,
+    "amti": 280500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 312000.0,
@@ -28267,7 +31200,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 51934.0,
-    "total_tax": 52840.0
+    "total_tax": 52840.0,
+    "amti": 280500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -28292,7 +31227,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 58534.0,
-    "total_tax": 60314.0
+    "total_tax": 60314.0,
+    "amti": 303500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 335000.0,
@@ -28302,7 +31239,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 58534.0,
-    "total_tax": 60314.0
+    "total_tax": 60314.0,
+    "amti": 303500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -28327,7 +31266,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 57454.0,
-    "total_tax": 59234.0
+    "total_tax": 59234.0,
+    "amti": 303500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 335000.0,
@@ -28337,7 +31278,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 57454.0,
-    "total_tax": 59234.0
+    "total_tax": 59234.0,
+    "amti": 303500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -28362,7 +31305,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 56734.0,
-    "total_tax": 58514.0
+    "total_tax": 58514.0,
+    "amti": 303500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 335000.0,
@@ -28372,7 +31317,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 56734.0,
-    "total_tax": 58514.0
+    "total_tax": 58514.0,
+    "amti": 303500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -28397,7 +31344,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 55534.0,
-    "total_tax": 57010.0
+    "total_tax": 57010.0,
+    "amti": 295500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 327000.0,
@@ -28407,7 +31356,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 55534.0,
-    "total_tax": 57010.0
+    "total_tax": 57010.0,
+    "amti": 295500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -28432,7 +31383,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 13449.0,
-    "total_tax": 13449.0
+    "total_tax": 13449.0,
+    "amti": 84250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -28458,7 +31411,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 8114.0,
-    "total_tax": 8114.0
+    "total_tax": 8114.0,
+    "amti": 60000.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -28484,7 +31439,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 69034.75,
-    "total_tax": 69934.75
+    "total_tax": 69934.75,
+    "amti": 284250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -28510,7 +31467,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 60547.25,
-    "total_tax": 61447.25
+    "total_tax": 61447.25,
+    "amti": 260000.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -28536,7 +31495,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7743.0,
-    "total_tax": 7743.0
+    "total_tax": 7743.0,
+    "amti": 68500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 100000.0,
@@ -28546,7 +31507,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7743.0,
-    "total_tax": 7743.0
+    "total_tax": 7743.0,
+    "amti": 68500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -28571,7 +31534,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 6723.0,
-    "total_tax": 6723.0
+    "total_tax": 6723.0,
+    "amti": 60000.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 100000.0,
@@ -28581,7 +31546,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 6723.0,
-    "total_tax": 6723.0
+    "total_tax": 6723.0,
+    "amti": 60000.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -28606,7 +31573,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 50134.0,
-    "total_tax": 50584.0
+    "total_tax": 50584.0,
+    "amti": 268500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 300000.0,
@@ -28616,7 +31585,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 50134.0,
-    "total_tax": 50584.0
+    "total_tax": 50584.0,
+    "amti": 268500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -28641,7 +31612,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 48094.0,
-    "total_tax": 48544.0
+    "total_tax": 48544.0,
+    "amti": 260000.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 300000.0,
@@ -28651,7 +31624,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 48094.0,
-    "total_tax": 48544.0
+    "total_tax": 48544.0,
+    "amti": 260000.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -28676,7 +31651,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1192.4,
-    "total_tax": 1192.4
+    "total_tax": 1192.4,
+    "amti": 11924.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -28702,7 +31679,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1192.62,
-    "total_tax": 1192.62
+    "total_tax": 1192.62,
+    "amti": 11926.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -28728,7 +31707,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5578.38,
-    "total_tax": 5578.38
+    "total_tax": 5578.38,
+    "amti": 48474.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -28754,7 +31735,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5578.72,
-    "total_tax": 5578.72
+    "total_tax": 5578.72,
+    "amti": 48476.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -28780,7 +31763,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 17650.78,
-    "total_tax": 17650.78
+    "total_tax": 17650.78,
+    "amti": 103349.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -28806,7 +31791,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 17651.24,
-    "total_tax": 17651.24
+    "total_tax": 17651.24,
+    "amti": 103351.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -28832,7 +31819,9 @@
     "addl_medicare": 117.44099999999999,
     "amt": 0.0,
     "income_tax": 40198.759999999995,
-    "total_tax": 40316.200999999994
+    "total_tax": 40316.200999999994,
+    "amti": 197299.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -28858,7 +31847,9 @@
     "addl_medicare": 117.45899999999999,
     "amt": 0.0,
     "income_tax": 40199.32,
-    "total_tax": 40316.779
+    "total_tax": 40316.779,
+    "amti": 197301.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -28884,7 +31875,9 @@
     "addl_medicare": 596.466,
     "amt": 0.0,
     "income_tax": 57230.68,
-    "total_tax": 57827.146
+    "total_tax": 57827.146,
+    "amti": 250524.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -28910,7 +31903,9 @@
     "addl_medicare": 596.4839999999999,
     "amt": 0.0,
     "income_tax": 57231.35,
-    "total_tax": 57827.833999999995
+    "total_tax": 57827.833999999995,
+    "amti": 250526.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -28936,7 +31931,9 @@
     "addl_medicare": 3978.8909999999996,
     "amt": 0.0,
     "income_tax": 188769.4,
-    "total_tax": 192748.291
+    "total_tax": 192748.291,
+    "amti": 626349.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -28962,7 +31959,9 @@
     "addl_medicare": 3978.9089999999997,
     "amt": 0.0,
     "income_tax": 188770.12,
-    "total_tax": 192749.02899999998
+    "total_tax": 192749.02899999998,
+    "amti": 626351.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -28988,7 +31987,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 16913.78,
-    "total_tax": 16913.78
+    "total_tax": 16913.78,
+    "amti": 99999.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -29014,7 +32015,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 16914.22,
-    "total_tax": 16914.22
+    "total_tax": 16914.22,
+    "amti": 100001.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -29040,7 +32043,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2384.9,
-    "total_tax": 2384.9
+    "total_tax": 2384.9,
+    "amti": 23849.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 55349.0,
@@ -29050,7 +32055,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2384.9,
-    "total_tax": 2384.9
+    "total_tax": 2384.9,
+    "amti": 23849.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -29075,7 +32082,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2385.12,
-    "total_tax": 2385.12
+    "total_tax": 2385.12,
+    "amti": 23851.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 55351.0,
@@ -29085,7 +32094,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2385.12,
-    "total_tax": 2385.12
+    "total_tax": 2385.12,
+    "amti": 23851.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -29110,7 +32121,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 11156.88,
-    "total_tax": 11156.88
+    "total_tax": 11156.88,
+    "amti": 96949.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 128449.0,
@@ -29120,7 +32133,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 11156.88,
-    "total_tax": 11156.88
+    "total_tax": 11156.88,
+    "amti": 96949.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -29145,7 +32160,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 11157.22,
-    "total_tax": 11157.22
+    "total_tax": 11157.22,
+    "amti": 96951.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 128451.0,
@@ -29155,7 +32172,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 11157.22,
-    "total_tax": 11157.22
+    "total_tax": 11157.22,
+    "amti": 96951.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -29180,7 +32199,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 35301.78,
-    "total_tax": 35301.78
+    "total_tax": 35301.78,
+    "amti": 206699.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 238199.0,
@@ -29190,7 +32211,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 35301.78,
-    "total_tax": 35301.78
+    "total_tax": 35301.78,
+    "amti": 206699.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -29215,7 +32238,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 35302.24,
-    "total_tax": 35302.24
+    "total_tax": 35302.24,
+    "amti": 206701.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 238201.0,
@@ -29225,7 +32250,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 35302.24,
-    "total_tax": 35302.24
+    "total_tax": 35302.24,
+    "amti": 206701.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -29250,7 +32277,9 @@
     "addl_medicare": 1584.8909999999998,
     "amt": 0.0,
     "income_tax": 80397.76,
-    "total_tax": 81982.651
+    "total_tax": 81982.651,
+    "amti": 394599.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 426099.0,
@@ -29260,7 +32289,9 @@
     "addl_medicare": 1584.8909999999998,
     "amt": 0.0,
     "income_tax": 80397.76,
-    "total_tax": 81982.651
+    "total_tax": 81982.651,
+    "amti": 394599.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -29285,7 +32316,9 @@
     "addl_medicare": 1584.9089999999999,
     "amt": 0.0,
     "income_tax": 80398.32,
-    "total_tax": 81983.229
+    "total_tax": 81983.229,
+    "amti": 394601.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 426101.0,
@@ -29295,7 +32328,9 @@
     "addl_medicare": 1584.9089999999999,
     "amt": 0.0,
     "income_tax": 80398.32,
-    "total_tax": 81983.229
+    "total_tax": 81983.229,
+    "amti": 394601.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -29320,7 +32355,9 @@
     "addl_medicare": 2542.941,
     "amt": 0.0,
     "income_tax": 114461.68,
-    "total_tax": 117004.621
+    "total_tax": 117004.621,
+    "amti": 501049.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 532549.0,
@@ -29330,7 +32367,9 @@
     "addl_medicare": 2542.941,
     "amt": 0.0,
     "income_tax": 114461.68,
-    "total_tax": 117004.621
+    "total_tax": 117004.621,
+    "amti": 501049.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -29355,7 +32394,9 @@
     "addl_medicare": 2542.959,
     "amt": 0.0,
     "income_tax": 114462.35,
-    "total_tax": 117005.30900000001
+    "total_tax": 117005.30900000001,
+    "amti": 501051.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 532551.0,
@@ -29365,7 +32406,9 @@
     "addl_medicare": 2542.959,
     "amt": 0.0,
     "income_tax": 114462.35,
-    "total_tax": 117005.30900000001
+    "total_tax": 117005.30900000001,
+    "amti": 501051.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -29390,7 +32433,9 @@
     "addl_medicare": 4797.891,
     "amt": 0.0,
     "income_tax": 202154.15,
-    "total_tax": 206952.041
+    "total_tax": 206952.041,
+    "amti": 751599.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 783099.0,
@@ -29400,7 +32445,9 @@
     "addl_medicare": 4797.891,
     "amt": 0.0,
     "income_tax": 202154.15,
-    "total_tax": 206952.041
+    "total_tax": 206952.041,
+    "amti": 751599.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -29425,7 +32472,9 @@
     "addl_medicare": 4797.909,
     "amt": 0.0,
     "income_tax": 202154.87,
-    "total_tax": 206952.77899999998
+    "total_tax": 206952.77899999998,
+    "amti": 751601.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 783101.0,
@@ -29435,7 +32484,9 @@
     "addl_medicare": 4797.909,
     "amt": 0.0,
     "income_tax": 202154.87,
-    "total_tax": 206952.77899999998
+    "total_tax": 206952.77899999998,
+    "amti": 751601.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -29460,7 +32511,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 11827.78,
-    "total_tax": 11827.78
+    "total_tax": 11827.78,
+    "amti": 99999.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 131499.0,
@@ -29470,7 +32523,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 11827.78,
-    "total_tax": 11827.78
+    "total_tax": 11827.78,
+    "amti": 99999.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -29495,7 +32550,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 11828.22,
-    "total_tax": 11828.22
+    "total_tax": 11828.22,
+    "amti": 100001.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 131501.0,
@@ -29505,7 +32562,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 11828.22,
-    "total_tax": 11828.22
+    "total_tax": 11828.22,
+    "amti": 100001.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -29530,7 +32589,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1192.4,
-    "total_tax": 1192.4
+    "total_tax": 1192.4,
+    "amti": 11924.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -29556,7 +32617,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1192.62,
-    "total_tax": 1192.62
+    "total_tax": 1192.62,
+    "amti": 11926.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -29582,7 +32645,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5578.38,
-    "total_tax": 5578.38
+    "total_tax": 5578.38,
+    "amti": 48474.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -29608,7 +32673,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 5578.72,
-    "total_tax": 5578.72
+    "total_tax": 5578.72,
+    "amti": 48476.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -29634,7 +32701,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 17650.78,
-    "total_tax": 17650.78
+    "total_tax": 17650.78,
+    "amti": 103349.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -29660,7 +32729,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 17651.24,
-    "total_tax": 17651.24
+    "total_tax": 17651.24,
+    "amti": 103351.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -29686,7 +32757,9 @@
     "addl_medicare": 792.4409999999999,
     "amt": 0.0,
     "income_tax": 40198.759999999995,
-    "total_tax": 40991.200999999994
+    "total_tax": 40991.200999999994,
+    "amti": 197299.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -29712,7 +32785,9 @@
     "addl_medicare": 792.459,
     "amt": 0.0,
     "income_tax": 40199.32,
-    "total_tax": 40991.779
+    "total_tax": 40991.779,
+    "amti": 197301.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -29738,7 +32813,9 @@
     "addl_medicare": 1271.466,
     "amt": 0.0,
     "income_tax": 57230.68,
-    "total_tax": 58502.146
+    "total_tax": 58502.146,
+    "amti": 250524.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -29764,7 +32841,9 @@
     "addl_medicare": 1271.484,
     "amt": 0.0,
     "income_tax": 57231.35,
-    "total_tax": 58502.833999999995
+    "total_tax": 58502.833999999995,
+    "amti": 250526.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -29790,7 +32869,9 @@
     "addl_medicare": 2398.941,
     "amt": 0.0,
     "income_tax": 101076.9,
-    "total_tax": 103475.841
+    "total_tax": 103475.841,
+    "amti": 375799.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -29816,7 +32897,9 @@
     "addl_medicare": 2398.959,
     "amt": 0.0,
     "income_tax": 101077.62,
-    "total_tax": 103476.579
+    "total_tax": 103476.579,
+    "amti": 375801.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -29842,7 +32925,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 16913.78,
-    "total_tax": 16913.78
+    "total_tax": 16913.78,
+    "amti": 99999.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -29868,7 +32953,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 16914.22,
-    "total_tax": 16914.22
+    "total_tax": 16914.22,
+    "amti": 100001.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -29894,7 +32981,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1699.9,
-    "total_tax": 1699.9
+    "total_tax": 1699.9,
+    "amti": 16999.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -29920,7 +33009,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 1700.12,
-    "total_tax": 1700.12
+    "total_tax": 1700.12,
+    "amti": 17001.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -29946,7 +33037,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7441.88,
-    "total_tax": 7441.88
+    "total_tax": 7441.88,
+    "amti": 64849.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -29972,7 +33065,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 7442.22,
-    "total_tax": 7442.22
+    "total_tax": 7442.22,
+    "amti": 64851.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -29998,7 +33093,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 15911.78,
-    "total_tax": 15911.78
+    "total_tax": 15911.78,
+    "amti": 103349.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30024,7 +33121,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 15912.24,
-    "total_tax": 15912.24
+    "total_tax": 15912.24,
+    "amti": 103351.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30050,7 +33149,9 @@
     "addl_medicare": 188.31599999999997,
     "amt": 0.0,
     "income_tax": 38459.759999999995,
-    "total_tax": 38648.075999999994
+    "total_tax": 38648.075999999994,
+    "amti": 197299.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30076,7 +33177,9 @@
     "addl_medicare": 188.33399999999997,
     "amt": 0.0,
     "income_tax": 38460.32,
-    "total_tax": 38648.654
+    "total_tax": 38648.654,
+    "amti": 197301.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30102,7 +33205,9 @@
     "addl_medicare": 667.116,
     "amt": 0.0,
     "income_tax": 55483.68,
-    "total_tax": 56150.796
+    "total_tax": 56150.796,
+    "amti": 250499.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30128,7 +33233,9 @@
     "addl_medicare": 667.1339999999999,
     "amt": 0.0,
     "income_tax": 55484.35,
-    "total_tax": 56151.484
+    "total_tax": 56151.484,
+    "amti": 250501.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30154,7 +33261,9 @@
     "addl_medicare": 4049.7659999999996,
     "amt": 0.0,
     "income_tax": 187031.15,
-    "total_tax": 191080.916
+    "total_tax": 191080.916,
+    "amti": 626349.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30180,7 +33289,9 @@
     "addl_medicare": 4049.7839999999997,
     "amt": 0.0,
     "income_tax": 187031.87,
-    "total_tax": 191081.65399999998
+    "total_tax": 191081.65399999998,
+    "amti": 626351.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30206,7 +33317,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 15174.779999999999,
-    "total_tax": 15174.779999999999
+    "total_tax": 15174.779999999999,
+    "amti": 99999.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30232,7 +33345,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 15175.220000000001,
-    "total_tax": 15175.220000000001
+    "total_tax": 15175.220000000001,
+    "amti": 100001.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30258,7 +33373,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2384.9,
-    "total_tax": 2384.9
+    "total_tax": 2384.9,
+    "amti": 23849.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30284,7 +33401,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 2385.12,
-    "total_tax": 2385.12
+    "total_tax": 2385.12,
+    "amti": 23851.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30310,7 +33429,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 11156.88,
-    "total_tax": 11156.88
+    "total_tax": 11156.88,
+    "amti": 96949.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30336,7 +33457,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 11157.22,
-    "total_tax": 11157.22
+    "total_tax": 11157.22,
+    "amti": 96951.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30362,7 +33485,9 @@
     "addl_medicare": 343.791,
     "amt": 0.0,
     "income_tax": 35301.78,
-    "total_tax": 35645.570999999996
+    "total_tax": 35645.570999999996,
+    "amti": 206699.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30388,7 +33513,9 @@
     "addl_medicare": 343.80899999999997,
     "amt": 0.0,
     "income_tax": 35302.24,
-    "total_tax": 35646.049
+    "total_tax": 35646.049,
+    "amti": 206701.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30414,7 +33541,9 @@
     "addl_medicare": 2034.8909999999998,
     "amt": 0.0,
     "income_tax": 80397.76,
-    "total_tax": 82432.651
+    "total_tax": 82432.651,
+    "amti": 394599.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30440,7 +33569,9 @@
     "addl_medicare": 2034.9089999999999,
     "amt": 0.0,
     "income_tax": 80398.32,
-    "total_tax": 82433.229
+    "total_tax": 82433.229,
+    "amti": 394601.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30466,7 +33597,9 @@
     "addl_medicare": 2992.941,
     "amt": 0.0,
     "income_tax": 114461.68,
-    "total_tax": 117454.621
+    "total_tax": 117454.621,
+    "amti": 501049.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30492,7 +33625,9 @@
     "addl_medicare": 2992.959,
     "amt": 0.0,
     "income_tax": 114462.35,
-    "total_tax": 117455.30900000001
+    "total_tax": 117455.30900000001,
+    "amti": 501051.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30518,7 +33653,9 @@
     "addl_medicare": 5247.891,
     "amt": 0.0,
     "income_tax": 202154.15,
-    "total_tax": 207402.041
+    "total_tax": 207402.041,
+    "amti": 751599.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30544,7 +33681,9 @@
     "addl_medicare": 5247.909,
     "amt": 0.0,
     "income_tax": 202154.87,
-    "total_tax": 207402.77899999998
+    "total_tax": 207402.77899999998,
+    "amti": 751601.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30570,7 +33709,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 11827.78,
-    "total_tax": 11827.78
+    "total_tax": 11827.78,
+    "amti": 99999.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30596,7 +33737,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 11828.22,
-    "total_tax": 11828.22
+    "total_tax": 11828.22,
+    "amti": 100001.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30622,7 +33765,9 @@
     "addl_medicare": 4950.0,
     "amt": 0.0,
     "income_tax": 228692.75,
-    "total_tax": 233642.75
+    "total_tax": 233642.75,
+    "amti": 734250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30648,7 +33793,9 @@
     "addl_medicare": 4950.0,
     "amt": 0.0,
     "income_tax": 268692.75,
-    "total_tax": 281242.75
+    "total_tax": 281242.75,
+    "amti": 934250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30674,7 +33821,9 @@
     "addl_medicare": 9000.0,
     "amt": 0.0,
     "income_tax": 395192.75,
-    "total_tax": 404192.75
+    "total_tax": 404192.75,
+    "amti": 1184250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30700,7 +33849,9 @@
     "addl_medicare": 9000.0,
     "amt": 0.0,
     "income_tax": 435192.75,
-    "total_tax": 451792.75
+    "total_tax": 451792.75,
+    "amti": 1384250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30726,7 +33877,9 @@
     "addl_medicare": 4500.0,
     "amt": 0.0,
     "income_tax": 190569.5,
-    "total_tax": 195069.5
+    "total_tax": 195069.5,
+    "amti": 718500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 750000.0,
@@ -30736,7 +33889,9 @@
     "addl_medicare": 4500.0,
     "amt": 0.0,
     "income_tax": 190569.5,
-    "total_tax": 195069.5
+    "total_tax": 195069.5,
+    "amti": 718500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -30761,7 +33916,9 @@
     "addl_medicare": 4500.0,
     "amt": 0.0,
     "income_tax": 230569.5,
-    "total_tax": 242669.5
+    "total_tax": 242669.5,
+    "amti": 918500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 950000.0,
@@ -30771,7 +33928,9 @@
     "addl_medicare": 4500.0,
     "amt": 0.0,
     "income_tax": 230569.5,
-    "total_tax": 242669.5
+    "total_tax": 242669.5,
+    "amti": 918500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -30796,7 +33955,9 @@
     "addl_medicare": 8550.0,
     "amt": 0.0,
     "income_tax": 356407.5,
-    "total_tax": 364957.5
+    "total_tax": 364957.5,
+    "amti": 1168500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 1200000.0,
@@ -30806,7 +33967,9 @@
     "addl_medicare": 8550.0,
     "amt": 0.0,
     "income_tax": 356407.5,
-    "total_tax": 364957.5
+    "total_tax": 364957.5,
+    "amti": 1168500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -30831,7 +33994,9 @@
     "addl_medicare": 8550.0,
     "amt": 0.0,
     "income_tax": 396407.5,
-    "total_tax": 412557.5
+    "total_tax": 412557.5,
+    "amti": 1368500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 1400000.0,
@@ -30841,7 +34006,9 @@
     "addl_medicare": 8550.0,
     "amt": 0.0,
     "income_tax": 396407.5,
-    "total_tax": 412557.5
+    "total_tax": 412557.5,
+    "amti": 1368500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -30866,7 +34033,9 @@
     "addl_medicare": 5625.0,
     "amt": 0.0,
     "income_tax": 233703.75,
-    "total_tax": 239328.75
+    "total_tax": 239328.75,
+    "amti": 734250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30892,7 +34061,9 @@
     "addl_medicare": 5625.0,
     "amt": 0.0,
     "income_tax": 273703.75,
-    "total_tax": 286928.75
+    "total_tax": 286928.75,
+    "amti": 934250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30918,7 +34089,9 @@
     "addl_medicare": 9675.0,
     "amt": 0.0,
     "income_tax": 400203.75,
-    "total_tax": 409878.75
+    "total_tax": 409878.75,
+    "amti": 1184250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30944,7 +34117,9 @@
     "addl_medicare": 9675.0,
     "amt": 0.0,
     "income_tax": 440203.75,
-    "total_tax": 457478.75
+    "total_tax": 457478.75,
+    "amti": 1384250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30970,7 +34145,9 @@
     "addl_medicare": 4950.0,
     "amt": 0.0,
     "income_tax": 224040.75,
-    "total_tax": 228990.75
+    "total_tax": 228990.75,
+    "amti": 726375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -30996,7 +34173,9 @@
     "addl_medicare": 4950.0,
     "amt": 0.0,
     "income_tax": 264040.75,
-    "total_tax": 276590.75
+    "total_tax": 276590.75,
+    "amti": 926375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31022,7 +34201,9 @@
     "addl_medicare": 9000.0,
     "amt": 0.0,
     "income_tax": 390540.75,
-    "total_tax": 399540.75
+    "total_tax": 399540.75,
+    "amti": 1176375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31048,7 +34229,9 @@
     "addl_medicare": 9000.0,
     "amt": 0.0,
     "income_tax": 430540.75,
-    "total_tax": 447140.75
+    "total_tax": 447140.75,
+    "amti": 1376375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31074,7 +34257,9 @@
     "addl_medicare": 4950.0,
     "amt": 0.0,
     "income_tax": 190569.5,
-    "total_tax": 195519.5
+    "total_tax": 195519.5,
+    "amti": 718500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31100,7 +34285,9 @@
     "addl_medicare": 4950.0,
     "amt": 0.0,
     "income_tax": 230569.5,
-    "total_tax": 243119.5
+    "total_tax": 243119.5,
+    "amti": 918500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31126,7 +34313,9 @@
     "addl_medicare": 9000.0,
     "amt": 0.0,
     "income_tax": 356407.5,
-    "total_tax": 365407.5
+    "total_tax": 365407.5,
+    "amti": 1168500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31152,7 +34341,9 @@
     "addl_medicare": 9000.0,
     "amt": 0.0,
     "income_tax": 396407.5,
-    "total_tax": 413007.5
+    "total_tax": 413007.5,
+    "amti": 1368500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31178,7 +34369,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 25067.0,
-    "total_tax": 25067.0
+    "total_tax": 25067.0,
+    "amti": 184250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31204,7 +34397,9 @@
     "addl_medicare": 0.0,
     "amt": 39073.0,
     "income_tax": 64140.0,
-    "total_tax": 64140.0
+    "total_tax": 64140.0,
+    "amti": 334250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31230,7 +34425,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 0.0,
     "income_tax": 69034.75,
-    "total_tax": 69934.75
+    "total_tax": 69934.75,
+    "amti": 334250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31256,7 +34453,9 @@
     "addl_medicare": 899.9999999999999,
     "amt": 37105.25,
     "income_tax": 106140.0,
-    "total_tax": 107040.0
+    "total_tax": 107040.0,
+    "amti": 484250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31282,7 +34481,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 15898.0,
-    "total_tax": 15898.0
+    "total_tax": 15898.0,
+    "amti": 168500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 150000.0,
@@ -31292,7 +34493,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 15898.0,
-    "total_tax": 15898.0
+    "total_tax": 15898.0,
+    "amti": 168500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -31317,7 +34520,9 @@
     "addl_medicare": 0.0,
     "amt": 31292.0,
     "income_tax": 47190.0,
-    "total_tax": 47190.0
+    "total_tax": 47190.0,
+    "amti": 318500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 150000.0,
@@ -31327,7 +34532,9 @@
     "addl_medicare": 0.0,
     "amt": 31292.0,
     "income_tax": 47190.0,
-    "total_tax": 47190.0
+    "total_tax": 47190.0,
+    "amti": 318500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -31352,7 +34559,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 50134.0,
-    "total_tax": 50584.0
+    "total_tax": 50584.0,
+    "amti": 318500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 300000.0,
@@ -31362,7 +34571,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 0.0,
     "income_tax": 50134.0,
-    "total_tax": 50584.0
+    "total_tax": 50584.0,
+    "amti": 318500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -31387,7 +34598,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 37904.0,
     "income_tax": 88038.0,
-    "total_tax": 88488.0
+    "total_tax": 88488.0,
+    "amti": 468500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 300000.0,
@@ -31397,7 +34610,9 @@
     "addl_medicare": 449.99999999999994,
     "amt": 37904.0,
     "income_tax": 88038.0,
-    "total_tax": 88488.0
+    "total_tax": 88488.0,
+    "amti": 468500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -31422,7 +34637,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 5028.0,
     "income_tax": 30095.0,
-    "total_tax": 30320.0
+    "total_tax": 30320.0,
+    "amti": 184250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31448,7 +34665,9 @@
     "addl_medicare": 224.99999999999997,
     "amt": 46952.0,
     "income_tax": 72019.0,
-    "total_tax": 72244.0
+    "total_tax": 72244.0,
+    "amti": 334250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31474,7 +34693,9 @@
     "addl_medicare": 1574.9999999999998,
     "amt": 2984.25,
     "income_tax": 72019.0,
-    "total_tax": 73594.0
+    "total_tax": 73594.0,
+    "amti": 334250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31500,7 +34721,216 @@
     "addl_medicare": 1574.9999999999998,
     "amt": 44984.25,
     "income_tax": 114019.0,
-    "total_tax": 115594.0
+    "total_tax": 115594.0,
+    "amti": 484250.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2025,
+   "tag": "L_amt_floor",
+   "status": "Single",
+   "w2": 0.0,
+   "se": 0.0,
+   "stcg": 0.0,
+   "ltcg": 0.0,
+   "interest": 0.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 200000.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 0.0,
+    "taxable_income": 0.0,
+    "se_tax": 0.0,
+    "niit": 0.0,
+    "addl_medicare": 0.0,
+    "amt": 24999.0,
+    "income_tax": 24999.0,
+    "total_tax": 24999.0,
+    "amti": 184250.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2025,
+   "tag": "L_amt_floor",
+   "status": "Married/Joint",
+   "w2": 0.0,
+   "se": 0.0,
+   "stcg": 0.0,
+   "ltcg": 0.0,
+   "interest": 0.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 200000.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 0.0,
+    "taxable_income": 0.0,
+    "se_tax": 0.0,
+    "niit": 0.0,
+    "addl_medicare": 0.0,
+    "amt": 8190.0,
+    "income_tax": 8190.0,
+    "total_tax": 8190.0,
+    "amti": 168500.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": {
+    "agi": 0.0,
+    "taxable_income": 0.0,
+    "se_tax": 0.0,
+    "niit": 0.0,
+    "addl_medicare": 0.0,
+    "amt": 8190.0,
+    "income_tax": 8190.0,
+    "total_tax": 8190.0,
+    "amti": 168500.0,
+    "qbi_deduction": 0.0
+   }
+  },
+  {
+   "year": 2025,
+   "tag": "L_amt_floor",
+   "status": "Married/Sep",
+   "w2": 0.0,
+   "se": 0.0,
+   "stcg": 0.0,
+   "ltcg": 0.0,
+   "interest": 0.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 200000.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 0.0,
+    "taxable_income": 0.0,
+    "se_tax": 0.0,
+    "niit": 0.0,
+    "addl_medicare": 0.0,
+    "amt": 30095.0,
+    "income_tax": 30095.0,
+    "total_tax": 30095.0,
+    "amti": 184250.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2025,
+   "tag": "L_amt_floor",
+   "status": "Head_of_House",
+   "w2": 0.0,
+   "se": 0.0,
+   "stcg": 0.0,
+   "ltcg": 0.0,
+   "interest": 0.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 200000.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 0.0,
+    "taxable_income": 0.0,
+    "se_tax": 0.0,
+    "niit": 0.0,
+    "addl_medicare": 0.0,
+    "amt": 22951.5,
+    "income_tax": 22951.5,
+    "total_tax": 22951.5,
+    "amti": 176375.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2025,
+   "tag": "L_amt_floor",
+   "status": "Widow(er)",
+   "w2": 0.0,
+   "se": 0.0,
+   "stcg": 0.0,
+   "ltcg": 0.0,
+   "interest": 0.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 200000.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 0.0,
+    "taxable_income": 0.0,
+    "se_tax": 0.0,
+    "niit": 0.0,
+    "addl_medicare": 0.0,
+    "amt": 8190.0,
+    "income_tax": 8190.0,
+    "total_tax": 8190.0,
+    "amti": 168500.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2025,
+   "tag": "M_amt_mfs",
+   "status": "Married/Sep",
+   "w2": 750000.0,
+   "se": 0.0,
+   "stcg": 0.0,
+   "ltcg": 0.0,
+   "interest": 0.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 300000.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 750000.0,
+    "taxable_income": 734250.0,
+    "se_tax": 0.0,
+    "niit": 0.0,
+    "addl_medicare": 5625.0,
+    "amt": 53495.25,
+    "income_tax": 287199.0,
+    "total_tax": 292824.0,
+    "amti": 1034250.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2025,
+   "tag": "N_amt_mfs_gain",
+   "status": "Married/Sep",
+   "w2": 250000.0,
+   "se": 0.0,
+   "stcg": 15458.0,
+   "ltcg": 6032.0,
+   "interest": 49171.0,
+   "ord_div": 11057.0,
+   "qual_div": 11057.0,
+   "itemized": 19444.0,
+   "iso": 50000.0,
+   "std_or_item": "Itemized",
+   "expected": {
+    "agi": 331718.0,
+    "taxable_income": 312274.0,
+    "se_tax": 0.0,
+    "niit": 3105.284,
+    "addl_medicare": 1125.0,
+    "amt": 2218.800000000003,
+    "income_tax": 78257.85,
+    "total_tax": 82488.134,
+    "amti": 362274.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31526,7 +34956,9 @@
     "addl_medicare": 240.34499999999997,
     "amt": 0.0,
     "income_tax": 43869.21789707777,
-    "total_tax": 44913.00789707777
+    "total_tax": 44913.00789707777,
+    "amti": 208769.43092836803,
+    "qbi_deduction": 4078.846571631976
    },
    "expected_spouse_attr": null
   },
@@ -31552,7 +34984,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 41327.0,
-    "total_tax": 42429.0
+    "total_tax": 42429.0,
+    "amti": 213250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31578,7 +35012,9 @@
     "addl_medicare": 258.34499999999997,
     "amt": 0.0,
     "income_tax": 44584.98948747777,
-    "total_tax": 45646.77948747777
+    "total_tax": 45646.77948747777,
+    "amti": 211006.217148368,
+    "qbi_deduction": 3842.060351631976
    },
    "expected_spouse_attr": null
   },
@@ -31604,7 +35040,9 @@
     "addl_medicare": 9.0,
     "amt": 0.0,
     "income_tax": 41807.0,
-    "total_tax": 42956.0
+    "total_tax": 42956.0,
+    "amti": 215250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31630,7 +35068,9 @@
     "addl_medicare": 240.34499999999997,
     "amt": 0.0,
     "income_tax": 43576.869280000006,
-    "total_tax": 44620.65928000001
+    "total_tax": 44620.65928000001,
+    "amti": 241178.62200000003,
+    "qbi_deduction": 5919.655500000001
    },
    "expected_spouse_attr": {
     "agi": 276880.5675,
@@ -31640,7 +35080,9 @@
     "addl_medicare": 240.34499999999997,
     "amt": 0.0,
     "income_tax": 43247.06896,
-    "total_tax": 47726.278959999996
+    "total_tax": 47726.278959999996,
+    "amti": 239804.45400000003,
+    "qbi_deduction": 5576.1135
    }
   },
   {
@@ -31665,7 +35107,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 42394.0,
-    "total_tax": 43496.0
+    "total_tax": 43496.0,
+    "amti": 247500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 279000.0,
@@ -31675,7 +35119,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 42394.0,
-    "total_tax": 43496.0
+    "total_tax": 43496.0,
+    "amti": 247500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -31700,7 +35146,9 @@
     "addl_medicare": 258.34499999999997,
     "amt": 0.0,
     "income_tax": 44056.869280000006,
-    "total_tax": 45118.65928000001
+    "total_tax": 45118.65928000001,
+    "amti": 243178.62200000003,
+    "qbi_deduction": 5919.655500000001
    },
    "expected_spouse_attr": {
     "agi": 278880.5675,
@@ -31710,7 +35158,9 @@
     "addl_medicare": 258.34499999999997,
     "amt": 0.0,
     "income_tax": 43727.06896,
-    "total_tax": 48224.278959999996
+    "total_tax": 48224.278959999996,
+    "amti": 241804.45400000003,
+    "qbi_deduction": 5576.1135
    }
   },
   {
@@ -31735,7 +35185,9 @@
     "addl_medicare": 9.0,
     "amt": 0.0,
     "income_tax": 42874.0,
-    "total_tax": 44023.0
+    "total_tax": 44023.0,
+    "amti": 249500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": {
     "agi": 281000.0,
@@ -31745,7 +35197,9 @@
     "addl_medicare": 9.0,
     "amt": 0.0,
     "income_tax": 42874.0,
-    "total_tax": 44023.0
+    "total_tax": 44023.0,
+    "amti": 249500.0,
+    "qbi_deduction": 0.0
    }
   },
   {
@@ -31770,7 +35224,9 @@
     "addl_medicare": 240.34499999999997,
     "amt": 0.0,
     "income_tax": 24180.06896,
-    "total_tax": 28659.278960000003
+    "total_tax": 28659.278960000003,
+    "amti": 130554.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": null
   },
@@ -31796,7 +35252,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 23327.0,
-    "total_tax": 24429.0
+    "total_tax": 24429.0,
+    "amti": 138250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31822,7 +35280,9 @@
     "addl_medicare": 258.34499999999997,
     "amt": 0.0,
     "income_tax": 24660.06896,
-    "total_tax": 29157.278960000003
+    "total_tax": 29157.278960000003,
+    "amti": 132554.454,
+    "qbi_deduction": 5576.1135
    },
    "expected_spouse_attr": null
   },
@@ -31848,7 +35308,9 @@
     "addl_medicare": 9.0,
     "amt": 0.0,
     "income_tax": 23807.0,
-    "total_tax": 24956.0
+    "total_tax": 24956.0,
+    "amti": 140250.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31874,7 +35336,9 @@
     "addl_medicare": 240.34499999999997,
     "amt": 0.0,
     "income_tax": 39311.86725987777,
-    "total_tax": 40355.65725987777
+    "total_tax": 40355.65725987777,
+    "amti": 199962.08518711803,
+    "qbi_deduction": 5011.192312881976
    },
    "expected_spouse_attr": null
   },
@@ -31900,7 +35364,9 @@
     "addl_medicare": 0.0,
     "amt": 0.0,
     "income_tax": 37698.0,
-    "total_tax": 38800.0
+    "total_tax": 38800.0,
+    "amti": 205375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31926,7 +35392,9 @@
     "addl_medicare": 258.34499999999997,
     "amt": 0.0,
     "income_tax": 40027.63885027776,
-    "total_tax": 41089.42885027776
+    "total_tax": 41089.42885027776,
+    "amti": 202198.87140711801,
+    "qbi_deduction": 4774.406092881976
    },
    "expected_spouse_attr": null
   },
@@ -31952,7 +35420,9 @@
     "addl_medicare": 9.0,
     "amt": 0.0,
     "income_tax": 38178.0,
-    "total_tax": 39327.0
+    "total_tax": 39327.0,
+    "amti": 207375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -31978,7 +35448,9 @@
     "addl_medicare": 240.34499999999997,
     "amt": 0.0,
     "income_tax": 31887.296839999995,
-    "total_tax": 32931.086839999996
+    "total_tax": 32931.086839999996,
+    "amti": 191178.622,
+    "qbi_deduction": 5919.655500000001
    },
    "expected_spouse_attr": null
   },
@@ -32004,7 +35476,9 @@
     "addl_medicare": 440.99999999999994,
     "amt": 0.0,
     "income_tax": 42394.0,
-    "total_tax": 43937.0
+    "total_tax": 43937.0,
+    "amti": 247500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -32030,7 +35504,9 @@
     "addl_medicare": 258.34499999999997,
     "amt": 0.0,
     "income_tax": 32350.71624324548,
-    "total_tax": 33412.50624324548
+    "total_tax": 33412.50624324548,
+    "amti": 193285.073832934,
+    "qbi_deduction": 5813.203667065988
    },
    "expected_spouse_attr": null
   },
@@ -32056,7 +35532,9 @@
     "addl_medicare": 458.99999999999994,
     "amt": 0.0,
     "income_tax": 42874.0,
-    "total_tax": 44473.0
+    "total_tax": 44473.0,
+    "amti": 249500.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -32082,7 +35560,9 @@
     "addl_medicare": 484.91999999999996,
     "amt": 0.0,
     "income_tax": 67159.809,
-    "total_tax": 72447.249
+    "total_tax": 72447.249,
+    "amti": 313178.74,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -32108,7 +35588,9 @@
     "addl_medicare": 34.919999999999995,
     "amt": 0.0,
     "income_tax": 47888.31807999999,
-    "total_tax": 52725.758079999985
+    "total_tax": 52725.758079999985,
+    "amti": 281642.99199999997,
+    "qbi_deduction": 15785.748000000001
    },
    "expected_spouse_attr": {
     "agi": 324348.18,
@@ -32118,7 +35600,9 @@
     "addl_medicare": 34.919999999999995,
     "amt": 0.0,
     "income_tax": 47008.850560000006,
-    "total_tax": 61007.410560000004
+    "total_tax": 61007.410560000004,
+    "amti": 277978.544,
+    "qbi_deduction": 14869.635999999999
    }
   },
   {
@@ -32143,7 +35627,9 @@
     "addl_medicare": 1159.9199999999998,
     "amt": 0.0,
     "income_tax": 67818.746,
-    "total_tax": 73781.186
+    "total_tax": 73781.186,
+    "amti": 313178.74,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -32169,7 +35655,9 @@
     "addl_medicare": 484.91999999999996,
     "amt": 0.0,
     "income_tax": 62821.19679999999,
-    "total_tax": 68108.6368
+    "total_tax": 68108.6368,
+    "amti": 305303.74,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   },
@@ -32195,7 +35683,261 @@
     "addl_medicare": 484.91999999999996,
     "amt": 0.0,
     "income_tax": 51676.8976,
-    "total_tax": 56964.33759999999
+    "total_tax": 56964.33759999999,
+    "amti": 297428.74,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2025,
+   "tag": "J_loss",
+   "status": "Single",
+   "w2": 300000.0,
+   "se": 0.0,
+   "stcg": -1000.0,
+   "ltcg": 0.0,
+   "interest": 100000.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 0.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 399000.0,
+    "taxable_income": 383250.0,
+    "se_tax": 0.0,
+    "niit": 3762.0,
+    "addl_medicare": 899.9999999999999,
+    "amt": 0.0,
+    "income_tax": 103684.75,
+    "total_tax": 108346.75,
+    "amti": 383250.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2025,
+   "tag": "J_loss",
+   "status": "Single",
+   "w2": 300000.0,
+   "se": 0.0,
+   "stcg": -3000.0,
+   "ltcg": 0.0,
+   "interest": 100000.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 0.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 397000.0,
+    "taxable_income": 381250.0,
+    "se_tax": 0.0,
+    "niit": 3686.0,
+    "addl_medicare": 899.9999999999999,
+    "amt": 0.0,
+    "income_tax": 102984.75,
+    "total_tax": 107570.75,
+    "amti": 381250.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2025,
+   "tag": "J_loss",
+   "status": "Single",
+   "w2": 300000.0,
+   "se": 0.0,
+   "stcg": -50000.0,
+   "ltcg": 0.0,
+   "interest": 100000.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 0.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 397000.0,
+    "taxable_income": 381250.0,
+    "se_tax": 0.0,
+    "niit": 3686.0,
+    "addl_medicare": 899.9999999999999,
+    "amt": 0.0,
+    "income_tax": 102984.75,
+    "total_tax": 107570.75,
+    "amti": 381250.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2025,
+   "tag": "J_loss",
+   "status": "Single",
+   "w2": 300000.0,
+   "se": 0.0,
+   "stcg": -50000.0,
+   "ltcg": 10000.0,
+   "interest": 100000.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 0.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 397000.0,
+    "taxable_income": 381250.0,
+    "se_tax": 0.0,
+    "niit": 3686.0,
+    "addl_medicare": 899.9999999999999,
+    "amt": 0.0,
+    "income_tax": 102984.75,
+    "total_tax": 107570.75,
+    "amti": 381250.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2025,
+   "tag": "J_loss",
+   "status": "Married/Sep",
+   "w2": 300000.0,
+   "se": 0.0,
+   "stcg": -1000.0,
+   "ltcg": 0.0,
+   "interest": 100000.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 0.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 399000.0,
+    "taxable_income": 383250.0,
+    "se_tax": 0.0,
+    "niit": 3762.0,
+    "addl_medicare": 1574.9999999999998,
+    "amt": 0.0,
+    "income_tax": 103833.75,
+    "total_tax": 109170.75,
+    "amti": 383250.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2025,
+   "tag": "J_loss",
+   "status": "Married/Sep",
+   "w2": 300000.0,
+   "se": 0.0,
+   "stcg": -3000.0,
+   "ltcg": 0.0,
+   "interest": 100000.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 0.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 398500.0,
+    "taxable_income": 382750.0,
+    "se_tax": 0.0,
+    "niit": 3743.0,
+    "addl_medicare": 1574.9999999999998,
+    "amt": 0.0,
+    "income_tax": 103648.75,
+    "total_tax": 108966.75,
+    "amti": 382750.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2025,
+   "tag": "J_loss",
+   "status": "Married/Sep",
+   "w2": 300000.0,
+   "se": 0.0,
+   "stcg": -50000.0,
+   "ltcg": 0.0,
+   "interest": 100000.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 0.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 398500.0,
+    "taxable_income": 382750.0,
+    "se_tax": 0.0,
+    "niit": 3743.0,
+    "addl_medicare": 1574.9999999999998,
+    "amt": 0.0,
+    "income_tax": 103648.75,
+    "total_tax": 108966.75,
+    "amti": 382750.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2025,
+   "tag": "J_loss",
+   "status": "Married/Sep",
+   "w2": 300000.0,
+   "se": 0.0,
+   "stcg": -50000.0,
+   "ltcg": 10000.0,
+   "interest": 100000.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 0.0,
+   "iso": 0.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 398500.0,
+    "taxable_income": 382750.0,
+    "se_tax": 0.0,
+    "niit": 3743.0,
+    "addl_medicare": 1574.9999999999998,
+    "amt": 0.0,
+    "income_tax": 103648.75,
+    "total_tax": 108966.75,
+    "amti": 382750.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2025,
+   "tag": "K_deduction",
+   "status": "Head_of_House",
+   "w2": 0.0,
+   "se": 0.0,
+   "stcg": 0.0,
+   "ltcg": 60000.0,
+   "interest": 0.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 56000.0,
+   "iso": 0.0,
+   "std_or_item": "Standard",
+   "expected": {
+    "agi": 60000.0,
+    "taxable_income": 36375.0,
+    "se_tax": 0.0,
+    "niit": 0.0,
+    "addl_medicare": 0.0,
+    "amt": 0.0,
+    "income_tax": 0.0,
+    "total_tax": 0.0,
+    "amti": 36375.0,
+    "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null
   }

--- a/tests/taxcalc/fixtures/taxcalc_goldens.json
+++ b/tests/taxcalc/fixtures/taxcalc_goldens.json
@@ -6,7 +6,7 @@
    2024,
    2025
   ],
-  "n_cases": 1178
+  "n_cases": 1179
  },
  "cases": [
   {
@@ -16936,6 +16936,34 @@
     "income_tax": 287586.0,
     "total_tax": 293211.0,
     "amti": 1035400.0,
+    "qbi_deduction": 0.0
+   },
+   "expected_spouse_attr": null
+  },
+  {
+   "year": 2024,
+   "tag": "P_amt_mfs_stale_only",
+   "status": "Married/Sep",
+   "w2": 600000.0,
+   "se": 0.0,
+   "stcg": 0.0,
+   "ltcg": 0.0,
+   "interest": 0.0,
+   "ord_div": 0.0,
+   "qual_div": 0.0,
+   "itemized": 20000.0,
+   "iso": 250000.0,
+   "std_or_item": "Itemized",
+   "expected": {
+    "agi": 600000.0,
+    "taxable_income": 580000.0,
+    "se_tax": 0.0,
+    "niit": 0.0,
+    "addl_medicare": 4275.0,
+    "amt": 49194.75,
+    "income_tax": 226857.5,
+    "total_tax": 231132.5,
+    "amti": 830000.0,
     "qbi_deduction": 0.0
    },
    "expected_spouse_attr": null

--- a/tests/taxcalc/goldens_test.py
+++ b/tests/taxcalc/goldens_test.py
@@ -3,8 +3,8 @@
 The fixture (tests/taxcalc/fixtures/taxcalc_goldens.json) pins taxcalc's
 expectations for the boundary grid at an exact taxcalc version, so the
 default test run gets standing differential coverage with no taxcalc dependency.
-Disagreements are excused only by known-defect signature (taxcalc_policy.py);
-anything novel fails.
+Known defects contribute signed, bounded deltas through taxcalc_policy.py;
+anything outside those bounds fails.
 
 A stratified subset runs by default (fast); the full grid runs under
 TENFORTY_TAXCALC=1.
@@ -15,10 +15,23 @@ import os
 from pathlib import Path
 
 import pytest
+import tomllib
 
 from .taxcalc_policy import unexcused_violations
 
 FIXTURE = Path(__file__).parent / "fixtures" / "taxcalc_goldens.json"
+PROJECT_ROOT = Path(__file__).parents[2]
+PAYLOAD = json.loads(FIXTURE.read_text())
+
+
+def _pinned_taxcalc_version() -> str:
+    pyproject = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text())
+    requirement = next(
+        item
+        for item in pyproject["dependency-groups"]["taxcalc"]
+        if item.startswith("taxcalc==")
+    )
+    return requirement.removeprefix("taxcalc==")
 
 
 def _graph_available() -> bool:
@@ -31,8 +44,7 @@ def _graph_available() -> bool:
 
 
 def _load_cases() -> list[dict]:
-    payload = json.loads(FIXTURE.read_text())
-    cases = payload["cases"]
+    cases = PAYLOAD["cases"]
     if os.environ.get("TENFORTY_TAXCALC"):
         return cases
     # Stratified fast subset: first case of every (year, tag, status) stratum.
@@ -49,6 +61,48 @@ def _load_cases() -> list[dict]:
 CASES = _load_cases()
 
 
+def test_golden_metadata_matches_the_pinned_oracle():
+    """Fixture provenance and cardinality cannot drift from their declarations."""
+    meta = PAYLOAD["meta"]
+    cases = PAYLOAD["cases"]
+
+    assert meta["taxcalc_version"] == _pinned_taxcalc_version()
+    assert meta["n_cases"] == len(cases)
+    assert meta["years"] == sorted({case["year"] for case in cases})
+
+
+def test_golden_grid_keeps_nonvacuous_boundary_strata():
+    """The committed oracle must retain AMT, cliffs, high incomes, and losses."""
+    cases = PAYLOAD["cases"]
+    tags = {case["tag"] for case in cases}
+
+    assert {
+        "F_cliff",
+        "G_high",
+        "H_amt",
+        "I_straddle",
+        "J_loss",
+        "L_amt_floor",
+        "M_amt_mfs",
+        "N_amt_mfs_gain",
+        "O_amt_itemized_floor",
+    } <= tags
+    assert sum(case["expected"]["amt"] > 0.0 for case in cases) >= 10
+    assert any(case["w2"] > 400_000.0 for case in cases)
+    assert any(case["stcg"] < 0.0 or case["ltcg"] < 0.0 for case in cases)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TENFORTY_TAXCALC"),
+    reason="live TaxCalc version is checked only under the oracle gate",
+)
+def test_live_taxcalc_matches_the_fixture_pin():
+    """A gated run cannot silently use a different oracle version."""
+    import taxcalc
+
+    assert taxcalc.__version__ == _pinned_taxcalc_version()
+
+
 @pytest.mark.parametrize(
     "backend",
     [
@@ -62,7 +116,7 @@ CASES = _load_cases()
     ],
 )
 def test_matches_goldens(backend):
-    """Every fixture case matches pinned taxcalc, unless excused by name."""
+    """Every fixture case falls within its pinned, modeled TaxCalc range."""
     violations = []
     for case in CASES:
         violations.extend(

--- a/tests/taxcalc/goldens_test.py
+++ b/tests/taxcalc/goldens_test.py
@@ -15,7 +15,11 @@ import os
 from pathlib import Path
 
 import pytest
-import tomllib
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib
 
 from .taxcalc_policy import unexcused_violations
 

--- a/tests/taxcalc/goldens_test.py
+++ b/tests/taxcalc/goldens_test.py
@@ -90,6 +90,7 @@ def test_golden_grid_keeps_nonvacuous_boundary_strata():
         "M_amt_mfs",
         "N_amt_mfs_gain",
         "O_amt_itemized_floor",
+        "P_amt_mfs_stale_only",
     } <= tags
     assert sum(case["expected"]["amt"] > 0.0 for case in cases) >= 10
     assert any(case["w2"] > 400_000.0 for case in cases)

--- a/tests/taxcalc/policy_lifecycle_test.py
+++ b/tests/taxcalc/policy_lifecycle_test.py
@@ -1,0 +1,65 @@
+"""Lifecycle contract for differential signatures, burn-ins, and the audit."""
+
+import json
+import re
+from pathlib import Path
+
+from .taxcalc_policy import SIGNATURES
+
+ROOT = Path(__file__).parents[2]
+AUDIT = ROOT / "docs" / "taxcalc-differential-audit.md"
+FIXTURE = Path(__file__).parent / "fixtures" / "taxcalc_goldens.json"
+BURN_IN_SOURCES = (
+    ROOT / "tests" / "known_defects_test.py",
+    ROOT / "tests" / "taxcalc" / "adapter_conformance_test.py",
+)
+INVENTORY = ROOT / "tests" / "mapping_completeness_test.py"
+
+
+def _active_audit_ids() -> set[str]:
+    active = set()
+    for line in AUDIT.read_text().splitlines():
+        if not re.match(r"\| F\d+ ", line):
+            continue
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        finding_id, status = cells[0], cells[3].lower()
+        if "open" in status or "pending" in status:
+            active.add(finding_id)
+    return active
+
+
+def _strict_burn_in_ids() -> set[str]:
+    source = "\n".join(path.read_text() for path in BURN_IN_SOURCES)
+    return set(re.findall(r'reason="(F\d+):', source))
+
+
+def test_active_findings_have_one_signature_and_strict_burn_in():
+    """A fixed defect cannot leave behind a silent permanent delta allowance."""
+    signature_ids = [defect.finding_id for defect in SIGNATURES]
+
+    assert len(signature_ids) == len(set(signature_ids))
+    assert set(signature_ids) == _active_audit_ids()
+    assert set(signature_ids) == _strict_burn_in_ids()
+
+
+def test_inventory_findings_are_active_and_burned_in():
+    """Any mapping-level missing:F marker participates in the same lifecycle."""
+    inventory_ids = set(re.findall(r"missing:(F\d+)", INVENTORY.read_text()))
+
+    assert inventory_ids <= _active_audit_ids()
+    assert inventory_ids <= _strict_burn_in_ids()
+
+
+def test_every_signature_matches_a_committed_golden_case():
+    """A signature with no golden witness is stale or untested policy."""
+    cases = json.loads(FIXTURE.read_text())["cases"]
+    missing = []
+    for defect in SIGNATURES:
+        if not any(
+            defect.signature(backend, case, case["expected"])
+            for backend in ("ots", "graph")
+            for case in cases
+        ):
+            missing.append(defect.finding_id)
+
+    assert not missing, f"signatures without a golden witness: {missing}"

--- a/tests/taxcalc/policy_test.py
+++ b/tests/taxcalc/policy_test.py
@@ -3,8 +3,22 @@
 import pytest
 
 from .taxcalc_policy import (
+    COMPONENT_TOL,
+    GAINS_WORKSHEET_TOL,
     QBI_SIMPLIFIED_THRESHOLD,
+    DeltaRange,
+    _f7_itemized_semantics,
+    _f11_ots_hoh_bracket,
+    _f12_itemized_category_amt,
+    _f14_taxcalc_omits_amt_std_addback,
+    _f19_deduction_choice_rule,
     _f21_taxcalc_qw_qbi_phase_range,
+    _f22_ots_amt_taxable_income_floor,
+    _f23_taxcalc_graph_omit_mfs_amt_increase,
+    _f24_ots_2024_mfs_amt_constants,
+    _f25_graph_2025_mfs_amt_cg_ceiling,
+    _f26_taxcalc_itemized_amt_floor,
+    tolerance,
 )
 
 _F21_QUANTITIES = {"taxable_income", "amt", "income_tax", "total_tax"}
@@ -42,25 +56,192 @@ def test_qbi_simplified_thresholds_match_form_8995():
     assert QBI_SIMPLIFIED_THRESHOLD == _EXPECTED_QBI_THRESHOLDS
 
 
-def test_f21_excuses_only_the_qw_taxcalc_phase_range():
-    """F21 is limited to the graph QW case inside TaxCalc's longer range."""
+def test_f21_models_only_the_qw_taxcalc_phase_range():
+    """F21 is limited to both backends inside TaxCalc's longer QW range."""
     case = _case(status="Widow(er)", se=100_000.0)
     reference = {"taxable_income": 200_000.0, "qbi_deduction": 10_000.0}
 
-    assert _f21_taxcalc_qw_qbi_phase_range("graph", case, reference) == _F21_QUANTITIES
-    assert _f21_taxcalc_qw_qbi_phase_range("ots", case, reference) == _F21_QUANTITIES
+    graph_model = _f21_taxcalc_qw_qbi_phase_range("graph", case, reference)
+    ots_model = _f21_taxcalc_qw_qbi_phase_range("ots", case, reference)
+
+    assert set(graph_model) == _F21_QUANTITIES
+    assert set(ots_model) == _F21_QUANTITIES
+    assert graph_model["taxable_income"] == DeltaRange(0.0, 10_000.0)
     assert (
         _f21_taxcalc_qw_qbi_phase_range(
             "graph", {**case, "status": "Single"}, reference
         )
-        == set()
+        == {}
     )
 
 
 @pytest.mark.parametrize("pre_qbi", [191_950.0, 291_950.0, 400_000.0])
-def test_f21_does_not_excuse_outside_taxcalcs_qw_phase_range(pre_qbi):
+def test_f21_does_not_model_outside_taxcalcs_qw_phase_range(pre_qbi):
     """F21 leaves both endpoints and values above TaxCalc's range exposed."""
     case = _case(status="Widow(er)", se=100_000.0)
     reference = {"taxable_income": pre_qbi, "qbi_deduction": 0.0}
 
-    assert _f21_taxcalc_qw_qbi_phase_range("graph", case, reference) == set()
+    assert _f21_taxcalc_qw_qbi_phase_range("graph", case, reference) == {}
+
+
+@pytest.mark.parametrize(
+    ("taxable_income", "expected_delta"),
+    [(191_150.0, 0.0), (191_550.0, 32.0), (191_950.0, 64.0), (300_000.0, 64.0)],
+)
+def test_f11_models_the_exact_hoh_bracket_overcharge(taxable_income, expected_delta):
+    """F11 permits only the 8-point spread across the erroneous $800 band."""
+    case = _case(year=2024, status="Head_of_House")
+    model = _f11_ots_hoh_bracket("ots", case, {"taxable_income": taxable_income})
+
+    if expected_delta == 0.0:
+        assert model == {}
+    else:
+        assert model == {
+            "income_tax": DeltaRange.exact(expected_delta),
+            "total_tax": DeltaRange.exact(expected_delta),
+        }
+
+
+def test_f14_accounts_for_the_taxable_income_floor():
+    """TaxCalc's AMTI gap includes the unused standard deduction below zero."""
+    case = _case(
+        status="Head_of_House",
+        iso=200_000.0,
+        itemized=0.0,
+        std_or_item="Standard",
+    )
+
+    model = _f14_taxcalc_omits_amt_std_addback("graph", case, {"agi": 0.0})
+
+    assert model["amt"] == DeltaRange(0.0, 0.35 * 43_800.0)
+
+
+def test_f12_reserves_the_preferential_worksheet_displacement():
+    """Preferential income can stack a 20% band shift on the 35% AMT slope."""
+    case = _case(itemized=50_000.0, qual_div=20_000.0)
+
+    model = _f12_itemized_category_amt("ots", case, None)
+
+    assert model["amt"].minimum == 0.0
+    assert model["amt"].maximum == pytest.approx(27_500.0)
+
+
+def test_f19_does_not_model_amt_sensitive_deduction_choice():
+    """An ISO preference can make larger itemization lower total tax."""
+    case = _case(
+        status="Head_of_House",
+        ord_div=48_071.0,
+        qual_div=48_071.0,
+        itemized=46_318.0,
+        iso=198_397.0,
+    )
+
+    assert _f19_deduction_choice_rule("ots", case, {"taxable_income": 1_753.0}) == {}
+
+
+def test_f22_is_a_signed_correction_to_the_correct_amt_path():
+    """OTS can remove only the tax effect of the unused deduction floor."""
+    case = _case(
+        status="Head_of_House",
+        iso=200_000.0,
+        itemized=0.0,
+        std_or_item="Standard",
+    )
+
+    model = _f22_ots_amt_taxable_income_floor(
+        "ots", case, {"agi": 0.0, "qbi_deduction": 0.0}
+    )
+
+    assert model["amt"] == DeltaRange(-0.35 * 21_900.0, 0.0)
+    assert (
+        _f22_ots_amt_taxable_income_floor(
+            "graph", case, {"agi": 0.0, "qbi_deduction": 0.0}
+        )
+        == {}
+    )
+
+
+def test_f23_models_the_official_mfs_line4_increase():
+    """The reference defect contributes at most 28% of the required addition."""
+    case = _case(year=2025, status="Married/Sep")
+    reference = {"amti": 920_350.0}
+
+    model = _f23_taxcalc_graph_omit_mfs_amt_increase("ots", case, reference)
+
+    assert model["amt"].minimum == 0.0
+    assert model["amt"].maximum == pytest.approx(1_400.0)
+    assert _f23_taxcalc_graph_omit_mfs_amt_increase("graph", case, reference) == {}
+
+
+def test_f24_models_only_the_stale_2024_constant_difference():
+    """OTS's early threshold composes with the official F23 reference delta."""
+    case = _case(year=2024, status="Married/Sep")
+    reference = {"amti": 875_950.0}
+
+    model = _f24_ots_2024_mfs_amt_constants("ots", case, reference)
+
+    assert model["amt"].minimum == 0.0
+    assert model["amt"].maximum == pytest.approx(3_136.0)
+
+
+def test_f25_caps_the_stale_mfs_preferential_band_at_1665():
+    """Only the 5-point spread across the $33,300 band is modeled."""
+    case = _case(
+        year=2025,
+        status="Married/Sep",
+        ltcg=100_000.0,
+    )
+
+    model = _f25_graph_2025_mfs_amt_cg_ceiling("graph", case, None)
+
+    assert model["amt"] == DeltaRange(0.0, 1_665.0)
+
+
+def test_f26_bounds_only_the_unused_itemized_deduction():
+    """The Form 1040 line-15 floor prevents the excess from reducing AMTI."""
+    case = _case(
+        status="Married/Sep",
+        itemized=50_061.0,
+        qual_div=16_556.0,
+        iso=300_000.0,
+    )
+    reference = {
+        "agi": 46_691.0,
+        "taxable_income": 0.0,
+        "qbi_deduction": 0.0,
+    }
+
+    model = _f26_taxcalc_itemized_amt_floor("graph", case, reference)
+
+    assert model["amt"].minimum == 0.0
+    assert model["amt"].maximum == pytest.approx(0.55 * 3_370.0)
+
+
+def test_f7_bounds_the_qbi_cap_response_to_forced_itemization():
+    """QBI can absorb at most 20% of the gross deduction difference."""
+    case = _case(
+        year=2025,
+        status="Widow(er)",
+        se=154_646.0,
+        itemized=0.0,
+        std_or_item="Itemized",
+    )
+    reference = {
+        "agi": 164_709.49,
+        "taxable_income": 133_209.49,
+        "qbi_deduction": 31_500.0,
+        "se_tax": 15_915.02,
+    }
+
+    model = _f7_itemized_semantics("ots", case, reference)
+
+    assert model["taxable_income"] == DeltaRange(25_200.0, 31_500.0)
+
+
+def test_gains_tolerance_requires_a_material_worksheet_input():
+    """A token gain cannot buy the full Schedule D worksheet allowance."""
+    small = _case(stcg=1.0)
+    material = _case(ltcg=1_000.0)
+
+    assert tolerance("ots", "total_tax", 150_000.0, small) == COMPONENT_TOL
+    assert tolerance("ots", "total_tax", 150_000.0, material) == GAINS_WORKSHEET_TOL

--- a/tests/taxcalc/policy_test.py
+++ b/tests/taxcalc/policy_test.py
@@ -173,15 +173,21 @@ def test_f23_models_the_official_mfs_line4_increase():
     assert _f23_taxcalc_graph_omit_mfs_amt_increase("graph", case, reference) == {}
 
 
-def test_f24_models_only_the_stale_2024_constant_difference():
-    """OTS's early threshold composes with the official F23 reference delta."""
-    case = _case(year=2024, status="Married/Sep")
-    reference = {"amti": 875_950.0}
+def test_f24_fires_between_the_stale_and_official_thresholds_without_f23():
+    """OTS's stale rule is active while the official line-4 addition is zero."""
+    case = _case(
+        year=2024,
+        status="Married/Sep",
+        itemized=20_000.0,
+        std_or_item="Itemized",
+    )
+    reference = {"amti": 830_000.0}
 
     model = _f24_ots_2024_mfs_amt_constants("ots", case, reference)
 
+    assert _f23_taxcalc_graph_omit_mfs_amt_increase("ots", case, reference) == {}
     assert model["amt"].minimum == 0.0
-    assert model["amt"].maximum == pytest.approx(3_136.0)
+    assert model["amt"].maximum == pytest.approx(1_649.375)
 
 
 def test_f25_caps_the_stale_mfs_preferential_band_at_1665():

--- a/tests/taxcalc/taxcalc_differential_test.py
+++ b/tests/taxcalc/taxcalc_differential_test.py
@@ -45,7 +45,7 @@ from hypothesis import strategies as st  # noqa: E402
 
 import tenforty  # noqa: E402
 
-from .taxcalc_policy import excused_quantities, tolerance  # noqa: E402
+from .taxcalc_policy import ZERO_DELTA, modeled_deltas, tolerance  # noqa: E402
 
 MARS = {
     "Single": 1,
@@ -75,8 +75,10 @@ def _normalize_case(case):
 
 def _case_strategy():
     dollars = st.one_of(
-        st.sampled_from((0, 125_000, 168_600, 176_100, 200_000, 250_000)),
-        st.integers(min_value=0, max_value=400_000),
+        st.sampled_from(
+            (0, 125_000, 168_600, 176_100, 200_000, 250_000, 750_000, 1_200_000)
+        ),
+        st.integers(min_value=0, max_value=1_200_000),
     ).map(float)
     small_dollars = st.one_of(st.just(0), st.integers(0, 60_000)).map(float)
     return st.fixed_dictionaries(
@@ -85,19 +87,18 @@ def _case_strategy():
             "status": st.sampled_from(sorted(MARS)),
             "w2": dollars,
             "se": dollars,
-            "stcg": st.one_of(st.just(0), st.integers(0, 250_000)).map(float),
-            "ltcg": st.one_of(st.just(0), st.integers(0, 250_000)).map(float),
+            "stcg": st.one_of(st.just(0), st.integers(-250_000, 250_000)).map(float),
+            "ltcg": st.one_of(st.just(0), st.integers(-250_000, 250_000)).map(float),
             "interest": small_dollars,
             "ord_div": small_dollars,
             "qual_frac": st.sampled_from((0.0, 0.5, 1.0)),
             "itemized": small_dollars,
             "std_or_item": st.sampled_from(("Standard", "Itemized")),
-            # No "iso" yet, deliberately. The adapter now carries it (see
-            # cmbtp above), but generating AMT-preference cases surfaces F14 on
-            # both engines at once, and the _f14 signature currently excuses
-            # the backend that turned out to be RIGHT. Flip that signature and
-            # fix the graph spec first (tenforty-8ik), then add iso here as
-            # part of the AMT coverage in tenforty-y90.
+            "iso": st.one_of(
+                st.just(0.0),
+                st.sampled_from((50_000.0, 200_000.0)),
+                st.integers(0, 300_000).map(float),
+            ),
         }
     ).map(_normalize_case)
 
@@ -173,6 +174,7 @@ def _anchor(**kw):
         "ord_div": 0.0,
         "qual_div": 0.0,
         "itemized": 0.0,
+        "iso": 0.0,
         "std_or_item": "Standard",
     }
     base.update(kw)
@@ -184,6 +186,17 @@ ANCHOR_SE_WAGE_BASE = _anchor(w2=168_600.0, se=60_000.0)
 ANCHOR_8959_NO_WAGES = _anchor(se=300_000.0)
 ANCHOR_QBI_NET_BASE = _anchor(w2=50_000.0, se=80_000.0)
 ANCHOR_QBI_CAPITAL_GAIN_LIMIT = _anchor(se=100_000.0, ltcg=60_000.0)
+ANCHOR_AMT_ISO = _anchor(w2=150_000.0, iso=200_000.0)
+ANCHOR_AMT_FLOOR = _anchor(
+    status="Head_of_House",
+    iso=200_000.0,
+)
+ANCHOR_CAPITAL_LOSS = _anchor(
+    w2=300_000.0,
+    interest=100_000.0,
+    stcg=-50_000.0,
+    ltcg=10_000.0,
+)
 
 
 def taxcalc_batch(cases, wage_attribution="primary"):
@@ -248,6 +261,7 @@ def taxcalc_batch(cases, wage_attribution="primary"):
                 "niit": niit,
                 "addl_medicare": amc,
                 "amt": float(arr("c09600")[row]),
+                "amti": float(arr("c62100")[row]),
                 # Tax-Calculator nets refundable credits out of iitax, while
                 # tenforty's federal tax outputs stop at Form 1040 line 24.
                 # Add its line-32 analogue back before preserving the existing
@@ -278,6 +292,7 @@ def tenforty_components(case, backend):
         ordinary_dividends=case["ord_div"],
         qualified_dividends=case["qual_div"],
         itemized_deductions=case["itemized"],
+        incentive_stock_option_gains=case.get("iso", 0.0),
         standard_or_itemized=case["std_or_item"],
     )
     return {
@@ -301,19 +316,26 @@ def _assert_components_match_taxcalc(backend, cases):
     worst_excess = dict.fromkeys(QUANTITIES, 0.0)
     for case, exp, exp_alt in zip(cases, expected, expected_alt, strict=True):
         ours = tenforty_components(case, backend)
-        excused = excused_quantities(backend, case, exp)
+        deltas = modeled_deltas(backend, case, exp)
         for quantity in QUANTITIES:
             lo = min(exp[quantity], exp_alt[quantity])
             hi = max(exp[quantity], exp_alt[quantity])
             tol = tolerance(backend, quantity, exp["taxable_income"], case)
-            diff = max(lo - ours[quantity], ours[quantity] - hi, 0.0)
-            if quantity in excused:
-                continue
-            worst_excess[quantity] = max(worst_excess[quantity], max(0.0, diff - tol))
-            if diff > tol:
+            delta = deltas.get(quantity, ZERO_DELTA)
+            allowed_lo = lo + delta.minimum - tol
+            allowed_hi = hi + delta.maximum + tol
+            residual = max(
+                allowed_lo - ours[quantity],
+                ours[quantity] - allowed_hi,
+                0.0,
+            )
+            worst_excess[quantity] = max(worst_excess[quantity], residual)
+            if residual > 0.0:
                 failures.append(
                     f"{case}: {quantity} got={ours[quantity]:,.2f} "
-                    f"expected=[{lo:,.2f}, {hi:,.2f}] (diff {diff:,.2f} > {tol})"
+                    f"expected=[{lo:,.2f}, {hi:,.2f}] + "
+                    f"delta=[{delta.minimum:,.2f}, {delta.maximum:,.2f}] "
+                    f"+/- {tol} (residual {residual:,.2f})"
                 )
     # target() accepts one observation per label per example, so feed it the
     # batch maximum beyond tolerance: harmless OTS rounding has a zero gradient.
@@ -333,9 +355,12 @@ def _assert_components_match_taxcalc(backend, cases):
 @example(cases=[ANCHOR_8959_NO_WAGES])
 @example(cases=[ANCHOR_QBI_NET_BASE])
 @example(cases=[ANCHOR_QBI_CAPITAL_GAIN_LIMIT])
+@example(cases=[ANCHOR_AMT_ISO])
+@example(cases=[ANCHOR_AMT_FLOOR])
+@example(cases=[ANCHOR_CAPITAL_LOSS])
 @pytest.mark.parametrize("backend", ["ots", "graph"])
 def test_components_match_taxcalc(backend, cases):
-    """Every quantity matches taxcalc within tolerance, unless excused by name."""
+    """Every quantity falls within its modeled TaxCalc range and tolerance."""
     _assert_components_match_taxcalc(backend, cases)
 
 

--- a/tests/taxcalc/taxcalc_policy.py
+++ b/tests/taxcalc/taxcalc_policy.py
@@ -381,6 +381,17 @@ def _mfs_amt_line4_addition(amti: float, threshold: float, cap: float) -> float:
     return min(cap, 0.25 * max(0.0, amti - threshold))
 
 
+def _mfs_amt_line4_tax_effect(
+    amti: float, addition: float, exemption_terminal: float
+) -> float:
+    exemption_before = 0.25 * max(0.0, exemption_terminal - amti)
+    exemption_after = 0.25 * max(
+        0.0,
+        exemption_terminal - amti - addition,
+    )
+    return 0.28 * (addition + exemption_before - exemption_after)
+
+
 def _f23_taxcalc_graph_omit_mfs_amt_increase(
     backend: str, case: dict, reference: dict[str, float] | None
 ) -> DeltaModel:
@@ -399,9 +410,8 @@ def _f23_taxcalc_graph_omit_mfs_amt_increase(
     addition = _mfs_amt_line4_addition(ots_amti, *rule)
     if addition == 0.0:
         return {}
-    return _same_delta(
-        {"amt", "income_tax", "total_tax"}, DeltaRange(0.0, 0.28 * addition)
-    )
+    tax_effect = _mfs_amt_line4_tax_effect(ots_amti, addition, rule[0])
+    return _same_delta({"amt", "income_tax", "total_tax"}, DeltaRange(0.0, tax_effect))
 
 
 def _f24_ots_2024_mfs_amt_constants(
@@ -419,7 +429,10 @@ def _f24_ots_2024_mfs_amt_constants(
     ots_amti = reference["amti"] + max(0.0, case.get("itemized", 0.0))
     official = _mfs_amt_line4_addition(ots_amti, *MFS_AMT_LINE4_RULE[2024])
     stale = _mfs_amt_line4_addition(ots_amti, *OTS_2024_MFS_AMT_LINE4_RULE)
-    tax_delta = 0.28 * (stale - official)
+    exemption_terminal = MFS_AMT_LINE4_RULE[2024][0]
+    tax_delta = _mfs_amt_line4_tax_effect(
+        ots_amti, stale, exemption_terminal
+    ) - _mfs_amt_line4_tax_effect(ots_amti, official, exemption_terminal)
     if tax_delta == 0.0:
         return {}
     delta = DeltaRange(min(0.0, tax_delta), max(0.0, tax_delta))

--- a/tests/taxcalc/taxcalc_policy.py
+++ b/tests/taxcalc/taxcalc_policy.py
@@ -1,9 +1,9 @@
 """Shared taxcalc comparison policy: known-defect signatures and tolerances.
 
-Each signature maps a case (backend + inputs) to the set of compared
-quantities its defect is expected to corrupt. The differential suite excuses
-exactly these disagreements and fails on anything unclassified — so known
-bugs are tolerated by name while novel regressions break the run.
+Each signature maps a case (backend + inputs + reference result) to bounded
+expected deltas for the quantities its defect changes. The differential suite
+checks the residual after applying those bounds, so a known bug cannot excuse
+an error with the wrong sign or an unrelated magnitude.
 
 When a defect is fixed, delete its signature here and remove its strict-xfail
 burn-in in tests/known_defects_test.py in the same PR.
@@ -12,6 +12,50 @@ Finding IDs refer to docs/taxcalc-differential-audit.md.
 """
 
 from collections.abc import Callable
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DeltaRange:
+    """Allowed backend-minus-reference delta for one compared quantity."""
+
+    minimum: float
+    maximum: float
+
+    def __post_init__(self) -> None:
+        """Reject inverted ranges."""
+        if self.minimum > self.maximum:
+            raise ValueError("delta minimum cannot exceed maximum")
+
+    @classmethod
+    def exact(cls, value: float) -> "DeltaRange":
+        """Construct a point delta."""
+        return cls(value, value)
+
+    def __add__(self, other: "DeltaRange") -> "DeltaRange":
+        """Combine independent delta ranges."""
+        return DeltaRange(
+            self.minimum + other.minimum,
+            self.maximum + other.maximum,
+        )
+
+
+ZERO_DELTA = DeltaRange.exact(0.0)
+DeltaModel = dict[str, DeltaRange]
+Signature = Callable[[str, dict, dict[str, float] | None], DeltaModel]
+
+
+@dataclass(frozen=True)
+class KnownDefect:
+    """A named audit finding and its bounded delta signature."""
+
+    finding_id: str
+    signature: Signature
+
+
+def _same_delta(quantities: set[str], delta: DeltaRange) -> DeltaModel:
+    return {quantity: delta for quantity in quantities}
+
 
 STANDARD_DEDUCTION = {
     (2024, "Single"): 14_600.0,
@@ -39,12 +83,16 @@ QBI_SIMPLIFIED_THRESHOLD = {
     (2025, "Widow(er)"): 197_300.0,
 }
 
-_F21_AFFECTED_QUANTITIES = {"taxable_income", "amt", "income_tax", "total_tax"}
+MFS_AMT_LINE4_RULE = {
+    2024: (875_950.0, 66_650.0),
+    2025: (900_350.0, 68_500.0),
+}
+OTS_2024_MFS_AMT_LINE4_RULE = (831_150.0, 63_250.0)
 
 
 def _f21_taxcalc_qw_qbi_phase_range(
     backend: str, case: dict, reference: dict[str, float] | None
-) -> set[str]:
+) -> DeltaModel:
     """F21: TaxCalc doubles the QBI phase-in range for qualifying widow(er)."""
     if (
         backend not in {"graph", "ots"}
@@ -52,11 +100,11 @@ def _f21_taxcalc_qw_qbi_phase_range(
         or case.get("se", 0) <= 0
         or reference is None
     ):
-        return set()
+        return {}
 
     threshold = QBI_SIMPLIFIED_THRESHOLD.get((case.get("year"), "Widow(er)"))
     if threshold is None:
-        return set()
+        return {}
     if "qbi_deduction" in reference:
         taxable_income_before_qbi = (
             reference["taxable_income"] + reference["qbi_deduction"]
@@ -66,11 +114,22 @@ def _f21_taxcalc_qw_qbi_phase_range(
         deduction = max(standard, case.get("itemized", 0.0))
         taxable_income_before_qbi = max(0.0, reference["agi"] - deduction)
     if threshold < taxable_income_before_qbi < threshold + 100_000.0:
-        return _F21_AFFECTED_QUANTITIES.copy()
-    return set()
+        maximum = max(
+            0.0,
+            reference.get("qbi_deduction", 0.2 * case.get("se", 0.0)),
+        )
+        return {
+            "taxable_income": DeltaRange(0.0, maximum),
+            "amt": DeltaRange(-maximum, maximum),
+            "income_tax": DeltaRange(0.0, maximum),
+            "total_tax": DeltaRange(0.0, maximum),
+        }
+    return {}
 
 
-def _f11_ots_hoh_bracket(backend: str, case: dict) -> set[str]:
+def _f11_ots_hoh_bracket(
+    backend: str, case: dict, reference: dict[str, float] | None
+) -> DeltaModel:
     """F11: upstream OTS 2024 HoH table starts the 32% bracket at $191,150.
 
     The IRS figure (Rev. Proc. 2023-34) is $191,950; taxcalc and graph agree.
@@ -87,21 +146,34 @@ def _f11_ots_hoh_bracket(backend: str, case: dict) -> set[str]:
         or case.get("status") != "Head_of_House"
         or case.get("year") != 2024
     ):
-        return set()
-    gross = sum(
-        case.get(k, 0) for k in ("w2", "se", "stcg", "ltcg", "interest", "ord_div")
+        return {}
+    if reference is None:
+        return {}
+    ordinary_taxable_income = max(
+        0.0,
+        reference["taxable_income"] - max(0.0, _preferential_income(case)),
     )
-    if gross > 210_000:
-        return {"income_tax", "total_tax"}
-    return set()
+    overcharge = 0.08 * min(
+        800.0,
+        max(0.0, ordinary_taxable_income - 191_150.0),
+    )
+    if overcharge == 0.0:
+        return {}
+    return _same_delta({"income_tax", "total_tax"}, DeltaRange.exact(overcharge))
 
 
 def _ordinary_income(case: dict) -> float:
     """Income taxed at ordinary rates, which a deduction displaces first."""
+    net_gain = case.get("stcg", 0.0) + case.get("ltcg", 0.0)
+    preferential_gain = max(0.0, min(case.get("ltcg", 0.0), net_gain))
+    loss_cap = -1_500.0 if case.get("status") == "Married/Sep" else -3_000.0
+    ordinary_capital = (
+        net_gain - preferential_gain if net_gain >= 0.0 else max(net_gain, loss_cap)
+    )
     return (
         case.get("w2", 0)
         + case.get("se", 0)
-        + case.get("stcg", 0)
+        + ordinary_capital
         + case.get("interest", 0)
         + max(0.0, case.get("ord_div", 0) - case.get("qual_div", 0))
     )
@@ -109,10 +181,14 @@ def _ordinary_income(case: dict) -> float:
 
 def _preferential_income(case: dict) -> float:
     """Income taxed at long-term capital gain rates, stacked on top."""
-    return case.get("ltcg", 0) + case.get("qual_div", 0)
+    net_gain = case.get("stcg", 0.0) + case.get("ltcg", 0.0)
+    preferential_gain = max(0.0, min(case.get("ltcg", 0.0), net_gain))
+    return preferential_gain + case.get("qual_div", 0)
 
 
-def _f19_deduction_choice_rule(backend: str, case: dict) -> set[str]:
+def _f19_deduction_choice_rule(
+    backend: str, case: dict, reference: dict[str, float] | None
+) -> DeltaModel:
     """F19: taxcalc picks the CHEAPER deduction; tenforty picks the LARGER one.
 
     Replaces F15, which claimed OTS deducted an itemized aggregate the caller had
@@ -153,25 +229,73 @@ def _f19_deduction_choice_rule(backend: str, case: dict) -> set[str]:
     """
     std = STANDARD_DEDUCTION.get((case.get("year", 2024), case.get("status", "")))
     if std is None or case.get("itemized", 0) <= std:
-        return set()
+        return {}
     if _preferential_income(case) <= 0:
-        return set()
+        return {}
+    if case.get("iso", 0):
+        # The extra deduction can reduce AMT even when it displaces only
+        # zero-rate gains, so TaxCalc may choose itemization on total tax.
+        return {}
     if _ordinary_income(case) > std:
-        return set()
-    return {"taxable_income"}
+        return {}
+    if reference is None:
+        return {}
+    difference = min(
+        case.get("itemized", 0.0) - std,
+        max(0.0, reference["taxable_income"]),
+    )
+    return {"taxable_income": DeltaRange.exact(-difference)}
 
 
-def _f7_itemized_semantics(backend: str, case: dict) -> set[str]:
+def _f7_itemized_semantics(
+    backend: str, case: dict, reference: dict[str, float] | None
+) -> DeltaModel:
     """F7: OTS forces itemization; taxcalc and graph take best-of."""
     if backend != "ots" or case.get("std_or_item") != "Itemized":
-        return set()
+        return {}
     std = STANDARD_DEDUCTION.get((case.get("year", 2024), case.get("status", "")))
-    if std is not None and case.get("itemized", 0) < std:
-        return {"taxable_income", "income_tax", "total_tax"}
-    return set()
+    if std is None or case.get("itemized", 0) >= std or reference is None:
+        return {}
+    agi = reference["agi"]
+    gross_taxable_delta = max(0.0, agi - case.get("itemized", 0.0)) - max(
+        0.0, agi - std
+    )
+    if gross_taxable_delta == 0.0:
+        return {}
+    reference_qbi = reference.get("qbi_deduction", 0.0)
+    pre_qbi_taxable = reference["taxable_income"] + reference_qbi
+    qbi_threshold = QBI_SIMPLIFIED_THRESHOLD.get((case.get("year"), case.get("status")))
+    if (
+        case.get("se", 0.0) > 0.0
+        and qbi_threshold is not None
+        and pre_qbi_taxable + gross_taxable_delta <= qbi_threshold
+    ):
+        taxable_delta = DeltaRange(
+            0.8 * gross_taxable_delta,
+            gross_taxable_delta,
+        )
+    else:
+        qbi_component_bound = 0.2 * max(
+            0.0,
+            case.get("se", 0.0) - 0.5 * reference.get("se_tax", 0.0),
+        )
+        taxable_delta = DeltaRange(
+            max(0.0, gross_taxable_delta - qbi_component_bound),
+            gross_taxable_delta + qbi_component_bound,
+        )
+    return {
+        "taxable_income": taxable_delta,
+        # The higher regular tax from forced itemization can reduce AMT
+        # dollar-for-dollar. Bound that reduction by the 37% top regular rate.
+        "amt": DeltaRange(-0.37 * taxable_delta.maximum, 0.0),
+        "income_tax": DeltaRange(0.0, taxable_delta.maximum),
+        "total_tax": DeltaRange(0.0, taxable_delta.maximum),
+    }
 
 
-def _f12_itemized_category_amt(backend: str, case: dict) -> set[str]:
+def _f12_itemized_category_amt(
+    backend: str, case: dict, reference: dict[str, float] | None
+) -> DeltaModel:
     """F12: per-engine Schedule A category for the itemized aggregate.
 
     OTS carries it as A6 "other taxes" (AMT add-back); graph as L16 "other
@@ -180,11 +304,18 @@ def _f12_itemized_category_amt(backend: str, case: dict) -> set[str]:
     (categorized deductions, input model v2).
     """
     if backend == "ots" and case.get("itemized", 0):
-        return {"amt", "income_tax", "total_tax"}
-    return set()
+        # Inside the AMT exemption phaseout, each extra dollar of AMTI incurs
+        # 28 cents directly plus 7 cents through the 25% exemption reduction.
+        # The preferential worksheet can also displace gain into its 20% band.
+        rate = 0.55 if _preferential_income(case) > 0.0 else 0.35
+        maximum = rate * case["itemized"]
+        return _same_delta({"amt", "income_tax", "total_tax"}, DeltaRange(0.0, maximum))
+    return {}
 
 
-def _f14_taxcalc_omits_amt_std_addback(backend: str, case: dict) -> set[str]:
+def _f14_taxcalc_omits_amt_std_addback(
+    backend: str, case: dict, reference: dict[str, float] | None
+) -> DeltaModel:
     """F14: taxcalc omits the Form 6251 line 2a standard-deduction add-back.
 
     Adjudicated (tenforty-ztx): for a non-itemizer the standard deduction is
@@ -197,29 +328,169 @@ def _f14_taxcalc_omits_amt_std_addback(backend: str, case: dict) -> set[str]:
     here, not us. Upstream note filed to PSL (docs/upstream-taxcalc-reports.md);
     delete this once a taxcalc release carries the correction.
     """
-    if case.get("iso", 0) and case.get("std_or_item") == "Standard":
-        return {"amt", "income_tax", "total_tax"}
-    return set()
+    std = STANDARD_DEDUCTION.get((case.get("year"), case.get("status")))
+    if (
+        case.get("iso", 0)
+        and std is not None
+        and case.get("itemized", 0.0) <= std
+        and reference is not None
+    ):
+        # TaxCalc starts AMTI from AGI less the standard deduction. Form 6251
+        # starts from taxable income (floored at zero) and adds the standard
+        # deduction back. Below the taxable-income floor, that makes the AMTI
+        # gap the standard deduction plus the unused part of the deduction.
+        amti_gap = std + max(0.0, std - reference["agi"])
+        return _same_delta(
+            {"amt", "income_tax", "total_tax"}, DeltaRange(0.0, 0.35 * amti_gap)
+        )
+    return {}
 
 
-SIGNATURES: list[Callable[[str, dict], set[str]]] = [
-    _f7_itemized_semantics,
-    _f11_ots_hoh_bracket,
-    _f12_itemized_category_amt,
-    _f19_deduction_choice_rule,
-    _f14_taxcalc_omits_amt_std_addback,
+def _f22_ots_amt_taxable_income_floor(
+    backend: str, case: dict, reference: dict[str, float] | None
+) -> DeltaModel:
+    """F22: OTS cancels the AMT add-back when regular taxable income is zero.
+
+    OTS substitutes the unfloored ``L11 - L14`` for Form 6251 line 1 whenever
+    Form 1040 line 15 is zero. Adding the standard deduction on line 2a then
+    cancels the unused deduction instead of starting from the required zero.
+    The signed model is negative relative to the correct Form 6251 result; it
+    composes with F14's positive TaxCalc-reference delta.
+    """
+    std = STANDARD_DEDUCTION.get((case.get("year"), case.get("status")))
+    if (
+        backend != "ots"
+        or not case.get("iso", 0)
+        or case.get("std_or_item") != "Standard"
+        or std is None
+        or case.get("itemized", 0.0) > std
+        or reference is None
+    ):
+        return {}
+    deduction = std + reference.get("qbi_deduction", 0.0)
+    missing_floor = max(0.0, deduction - reference["agi"])
+    if missing_floor == 0.0:
+        return {}
+    return _same_delta(
+        {"amt", "income_tax", "total_tax"},
+        DeltaRange(-0.35 * missing_floor, 0.0),
+    )
+
+
+def _mfs_amt_line4_addition(amti: float, threshold: float, cap: float) -> float:
+    return min(cap, 0.25 * max(0.0, amti - threshold))
+
+
+def _f23_taxcalc_graph_omit_mfs_amt_increase(
+    backend: str, case: dict, reference: dict[str, float] | None
+) -> DeltaModel:
+    """F23: TaxCalc and graph omit the high-income MFS line-4 increase."""
+    if (
+        backend != "ots"
+        or case.get("status") != "Married/Sep"
+        or reference is None
+        or "amti" not in reference
+    ):
+        return {}
+    rule = MFS_AMT_LINE4_RULE.get(case.get("year"))
+    if rule is None:
+        return {}
+    ots_amti = reference["amti"] + max(0.0, case.get("itemized", 0.0))
+    addition = _mfs_amt_line4_addition(ots_amti, *rule)
+    if addition == 0.0:
+        return {}
+    return _same_delta(
+        {"amt", "income_tax", "total_tax"}, DeltaRange(0.0, 0.28 * addition)
+    )
+
+
+def _f24_ots_2024_mfs_amt_constants(
+    backend: str, case: dict, reference: dict[str, float] | None
+) -> DeltaModel:
+    """F24: OTS 2024 applies the 2023 MFS line-4 threshold and cap."""
+    if (
+        backend != "ots"
+        or case.get("year") != 2024
+        or case.get("status") != "Married/Sep"
+        or reference is None
+        or "amti" not in reference
+    ):
+        return {}
+    ots_amti = reference["amti"] + max(0.0, case.get("itemized", 0.0))
+    official = _mfs_amt_line4_addition(ots_amti, *MFS_AMT_LINE4_RULE[2024])
+    stale = _mfs_amt_line4_addition(ots_amti, *OTS_2024_MFS_AMT_LINE4_RULE)
+    tax_delta = 0.28 * (stale - official)
+    if tax_delta == 0.0:
+        return {}
+    delta = DeltaRange(min(0.0, tax_delta), max(0.0, tax_delta))
+    return _same_delta({"amt", "income_tax", "total_tax"}, delta)
+
+
+def _f25_graph_2025_mfs_amt_cg_ceiling(
+    backend: str, case: dict, reference: dict[str, float] | None
+) -> DeltaModel:
+    """F25: graph Form 6251 uses $266,700, not $300,000, for 2025 MFS."""
+    if (
+        backend != "graph"
+        or case.get("year") != 2025
+        or case.get("status") != "Married/Sep"
+    ):
+        return {}
+    preferential = max(0.0, _preferential_income(case))
+    if preferential == 0.0:
+        return {}
+    overcharge = 0.05 * min(33_300.0, preferential)
+    return _same_delta({"amt", "income_tax", "total_tax"}, DeltaRange(0.0, overcharge))
+
+
+def _f26_taxcalc_itemized_amt_floor(
+    backend: str, case: dict, reference: dict[str, float] | None
+) -> DeltaModel:
+    """F26: TaxCalc lets unused itemization reduce AMTI below Form 1040 line 15."""
+    if (
+        backend != "graph"
+        or not case.get("iso", 0.0)
+        or case.get("itemized", 0.0) <= 0.0
+        or reference is None
+        or reference.get("taxable_income") != 0.0
+    ):
+        return {}
+    unused = max(
+        0.0,
+        case["itemized"] + reference.get("qbi_deduction", 0.0) - reference["agi"],
+    )
+    if unused == 0.0:
+        return {}
+    rate = 0.55 if _preferential_income(case) > 0.0 else 0.35
+    return _same_delta(
+        {"amt", "income_tax", "total_tax"}, DeltaRange(0.0, rate * unused)
+    )
+
+
+SIGNATURES = [
+    KnownDefect("F7", _f7_itemized_semantics),
+    KnownDefect("F11", _f11_ots_hoh_bracket),
+    KnownDefect("F12", _f12_itemized_category_amt),
+    KnownDefect("F14", _f14_taxcalc_omits_amt_std_addback),
+    KnownDefect("F19", _f19_deduction_choice_rule),
+    KnownDefect("F21", _f21_taxcalc_qw_qbi_phase_range),
+    KnownDefect("F22", _f22_ots_amt_taxable_income_floor),
+    KnownDefect("F23", _f23_taxcalc_graph_omit_mfs_amt_increase),
+    KnownDefect("F24", _f24_ots_2024_mfs_amt_constants),
+    KnownDefect("F25", _f25_graph_2025_mfs_amt_cg_ceiling),
+    KnownDefect("F26", _f26_taxcalc_itemized_amt_floor),
 ]
 
 
-def excused_quantities(
+def modeled_deltas(
     backend: str, case: dict, reference: dict[str, float] | None = None
-) -> set[str]:
-    """Return quantities whose disagreement is attributable to a known defect."""
-    excused: set[str] = set()
-    for signature in SIGNATURES:
-        excused |= signature(backend, case)
-    excused |= _f21_taxcalc_qw_qbi_phase_range(backend, case, reference)
-    return excused
+) -> DeltaModel:
+    """Combine the bounded deltas for every active finding matching a case."""
+    combined: DeltaModel = {}
+    for defect in SIGNATURES:
+        for quantity, delta in defect.signature(backend, case, reference).items():
+            combined[quantity] = combined.get(quantity, ZERO_DELTA) + delta
+    return combined
 
 
 # Tolerance policy (tribunal finding, unanimous): the $50-step 1040 tax tables
@@ -235,6 +506,7 @@ TAX_TABLE_CEILING = 100_000.0
 # taxcalc computes exact preferential-rate math. Observed differences are
 # a few dollars.
 GAINS_WORKSHEET_TOL = 10.0
+GAINS_WORKSHEET_MIN = 1_000.0
 
 
 def tolerance(
@@ -244,7 +516,12 @@ def tolerance(
     if quantity in ("total_tax", "income_tax") and backend == "ots":
         if taxable_income < TAX_TABLE_CEILING:
             return TAX_TABLE_TOL
-        if case is not None and (case.get("stcg", 0) or case.get("ltcg", 0)):
+        gains = (
+            abs(case.get("stcg", 0.0)) + abs(case.get("ltcg", 0.0))
+            if case is not None
+            else 0.0
+        )
+        if gains >= GAINS_WORKSHEET_MIN:
             return GAINS_WORKSHEET_TOL
     return COMPONENT_TOL
 
@@ -305,17 +582,22 @@ def unexcused_violations(
     pass expected_alt (the spouse-attribution run) to form bounds.
     """
     ours = evaluate_components(case, backend)
-    excused = excused_quantities(backend, case, expected)
+    deltas = modeled_deltas(backend, case, expected)
     violations = []
     for quantity in QUANTITIES:
         exp_alt = expected_alt or expected
         lo = min(expected[quantity], exp_alt[quantity])
         hi = max(expected[quantity], exp_alt[quantity])
         tol = tolerance(backend, quantity, expected["taxable_income"], case)
-        diff = max(lo - ours[quantity], ours[quantity] - hi, 0.0)
-        if diff > tol and quantity not in excused:
+        delta = deltas.get(quantity, ZERO_DELTA)
+        allowed_lo = lo + delta.minimum - tol
+        allowed_hi = hi + delta.maximum + tol
+        residual = max(allowed_lo - ours[quantity], ours[quantity] - allowed_hi, 0.0)
+        if residual > 0.0:
             violations.append(
                 f"{case}: {quantity} got={ours[quantity]:,.2f} "
-                f"expected=[{lo:,.2f}, {hi:,.2f}] (diff {diff:,.2f} > {tol})"
+                f"expected=[{lo:,.2f}, {hi:,.2f}] + "
+                f"delta=[{delta.minimum:,.2f}, {delta.maximum:,.2f}] "
+                f"+/- {tol} (residual {residual:,.2f})"
             )
     return violations


### PR DESCRIPTION
## Summary

- replace quantity-wide known-defect excusals with signed, bounded delta models and make Hypothesis target the residual outside those ranges
- enforce the finding lifecycle across the audit ledger, one policy signature, one strict-xfail burn-in, and at least one committed golden witness
- expand the pinned TaxCalc 6.7.2 corpus from 902 to 1,179 cases, adding ISO/AMT, negative gains, high-income MFS, taxable-income-floor, and deduction-choice strata
- verify fixture provenance and semantic regeneration in the existing TaxCalc adapter job; the full randomized differential remains a local-only gate
- compare scalar and batch results over every `InterpretedTaxReturn` field, including the tenforty-7d0 acceptance criteria
- add tax-component identity checks and require a material gain before granting the OTS gains-workbook tolerance

## Findings exposed

The widened differential isolated and recorded five additional bounded defects without changing either compute engine:

- F22 / `tenforty-by2`: OTS loses the Form 1040 taxable-income floor in Form 6251
- F23 / `tenforty-3bt` + `tenforty-doo`: graph and TaxCalc omit the high-income MFS line-4 increase
- F24 / `tenforty-2jv`: OTS 2024 uses stale 2023 MFS line-4 constants
- F25 / `tenforty-c9a`: graph Form 6251 retains the stale 2025 MFS preferential ceiling
- F26 / `tenforty-w7t`: TaxCalc lets unused itemization reduce AMTI below the taxable-income floor

Strict burn-ins, bounded signatures, golden witnesses, and staged upstream reports are included for each applicable finding. The F24 witness lies between the stale and official thresholds, so F24 is exercised while F23 is exactly zero; this also pins the stale addition's 35% exemption-phaseout effect.

Bead: `tenforty-y90` (consolidates `tenforty-7d0`)

## Validation

- `uv run pytest tests/ -q --tb=line` — 1,095 passed, 13 skipped, 27 xfailed
- `TENFORTY_TAXCALC=1 uv run pytest tests/taxcalc/ -q --tb=line` — 50 passed, 4 xfailed
- `TENFORTY_TAXCALC=1 uv run python scripts/taxcalc_audit.py --check-goldens tests/taxcalc/fixtures/taxcalc_goldens.json` — 1,179 cases, fixture current
- F24 refinement: live 1,179-case golden evaluation and focused policy/lifecycle suite passed
- pre-commit hooks — passed on every changed file

No deep/soak sweep: this changes the differential harness, fixtures, tests, and documentation, not a compute engine.
