### PR TITLE
test(ots): pin AMT preferential worksheet defect

### DIFF
--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -41,6 +41,7 @@ signature, and update this table in the same PR.
 | F24 | OTS 2024 MFS AMTI increase uses stale 2023 constants | upstream OpenTaxSolver | open (tenforty-2jv; upstream report pending) | F23 adjudication |
 | F25 | Graph Form 6251 uses stale 2025 MFS 15%-gain ceiling | graph spec | open (tenforty-c9a) | randomized MFS ISO/gain differential |
 | F26 | TaxCalc lets unused itemization reduce AMTI below the taxable-income floor | upstream TaxCalc | open (tenforty-w7t; upstream report pending) | randomized itemized ISO/loss differential |
+| F27 | OTS skips the AMT preferential-rate worksheet when regular taxable income is zero | upstream OpenTaxSolver | open (tenforty-909.1; upstream report pending) | randomized zero-taxable-income ISO/dividend differential |
 
 ## Method
 
@@ -674,3 +675,36 @@ Graph starts line 1 at zero and reports AMT **$58,376.32**. TaxCalc carries the
 F26 applies only to the positive graph-minus-TaxCalc effect of that unused
 deduction, bounded by the same AMT/preferential slopes as F12. A TaxCalc
 strict-xfail, upstream draft, and golden witness track `tenforty-w7t`.
+
+### F27. NEW, ADJUDICATED — OTS skips the AMT preferential-rate worksheet at zero taxable income
+
+The zero-taxable-income path exposes a second OTS defect independent of F22.
+The 2024 1040 routine does not run its qualified-dividend or Schedule D tax
+worksheet when line 15 is zero. Form 6251 Part III nevertheless reads the
+worksheet arrays when qualified dividends or gains are present. Their
+zero-initialized values make the AMT computation treat all AMT taxable income
+as ordinary rather than preserving its preferential component. The 2025
+routine has the same control flow.
+
+The deterministic witness is 2024 Head of Household with $17,322 of ordinary
+dividends, all qualified, a $200,000 ISO spread, and the standard deduction.
+The official path has AMTI $221,900 and AMT taxable income $136,200. Removing
+the $17,322 preferential component leaves $118,878 taxed at 26%, for AMT
+**$30,908.28**.
+
+OTS also carries F22 on this return, putting AMT taxable income at $131,622.
+With only F22, Part III would tax $114,300 of ordinary AMT income and report
+**$29,718.00**. Instead the uninitialized worksheet makes OTS tax the full
+$131,622 at 26%, reporting **$34,221.72**. Thus F27 contributes exactly
+$4,503.72, while F22 separately contributes -$1,190.28 relative to the
+official path. TaxCalc's **$24,024.00** remains the already-adjudicated F14
+standard-deduction defect.
+
+The F27 signature is a nonnegative OTS correction bounded by 28% of the
+preferential income, the largest amount skipping Part III can add. It applies
+only when TaxCalc regular taxable income is zero, preference income and an ISO
+adjustment are present, and composes with F14 and F22. A deterministic
+differential anchor prevents the randomized suite from rediscovering the case
+as an unclassified failure. The strict-xfail accepts either the F22-only result
+or the fully corrected result, so an upstream F27 correction flips it even if
+F22 remains. Tracked by `tenforty-909.1`; the vendored source is unchanged.

--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -686,11 +686,26 @@ zero-initialized values make the AMT computation treat all AMT taxable income
 as ordinary rather than preserving its preferential component. The 2025
 routine has the same control flow.
 
-The deterministic witness is 2024 Head of Household with $17,322 of ordinary
-dividends, all qualified, a $200,000 ISO spread, and the standard deduction.
-The official path has AMTI $221,900 and AMT taxable income $136,200. Removing
-the $17,322 preferential component leaves $118,878 taxed at 26%, for AMT
-**$30,908.28**.
+The cleanest isolated witness is 2024 Head of Household with a $200,000 ISO
+spread and ordinary dividends all reported as qualified. At exactly the
+$21,900 standard deduction, F22's unused-deduction error is zero, but F27 makes
+OTS tax the entire AMT base at 26%. One additional dollar activates the
+regular-tax worksheet and makes the defect disappear:
+
+| qualified dividends | taxable income | OTS AMT | graph AMT |
+|---:|---:|---:|---:|
+| $21,900 | $0 | $35,412.00 | $29,718.00 |
+| $21,901 | $1 | $29,718.00 | $29,718.00 |
+
+The $5,694 cliff is exactly 26% of $21,900. The same boundary reproduces in
+2025: OTS falls from $35,236.50 to $29,094.00 when taxable income moves from
+zero to one dollar, a $6,142.50 drop equal to 26% of the $23,625 standard
+deduction.
+
+The randomized differential originally exposed a composite 2024 witness with
+$17,322 of qualified dividends. Its official path has AMTI $221,900 and AMT
+taxable income $136,200. Removing the $17,322 preferential component leaves
+$118,878 taxed at 26%, for AMT **$30,908.28**.
 
 OTS also carries F22 on this return, putting AMT taxable income at $131,622.
 With only F22, Part III would tax $114,300 of ordinary AMT income and report
