### PR TITLE
docs(api): decide federal deduction-choice contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Here are all arguments available for those two functions:
 | `state`                      | str \| None               | None                | Two-letter state code. Income-tax states with OTS support: AZ, CA, MA, MI, NC, NJ, NY, OH, OR, PA, VA. No-income-tax states (AK, FL, NV, SD, TN, TX, WA, WY) also accepted. Other states unsupported for now. |
 | `filing_status`              | str                      | Single              | "Single", "Married/Joint", "Head_of_House", "Married/Sep", "Widow(er)" |
 | `num_dependents`             | int                      | 0                   |                                    |
-| `standard_or_itemized`       | str                      | Standard            | "Standard" or "Itemized"               |
+| `standard_or_itemized`       | str                      | Standard            | Legacy choice: "Standard" is automatic greater-of; "Itemized" forces federal itemization ([contract](docs/deduction-choice-contract.md); graph support pending) |
 | `w2_income`                  | float                    | 0.0                 |                                    |
 | `taxable_interest`           | float                    | 0.0                 |                                    |
 | `qualified_dividends`        | float                    | 0.0                 |                                    |

--- a/docs/deduction-choice-contract.md
+++ b/docs/deduction-choice-contract.md
@@ -30,6 +30,9 @@ says a married-filing-separately filer cannot take the standard deduction when
 their spouse itemizes, so that filer must be able to use itemized deductions
 even when the amount is smaller. See [IRS Topic 501](https://www.irs.gov/taxtopics/tc501)
 and the [2025 Form 1040 instructions](https://www.irs.gov/instructions/i1040gi).
+The IRS also notes that a filer who is eligible for the standard deduction may
+choose a smaller federal itemized deduction when doing so produces a larger
+state-tax benefit. See [Publication 501](https://www.irs.gov/publications/p501).
 OpenTaxSolver's `A18` input already implements this election; the graph backend
 currently drops the choice and is the nonconforming implementation.
 

--- a/docs/deduction-choice-contract.md
+++ b/docs/deduction-choice-contract.md
@@ -1,0 +1,72 @@
+# Federal deduction-choice contract
+
+Status: accepted 2026-08-01. Graph implementation is tracked by
+`tenforty-435`; the input-model-v2 replacement is tracked by `tenforty-avr`.
+
+## Decision
+
+The existing `standard_or_itemized` field keeps its historical, asymmetric
+meaning:
+
+| Legacy value | Contract |
+| --- | --- |
+| `"Standard"` | Choose the greater of the federal standard deduction and the supplied itemized deductions. This is the automatic/default mode despite the legacy name. |
+| `"Itemized"` | Use the supplied federal itemized deductions even when they are zero or less than the standard deduction. |
+
+`itemized_deductions` supplies the itemized candidate in either mode. The
+choice controls the federal Form 1040 deduction. It does not independently
+force a state's deduction method; state forms consume the resulting federal
+figures or apply their own state-specific rules.
+
+## Why
+
+Changing `"Standard"` to mean "force the standard deduction" would silently
+change the default behavior. Both backends have historically selected a larger
+itemized amount when the caller left the default unchanged, and callers can
+currently supply `itemized_deductions` without also changing the choice field.
+
+Removing forced itemization would make valid returns inexpressible. The IRS
+says a married-filing-separately filer cannot take the standard deduction when
+their spouse itemizes, so that filer must be able to use itemized deductions
+even when the amount is smaller. See [IRS Topic 501](https://www.irs.gov/taxtopics/tc501)
+and the [2025 Form 1040 instructions](https://www.irs.gov/instructions/i1040gi).
+OpenTaxSolver's `A18` input already implements this election; the graph backend
+currently drops the choice and is the nonconforming implementation.
+
+This preserves every default-mode result, retains the required election, and
+turns the existing OTS behavior into the explicit compatibility contract.
+
+## Graph implementation contract
+
+`tenforty-435` should make the choice part of the graph rather than selecting a
+different result after evaluation:
+
+1. Lower the legacy value to a graph input that distinguishes automatic choice
+   from forced itemization in scalar, batch, gradient, and solver paths.
+2. In Form 1040, use Schedule A when forced; otherwise use the greater of
+   Schedule A and the standard deduction.
+3. Export or import the actual itemization decision into Form 6251. Inferring
+   itemization from `deduction_taken > standard_deduction` is no longer valid
+   once a smaller itemized amount can be forced, and would apply the wrong AMT
+   line 2a add-back.
+4. Preserve the current default-mode results and make the existing F7 strict
+   xfail pass. Update the TaxCalc differential signature so forced-itemization
+   differences remain attributable for both tenforty backends; TaxCalc does not
+   expose an equivalent force switch.
+5. Test a forced amount below the standard deduction, forced zero itemization,
+   automatic selection on both sides of the threshold, AMT, scalar/batch
+   agreement, and a state return that consumes federal deduction results.
+
+## Input model v2
+
+The legacy name cannot honestly represent all three concepts. Input model v2
+should introduce a choice with `Auto`, `Standard`, and `Itemized`, defaulting to
+`Auto`. During the compatibility window:
+
+- legacy `"Standard"` lowers to `Auto`;
+- legacy `"Itemized"` lowers to `Itemized`;
+- the new `Standard` value is the first unambiguous way to force the standard
+  deduction.
+
+The legacy field can then follow the alias and deprecation schedule owned by
+`tenforty-avr` without changing old calculations during that window.

--- a/docs/taxcalc-differential-audit.md
+++ b/docs/taxcalc-differential-audit.md
@@ -23,7 +23,7 @@ signature, and update this table in the same PR.
 | F4 | Form 8960 L5a omits short-term gains | mapping, both backends | fixed (OTS #296, graph: L5a imports Schedule D L16) | mapping assessment + differential sweep |
 | F5 | Graph Form 8959 Part II drops SE earnings (line 12 used min, not subtract) | graph spec | fixed | mapping assessment + differential sweep |
 | F6 | OTS 8959 never fires with zero wages | OTS activation semantics | fixed | differential sweep |
-| F7 | "Itemized" force vs best-of divergence | API contract | open (owner decision) | differential sweep |
+| F7 | "Itemized" force vs best-of divergence | graph backend | contract decided; implementation pending (`tenforty-435`) | differential sweep |
 | F8 | Cross-mode batch grid explosion | graph batch path | fix in PR #287 | benchmark |
 | F9 | Batch path bypasses TaxReturnInput | graph batch path | fixed (tenforty-tve) | batch-conformance tests |
 | F10 | Short-term gains taxed at preferential rates (QCGWS line 3) | graph spec | fixed | differential grid |
@@ -417,6 +417,17 @@ best-of-both (agreeing with taxcalc, which cannot force). With deductions
 above the standard deduction all three agree. The API contract for
 "Itemized" is currently implemented two different ways.
 
+**Decision (`tenforty-ddj`, 2026-08-01):** preserve the historical default
+without discarding a required tax election. Legacy `"Standard"` remains the
+automatic greater-of mode; `"Itemized"` forces federal itemization even when
+the supplied amount is smaller or zero. Forced itemization is necessary for,
+among other cases, a married-filing-separately filer whose spouse itemizes and
+who is therefore ineligible for the standard deduction. The graph backend is
+the nonconforming implementation; `tenforty-435` owns the fix. Input model v2
+will replace the misleading legacy field with an explicit
+`Auto / Standard / Itemized` choice. See
+[`docs/deduction-choice-contract.md`](deduction-choice-contract.md).
+
 ### Clean areas
 
 Dividends (including the qualified-subset normalization), interest, AMT (no
@@ -442,10 +453,11 @@ bugs are batch-path defects this scalar harness deliberately did not probe.
    - Form 8995: completed in tenforty-2u6 with a preliminary OTS 1040 feeding
      OTS Form 8995, tenforty's Form 8995-A limitation, and a final 1040 pass
      carrying the resulting deduction (F3).
-4. **API decisions** (blocking full correctness, owner's call):
+4. **API decisions**:
    - per-spouse wage/SE fields (completes F1 for MFJ; taxcalc's
      `e00200p`/`e00200s` is a working reference);
-   - define "Itemized": force vs best-of, then make both backends match (F7);
+   - **decided:** legacy `"Standard"` is automatic greater-of and
+     `"Itemized"` forces itemization; make graph conform (F7, `tenforty-435`);
 5. **Keep the reference**: promote the harness to `scripts/`, commit a pinned
    golden fixture set at the semantic boundaries, and run the three-way sweep
    as a scheduled/pre-release job. Parity catches divergence; only an


### PR DESCRIPTION
## Summary

- preserve legacy `standard_or_itemized="Standard"` as automatic greater-of selection
- define `"Itemized"` as a real force-itemize election, including zero or below-standard deductions
- document both reasons the election must remain expressible: mandatory MFS coordination and voluntary itemization for a larger state-tax benefit
- document the graph, Form 6251, differential, and input-model-v2 follow-up requirements
- update F7 from an open owner decision to a decided contract awaiting `tenforty-435`

## Why this contract

Reinterpreting the default `"Standard"` value as forced-standard would silently change existing returns: both backends currently take a larger supplied itemized deduction in default mode.

Removing forced itemization would make valid choices inexpressible. IRS Topic 501 and the Form 1040 instructions require a married-filing-separately filer to itemize when their spouse itemizes. Publication 501 also notes that an otherwise eligible filer may choose a smaller federal itemized deduction when the resulting state-tax benefit is larger. OTS already exposes the election through A18; graph currently drops it.

The eventual input-model-v2 replacement is an explicit `Auto / Standard / Itemized` choice. During migration, legacy `"Standard"` lowers to `Auto` and legacy `"Itemized"` lowers to `Itemized`.

## Follow-up seam

`tenforty-435` must thread the actual itemization decision through Form 1040 and Form 6251. Form 6251 cannot infer itemization from `deduction_taken > standard_deduction`, because a forced itemized amount can be smaller.

The browser accuracy contract `tenforty-ox4.4.2` now depends on this decision, so the app will not invent a third interpretation.

## Validation

- direct 2024/2025 OTS/graph probes for automatic and below-standard forced-itemization behavior
- `uv run pytest tests/ots_force_itemize_test.py tests/known_defects_test.py -q --tb=short` — 24 passed, 10 expected failures
- `make run-hooks`
- `git diff --check`

Documentation/decision only; no compute path changed.
