### PR TITLE
ci(wasm): validate and deploy the Pages artifact

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -60,7 +60,7 @@ jobs:
         cp -R crates/tenforty-graph/pkg target/pages/pkg
         cp src/tenforty/forms/us_tax_graph_*.json target/pages/forms/
 
-    - name: Smoke-test WASM and tax graph
+    - name: Smoke-test WASM tax engine and graphs
       run: node scripts/smoke_wasm_demo.mjs target/pages
 
     - name: Setup Pages
@@ -91,7 +91,7 @@ jobs:
       id: deployment
       uses: actions/deploy-pages@v5
 
-    - name: Smoke-test deployed WASM and tax graph
+    - name: Smoke-test deployed WASM tax engine and graphs
       env:
         PAGE_URL: ${{ steps.deployment.outputs.page_url }}
       run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,23 +4,38 @@ on:
   push:
     branches: [main]
     paths:
+    - Cargo.lock
+    - Cargo.toml
     - crates/tenforty-graph/src/**
+    - crates/tenforty-graph/Cargo.toml
     - crates/tenforty-graph/demo/**
+    - scripts/smoke_wasm_demo.mjs
+    - src/tenforty/forms/**
+    - .github/workflows/pages.yml
+  pull_request:
+    paths:
+    - Cargo.lock
+    - Cargo.toml
+    - crates/tenforty-graph/src/**
+    - crates/tenforty-graph/Cargo.toml
+    - crates/tenforty-graph/demo/**
+    - scripts/smoke_wasm_demo.mjs
     - src/tenforty/forms/**
     - .github/workflows/pages.yml
   workflow_dispatch:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: pages
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
+    permissions:
+      contents: read
+      pages: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
@@ -34,30 +49,56 @@ jobs:
       run: curl --proto '=https' --tlsv1.2 https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
     - name: Build WASM module
-      run: |
-        wasm-pack build --target web --release crates/tenforty-graph -- --features wasm --no-default-features
-        ln -sfn ../pkg crates/tenforty-graph/demo/pkg
+      run: wasm-pack build --target web --release crates/tenforty-graph -- --features wasm --no-default-features
 
-    - name: Copy form data to demo
+    - name: Stage self-contained Pages artifact
       run: |
-        mkdir -p crates/tenforty-graph/demo/forms
-        cp src/tenforty/forms/*.json crates/tenforty-graph/demo/forms/
+        mkdir -p target/pages/forms
+        cp crates/tenforty-graph/demo/index.html target/pages/
+        cp crates/tenforty-graph/demo/app.js target/pages/
+        cp crates/tenforty-graph/demo/style.css target/pages/
+        cp -R crates/tenforty-graph/pkg target/pages/pkg
+        cp src/tenforty/forms/us_tax_graph_*.json target/pages/forms/
+
+    - name: Smoke-test WASM and tax graph
+      run: node scripts/smoke_wasm_demo.mjs target/pages
 
     - name: Setup Pages
+      if: github.event_name != 'pull_request'
       uses: actions/configure-pages@v6
 
     - name: Upload artifact
+      if: github.event_name != 'pull_request'
       uses: actions/upload-pages-artifact@v5
       with:
-        path: crates/tenforty-graph/demo
+        path: target/pages
 
   deploy:
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
     steps:
+    - uses: actions/checkout@v7
+
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@v5
+
+    - name: Smoke-test deployed WASM and tax graph
+      env:
+        PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+      run: |
+        smoke_dir=$(mktemp -d)
+        mkdir -p "$smoke_dir/pkg" "$smoke_dir/forms"
+        for asset in index.html app.js style.css pkg/graphlib.js pkg/graphlib_bg.wasm forms/us_tax_graph_2024.json forms/us_tax_graph_2025.json; do
+          curl --fail --location --retry 12 --retry-all-errors --retry-delay 5 \
+            "${PAGE_URL%/}/$asset" --output "$smoke_dir/$asset"
+        done
+        node scripts/smoke_wasm_demo.mjs "$smoke_dir"

--- a/crates/tenforty-graph/demo/README.md
+++ b/crates/tenforty-graph/demo/README.md
@@ -1,0 +1,17 @@
+# WASM tax calculator
+
+The browser demo runs the Rust graph runtime entirely in WebAssembly; tax data
+does not leave the browser. The deployed site is
+[mmacpherson.github.io/tenforty](https://mmacpherson.github.io/tenforty/).
+
+Build and serve it locally with:
+
+```console
+make wasm-serve
+```
+
+The Pages workflow builds a self-contained artifact, loads the generated WASM
+module and a resolved tax graph on every relevant pull request, and deploys only
+from `main`. GitHub Pages must be enabled for the repository with **GitHub
+Actions** selected as its publishing source; the workflow token cannot enable a
+Pages site itself.

--- a/crates/tenforty-graph/demo/README.md
+++ b/crates/tenforty-graph/demo/README.md
@@ -4,14 +4,20 @@ The browser demo runs the Rust graph runtime entirely in WebAssembly; tax data
 does not leave the browser. The deployed site is
 [mmacpherson.github.io/tenforty](https://mmacpherson.github.io/tenforty/).
 
+> **Current limitation:** The WASM engine and deployment work, but the calculator
+> UI still uses obsolete graph node names and therefore displays zeros. Repairing
+> the bindings and adding a browser-level contract are tracked by
+> `tenforty-ox4.4.3`.
+
 Build and serve it locally with:
 
 ```console
 make wasm-serve
 ```
 
-The Pages workflow builds a self-contained artifact, loads the generated WASM
-module and a resolved tax graph on every relevant pull request, and deploys only
-from `main`. GitHub Pages must be enabled for the repository with **GitHub
-Actions** selected as its publishing source; the workflow token cannot enable a
-Pages site itself.
+The Pages workflow builds a self-contained artifact and validates the generated
+WASM tax engine against the resolved tax graphs on every relevant pull request.
+It deploys only from `main`; the browser UI itself will be covered when the
+bindings are repaired. GitHub Pages must be enabled for the repository with
+**GitHub Actions** selected as its publishing source; the workflow token cannot
+enable a Pages site itself.

--- a/scripts/smoke_wasm_demo.mjs
+++ b/scripts/smoke_wasm_demo.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const siteDirectory = path.resolve(process.argv[2] ?? "target/pages");
+const modulePath = path.join(siteDirectory, "pkg", "graphlib.js");
+const wasmPath = path.join(siteDirectory, "pkg", "graphlib_bg.wasm");
+const graphlib = await import(pathToFileURL(modulePath));
+await graphlib.default({ module_or_path: await readFile(wasmPath) });
+
+const cases = [
+  { year: 2024, taxableIncome: 85_400, totalTax: 13_841 },
+  { year: 2025, taxableIncome: 84_250, totalTax: 13_449 },
+];
+
+for (const { year, taxableIncome, totalTax } of cases) {
+  const graphPath = path.join(
+    siteDirectory,
+    "forms",
+    `us_tax_graph_${year}.json`,
+  );
+  const graph = graphlib.Graph.fromJson(await readFile(graphPath, "utf8"));
+  const runtime = new graphlib.Runtime(graph, graphlib.FilingStatus.single());
+  runtime.set("us_1040_L1a_wages", 100_000);
+
+  assert.equal(runtime.eval("us_1040_L11_agi"), 100_000);
+  assert.equal(runtime.eval("us_1040_L15_taxable_income"), taxableIncome);
+  assert.equal(runtime.eval("us_1040_L24_total_tax"), totalTax);
+}
+
+console.log(`WASM smoke test passed: ${siteDirectory}`);


### PR DESCRIPTION
## Summary

- validate the release WASM tax engine and resolved graphs on every app-related pull request without deploying
- stage a self-contained Pages artifact containing only the browser files, WASM package, and resolved 2024/2025 graphs
- instantiate the WASM runtime and evaluate known returns against both graphs before upload
- reserve Pages and OIDC write permissions for the deploy job
- prevent pull-request runs from cancelling production and preserve in-flight main deployments
- smoke-test the live deployed WASM engine and graph assets after publication
- document the live URL, local workflow, repository prerequisite, and current UI limitation

## Repository setting

GitHub Pages was not configured, so `actions/configure-pages@v6` failed with a 404 after the WASM build succeeded. I enabled the site through GitHub's Pages API with `build_type: workflow`.

A manual run of the existing `main` workflow then built and deployed successfully:

- https://github.com/mmacpherson/tenforty/actions/runs/30716278035
- https://mmacpherson.github.io/tenforty/

This setting is external to the diff. The workflow deliberately does not use `configure-pages` automatic enablement because that requires a non-`GITHUB_TOKEN` administrative token.

## Smoke contract

For both 2024 and 2025, the smoke test:

1. imports and initializes the generated `graphlib_bg.wasm`;
2. parses the resolved per-year graph;
3. sets Single wages to $100,000 through the public WASM API;
4. pins AGI, taxable income, and Form 1040 line 24 total tax.

The same script runs against the staged artifact on pull requests and against assets downloaded from the deployed Pages URL after a main deployment. This validates the WASM tax engine, graphs, and published assets; it does not execute `demo/app.js` or establish that the calculator UI is functional.

## Follow-up discovered

The existing demo UI's calculated fields all use obsolete pre-resolved node names, such as `us_1040_wages`, and lookup errors are swallowed as zeros. Consequently, the currently deployed calculator displays zeros even though the engine itself works. This PR records that limitation prominently rather than broadening into the calculator rewrite; `tenforty-ox4.4.3` tracks repairing the bindings, eliminating silent fallbacks, and adding a browser-level integration contract.

## Validation

- `wasm-pack build --target web --release crates/tenforty-graph -- --features wasm --no-default-features`
- `node scripts/smoke_wasm_demo.mjs target/pages-fresh`
- live asset download plus the same WASM smoke script
- `uv run pre-commit run --files .github/workflows/pages.yml crates/tenforty-graph/demo/README.md`
- `git diff --check`