@@ -705,6 +720,7 @@ preferential income, the largest amount skipping Part III can add. It applies
 only when TaxCalc regular taxable income is zero, preference income and an ISO
 adjustment are present, and composes with F14 and F22. A deterministic
 differential anchor prevents the randomized suite from rediscovering the case
-as an unclassified failure. The strict-xfail accepts either the F22-only result
-or the fully corrected result, so an upstream F27 correction flips it even if
-F22 remains. Tracked by `tenforty-909.1`; the vendored source is unchanged.
+as an unclassified failure. The strict-xfail uses the exact-standard-deduction
+boundary where F22 is inert, while a passing companion pins the correct result
+one dollar above it. Tracked by `tenforty-909.1`; the vendored source is
+unchanged.

--- a/docs/upstream-ots-reports.md
+++ b/docs/upstream-ots-reports.md
@@ -256,9 +256,24 @@ if ((L[7] != 0.0) || (L3a != 0.0)
 Because the skipped worksheets never populate `qcgws`, Part III sees no
 preferential income and applies the ordinary AMT rate to the entire base.
 
-**Minimal reproducer:** 2024 Head of Household, under age 65, $17,322 of
-ordinary dividends all reported as qualified dividends, the standard
-deduction, and a $200,000 ISO adjustment on `AMTws3`.
+**Minimal reproducer:** 2024 Head of Household, under age 65, a $200,000 ISO
+adjustment on `AMTws3`, and ordinary dividends all reported as qualified.
+
+| qualified dividends | regular taxable income | OpenTaxSolver AMT | correct AMT |
+|---:|---:|---:|---:|
+| $21,900 | $0 | **$35,412.00** | **$29,718.00** |
+| $21,901 | $1 | **$29,718.00** | **$29,718.00** |
+
+At exactly the $21,900 standard deduction, the separate line-1 floor issue in
+report 3 contributes nothing. The $5,694 AMT drop caused by adding one dollar
+of income therefore isolates this issue: $5,694 is exactly 26% of the $21,900
+qualified dividend. The cliff occurs precisely where the regular-tax
+preferential worksheet starts running. The same boundary reproduces in 2025,
+where OTS falls from $35,236.50 to $29,094.00 between $0 and $1 of regular
+taxable income.
+
+The original differential witness used $17,322 of qualified dividends. It
+shows how this issue composes with report 3:
 
 | quantity | official Form 6251 | OTS with only the separate line-1 defect | OpenTaxSolver2024_22.06 |
 |---|---:|---:|---:|
@@ -267,10 +282,8 @@ deduction, and a $200,000 ISO adjustment on `AMTws3`.
 | ordinary AMT income | $118,878.00 | $114,300.00 | $131,622.00 |
 | AMT | **$30,908.28** | **$29,718.00** | **$34,221.72** |
 
-The middle column isolates the separate line-1 floor issue described in report
-3. Holding that lower OTS AMT base fixed, skipping the preferential worksheet
-adds exactly $4,503.72, or 26% of the $17,322 qualified dividend. The same
-control-flow issue reproduces in the 2025 routine.
+Holding the lower OTS AMT base fixed, skipping the preferential worksheet adds
+exactly $4,503.72, or 26% of the $17,322 qualified dividend.
 
 **Suggested fix:** make the preferential-income inputs required by Form 6251
 Part III available independently of whether the regular-tax worksheet itself

--- a/docs/upstream-ots-reports.md
+++ b/docs/upstream-ots-reports.md
@@ -219,3 +219,65 @@ to the 2024 release.
 
 We have not patched the vendored source because this is a tax-logic change. A
 strict-xfail records it until an upstream release carries the corrected table.
+
+---
+
+## 5. Form 6251 loses qualified dividends when regular taxable income is zero
+
+**Releases:** OpenTaxSolver2024_22.06, OpenTaxSolver2025_23.06
+**Files:**
+- `src/taxsolve_US_1040_2024.c`
+- `src/taxsolve_US_1040_2025.c`
+
+The 1040 routine deliberately skips its qualified-dividend and Schedule D tax
+worksheets when regular taxable income is zero:
+
+```c
+if (L[15] <= 0.0)
+  {
+   /* Do not use QDCGT or Schedule D Tax Worksheets. */
+  }
+else if (Do_QDCGTW)
+  capgains_qualdividends_worksheets(status);
+```
+
+Form 6251 Part III still uses the worksheet arrays when qualified dividends or
+capital gains are present:
+
+```c
+if ((L[7] != 0.0) || (L3a != 0.0)
+    || ((SchedD[15] > 0.0) && (SchedD[16] > 0.0)))
+  {
+   amtws[13] = largerof(qcgws[4], ws_sched_D[13]);
+   /* ... */
+  }
+```
+
+Because the skipped worksheets never populate `qcgws`, Part III sees no
+preferential income and applies the ordinary AMT rate to the entire base.
+
+**Minimal reproducer:** 2024 Head of Household, under age 65, $17,322 of
+ordinary dividends all reported as qualified dividends, the standard
+deduction, and a $200,000 ISO adjustment on `AMTws3`.
+
+| quantity | official Form 6251 | OTS with only the separate line-1 defect | OpenTaxSolver2024_22.06 |
+|---|---:|---:|---:|
+| AMT taxable income | $136,200.00 | $131,622.00 | $131,622.00 |
+| preferential income recognized | $17,322.00 | $17,322.00 | $0.00 |
+| ordinary AMT income | $118,878.00 | $114,300.00 | $131,622.00 |
+| AMT | **$30,908.28** | **$29,718.00** | **$34,221.72** |
+
+The middle column isolates the separate line-1 floor issue described in report
+3. Holding that lower OTS AMT base fixed, skipping the preferential worksheet
+adds exactly $4,503.72, or 26% of the $17,322 qualified dividend. The same
+control-flow issue reproduces in the 2025 routine.
+
+**Suggested fix:** make the preferential-income inputs required by Form 6251
+Part III available independently of whether the regular-tax worksheet itself
+is applicable. Calling the regular worksheet unconditionally may not match its
+instructions; deriving or initializing the Part III inputs inside the AMT path
+would avoid coupling them to Form 1040 line 15.
+
+We have not patched the vendored source because this changes a computed tax
+figure. A strict-xfail records the defect until an upstream release carries a
+correction.

--- a/tests/known_defects_test.py
+++ b/tests/known_defects_test.py
@@ -345,33 +345,59 @@ def test_ots_amt_preserves_the_zero_taxable_income_floor():
 )
 @skip_if_graph_unavailable
 @pytest.mark.parametrize(
-    ("year", "floor_only_amt", "official_amt"),
+    ("year", "qualified_dividends", "official_amt"),
     [
-        (2024, 29_718.00, 30_908.28),
-        (2025, 29_094.00, 30_732.78),
+        (2024, 21_900.0, 29_718.00),
+        (2025, 23_625.0, 29_094.00),
     ],
 )
 def test_ots_initializes_amt_preferential_inputs_at_zero_taxable_income(
     year,
-    floor_only_amt,
+    qualified_dividends,
     official_amt,
 ):
     """Part III must see qualified dividends even when Form 1040 line 15 is zero."""
     kwargs = dict(
         year=year,
         filing_status="Head_of_House",
-        ordinary_dividends=17_322.0,
-        qualified_dividends=17_322.0,
+        ordinary_dividends=qualified_dividends,
+        qualified_dividends=qualified_dividends,
         incentive_stock_option_gains=200_000.0,
     )
     ots = evaluate_return(backend="ots", **kwargs)
     graph = evaluate_return(backend="graph", **kwargs)
 
-    assert any(
-        ots.federal_amt == pytest.approx(expected, abs=1.0)
-        for expected in (floor_only_amt, graph.federal_amt)
+    assert ots.federal_amt == pytest.approx(graph.federal_amt, abs=0.01)
+    assert graph.federal_amt == pytest.approx(official_amt, abs=0.01)
+
+
+@skip_if_graph_unavailable
+@pytest.mark.parametrize(
+    ("year", "qualified_dividends", "official_amt"),
+    [
+        (2024, 21_901.0, 29_718.00),
+        (2025, 23_626.0, 29_094.00),
+    ],
+)
+def test_ots_amt_preferential_cliff_ends_above_zero_taxable_income(
+    year,
+    qualified_dividends,
+    official_amt,
+):
+    """One taxable dollar activates the preferential-rate worksheet in OTS."""
+    kwargs = dict(
+        year=year,
+        filing_status="Head_of_House",
+        ordinary_dividends=qualified_dividends,
+        qualified_dividends=qualified_dividends,
+        incentive_stock_option_gains=200_000.0,
     )
-    assert graph.federal_amt == pytest.approx(official_amt, abs=1.0)
+    ots = evaluate_return(backend="ots", **kwargs)
+    graph = evaluate_return(backend="graph", **kwargs)
+
+    assert ots.federal_taxable_income == pytest.approx(1.0, abs=0.01)
+    assert ots.federal_amt == pytest.approx(graph.federal_amt, abs=0.01)
+    assert graph.federal_amt == pytest.approx(official_amt, abs=0.01)
 
 
 @skip_if_graph_unavailable

--- a/tests/known_defects_test.py
+++ b/tests/known_defects_test.py
@@ -338,6 +338,42 @@ def test_ots_amt_preserves_the_zero_taxable_income_floor():
     assert graph.federal_amt == pytest.approx(35_412.00, abs=1.0)
 
 
+@pytest.mark.xfail(
+    reason="F27: OTS skips the AMT preferential-rate worksheet when regular "
+    "taxable income is zero",
+    strict=True,
+)
+@skip_if_graph_unavailable
+@pytest.mark.parametrize(
+    ("year", "floor_only_amt", "official_amt"),
+    [
+        (2024, 29_718.00, 30_908.28),
+        (2025, 29_094.00, 30_732.78),
+    ],
+)
+def test_ots_initializes_amt_preferential_inputs_at_zero_taxable_income(
+    year,
+    floor_only_amt,
+    official_amt,
+):
+    """Part III must see qualified dividends even when Form 1040 line 15 is zero."""
+    kwargs = dict(
+        year=year,
+        filing_status="Head_of_House",
+        ordinary_dividends=17_322.0,
+        qualified_dividends=17_322.0,
+        incentive_stock_option_gains=200_000.0,
+    )
+    ots = evaluate_return(backend="ots", **kwargs)
+    graph = evaluate_return(backend="graph", **kwargs)
+
+    assert any(
+        ots.federal_amt == pytest.approx(expected, abs=1.0)
+        for expected in (floor_only_amt, graph.federal_amt)
+    )
+    assert graph.federal_amt == pytest.approx(official_amt, abs=1.0)
+
+
 @skip_if_graph_unavailable
 def test_graph_applies_the_high_income_mfs_amt_increase():
     """2025 MFS line 4 adds 25% of AMTI above $900,350."""

--- a/tests/taxcalc/policy_test.py
+++ b/tests/taxcalc/policy_test.py
@@ -18,6 +18,7 @@ from .taxcalc_policy import (
     _f24_ots_2024_mfs_amt_constants,
     _f25_graph_2025_mfs_amt_cg_ceiling,
     _f26_taxcalc_itemized_amt_floor,
+    _f27_ots_skips_amt_preferential_worksheet,
     tolerance,
 )
 
@@ -222,6 +223,27 @@ def test_f26_bounds_only_the_unused_itemized_deduction():
 
     assert model["amt"].minimum == 0.0
     assert model["amt"].maximum == pytest.approx(0.55 * 3_370.0)
+
+
+def test_f27_bounds_the_uninitialized_amt_preferential_worksheet():
+    """Skipping Part III can overstate AMT by at most 28% of preference income."""
+    case = _case(
+        year=2024,
+        status="Head_of_House",
+        ord_div=17_322.0,
+        qual_div=17_322.0,
+        iso=200_000.0,
+    )
+    reference = {"taxable_income": 0.0}
+
+    model = _f27_ots_skips_amt_preferential_worksheet("ots", case, reference)
+
+    assert model["amt"] == DeltaRange(0.0, 0.28 * 17_322.0)
+    assert _f27_ots_skips_amt_preferential_worksheet("graph", case, reference) == {}
+    assert (
+        _f27_ots_skips_amt_preferential_worksheet("ots", case, {"taxable_income": 1.0})
+        == {}
+    )
 
 
 def test_f7_bounds_the_qbi_cap_response_to_forced_itemization():

--- a/tests/taxcalc/taxcalc_differential_test.py
+++ b/tests/taxcalc/taxcalc_differential_test.py
@@ -191,6 +191,12 @@ ANCHOR_AMT_FLOOR = _anchor(
     status="Head_of_House",
     iso=200_000.0,
 )
+ANCHOR_AMT_ZERO_TI_QUALIFIED_DIVIDENDS = _anchor(
+    status="Head_of_House",
+    ord_div=17_322.0,
+    qual_div=17_322.0,
+    iso=200_000.0,
+)
 ANCHOR_CAPITAL_LOSS = _anchor(
     w2=300_000.0,
     interest=100_000.0,
@@ -357,6 +363,7 @@ def _assert_components_match_taxcalc(backend, cases):
 @example(cases=[ANCHOR_QBI_CAPITAL_GAIN_LIMIT])
 @example(cases=[ANCHOR_AMT_ISO])
 @example(cases=[ANCHOR_AMT_FLOOR])
+@example(cases=[ANCHOR_AMT_ZERO_TI_QUALIFIED_DIVIDENDS])
 @example(cases=[ANCHOR_CAPITAL_LOSS])
 @pytest.mark.parametrize("backend", ["ots", "graph"])
 def test_components_match_taxcalc(backend, cases):

--- a/tests/taxcalc/taxcalc_policy.py
+++ b/tests/taxcalc/taxcalc_policy.py
@@ -490,6 +490,25 @@ def _f26_taxcalc_itemized_amt_floor(
     )
 
 
+def _f27_ots_skips_amt_preferential_worksheet(
+    backend: str, case: dict, reference: dict[str, float] | None
+) -> DeltaModel:
+    """F27: OTS leaves Form 6251's preferential-rate inputs uninitialized."""
+    preferential = _preferential_income(case)
+    if (
+        backend != "ots"
+        or not case.get("iso", 0.0)
+        or preferential <= 0.0
+        or reference is None
+        or reference.get("taxable_income") != 0.0
+    ):
+        return {}
+    return _same_delta(
+        {"amt", "income_tax", "total_tax"},
+        DeltaRange(0.0, 0.28 * preferential),
+    )
+
+
 SIGNATURES = [
     KnownDefect("F7", _f7_itemized_semantics),
     KnownDefect("F11", _f11_ots_hoh_bracket),
@@ -502,6 +521,7 @@ SIGNATURES = [
     KnownDefect("F24", _f24_ots_2024_mfs_amt_constants),
     KnownDefect("F25", _f25_graph_2025_mfs_amt_cg_ceiling),
     KnownDefect("F26", _f26_taxcalc_itemized_amt_floor),
+    KnownDefect("F27", _f27_ots_skips_amt_preferential_worksheet),
 ]
 
 


### PR DESCRIPTION
## Summary

- record F27 as a distinct upstream OpenTaxSolver defect when regular taxable income is zero but Form 6251 Part III needs preferential-income inputs
- compose a nonnegative, 28%-of-preferential-income bound with the existing F14 and F22 models rather than widening either one
- pin the isolated cliff on both sides: at exactly the HoH standard deduction OTS overstates AMT by $5,694.00 in 2024 and $6,142.50 in 2025, then agrees after one additional dollar makes taxable income positive
- retain the mandatory composite differential witness that originally exposed F27
- stage the adjudication and minimal reproducer in the consolidated OTS upstream report
- leave vendored OpenTaxSolver tax logic unchanged

## Validation

- `uv run pytest tests/known_defects_test.py tests/taxcalc/policy_lifecycle_test.py -q --tb=short` — 22 passed, 11 xfailed
- local TaxCalc 6.7.2: `TENFORTY_TAXCALC=1 uv run --group taxcalc pytest tests/taxcalc/ -q --tb=line` — 51 passed, 4 xfailed
- `uv run pytest tests/ -q --tb=line` — 1112 passed, 13 skipped, 28 xfailed
- `make run-hooks`

No deep sweep: this changes tests, differential policy metadata, and documentation only; no compute engine changes.
