### PR TITLE
feat(wasm): ship real-time browser tax calculator

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -58,11 +58,12 @@ jobs:
         cp crates/tenforty-graph/demo/app.js target/pages/
         cp crates/tenforty-graph/demo/browser_contract.js target/pages/
         cp crates/tenforty-graph/demo/browser_contract.json target/pages/
+        cp crates/tenforty-graph/demo/calculator.js target/pages/
         cp crates/tenforty-graph/demo/style.css target/pages/
         cp -R crates/tenforty-graph/pkg target/pages/pkg
         cp src/tenforty/forms/us_tax_graph_*.json target/pages/forms/
 
-    - name: Smoke-test WASM tax engine and graphs
+    - name: Smoke-test browser calculator contract
       run: node scripts/smoke_wasm_demo.mjs target/pages
 
     - name: Setup Pages
@@ -93,13 +94,13 @@ jobs:
       id: deployment
       uses: actions/deploy-pages@v5
 
-    - name: Smoke-test deployed WASM tax engine and graphs
+    - name: Smoke-test deployed browser calculator
       env:
         PAGE_URL: ${{ steps.deployment.outputs.page_url }}
       run: |
         smoke_dir=$(mktemp -d)
         mkdir -p "$smoke_dir/pkg" "$smoke_dir/forms"
-        for asset in index.html app.js browser_contract.js browser_contract.json style.css pkg/graphlib.js pkg/graphlib_bg.wasm forms/us_tax_graph_2024.json forms/us_tax_graph_2025.json; do
+        for asset in index.html app.js browser_contract.js browser_contract.json calculator.js style.css pkg/graphlib.js pkg/graphlib_bg.wasm forms/us_tax_graph_2024.json forms/us_tax_graph_2025.json; do
           curl --fail --location --retry 12 --retry-all-errors --retry-delay 5 \
             "${PAGE_URL%/}/$asset" --output "$smoke_dir/$asset"
         done

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,7 @@ wasm-serve: wasm-dev ## Serve the current Pages artifact locally
 	cp crates/tenforty-graph/demo/app.js target/pages-dev/
 	cp crates/tenforty-graph/demo/browser_contract.js target/pages-dev/
 	cp crates/tenforty-graph/demo/browser_contract.json target/pages-dev/
+	cp crates/tenforty-graph/demo/calculator.js target/pages-dev/
 	cp crates/tenforty-graph/demo/style.css target/pages-dev/
 	cp -R crates/tenforty-graph/pkg target/pages-dev/pkg
 	cp src/tenforty/forms/us_tax_graph_*.json target/pages-dev/forms/

--- a/crates/tenforty-graph/demo/README.md
+++ b/crates/tenforty-graph/demo/README.md
@@ -1,19 +1,15 @@
 # WASM tax calculator
 
-The browser demo runs the Rust graph runtime entirely in WebAssembly; tax data
-does not leave the browser. The deployed site is
+The browser calculator runs the Rust graph runtime entirely in WebAssembly; tax
+data does not leave the browser. The deployed site is
 [mmacpherson.github.io/tenforty](https://mmacpherson.github.io/tenforty/).
-
-> **Current limitation:** The WASM engine and deployment work, but the calculator
-> UI still uses obsolete graph node names. It stops during initialization at the
-> first stale input; the dimmed zero figures are untouched placeholders. Later
-> stale output and gradient lookups would also be swallowed as zeros. Repairing
-> the bindings and adding a browser-level contract are tracked by `tenforty-ox4.4.3`.
 
 The checked-in [browser calculator contract](../../../docs/browser-calculator-contract.md)
 defines the supported years, jurisdictions, public inputs and outputs, graph
-provenance, error behavior, and current limitations. The Pages smoke test
-validates that contract against both resolved graphs and pinned Python scenarios.
+provenance, error behavior, and current limitations. The UI renders public
+concepts from that contract rather than graph-node names. Share links serialize
+the same public scenario passed to the calculator boundary in the URL fragment,
+which browsers do not send to the hosting server.
 
 Build and serve it locally with:
 
@@ -22,8 +18,8 @@ make wasm-serve
 ```
 
 The Pages workflow builds a self-contained artifact and validates the generated
-WASM tax engine against the resolved tax graphs on every relevant pull request.
-It deploys only from `main`; the browser UI itself will be covered when the
-bindings are repaired. GitHub Pages must be enabled for the repository with
-**GitHub Actions** selected as its publishing source; the workflow token cannot
-enable a Pages site itself.
+WASM tax engine, browser calculation boundary, share-link round trips, resolved
+graphs, and pinned Python scenarios on every relevant pull request. It deploys
+only from `main`. GitHub Pages must be enabled for the repository with **GitHub
+Actions** selected as its publishing source; the workflow token cannot enable a
+Pages site itself.

--- a/crates/tenforty-graph/demo/app.js
+++ b/crates/tenforty-graph/demo/app.js
@@ -1,911 +1,541 @@
-import init, { FilingStatus, Graph, Runtime } from "./pkg/graphlib.js";
+import init, * as graphlib from "./pkg/graphlib.js";
+import {
+  BrowserContractError,
+  loadBrowserContract,
+} from "./browser_contract.js";
+import {
+  INPUT_GROUPS,
+  calculateScenario,
+  createDefaultScenario,
+  parseScenario,
+  serializeScenario,
+} from "./calculator.js";
 
-let graph = null;
-let runtime = null;
-let taxCurveData = [];
-let stackedCurveData = [];
+const CURRENCY_FORMATTER = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
 
-const CHART_PADDING = { top: 20, right: 20, bottom: 40, left: 60 };
+let contract;
+let scenario;
+let calculationSequence = 0;
+let toastTimer;
+const graphCache = new Map();
 
-const TAX_COMPONENTS = [
-  { key: "ordinary", label: "Ordinary Income", color: "#3498db" },
-  { key: "ltcg", label: "Capital Gains", color: "#9b59b6" },
-  { key: "amt", label: "AMT", color: "#e74c3c" },
-  { key: "niit", label: "NIIT", color: "#e67e22" },
-  { key: "medicare", label: "Add'l Medicare", color: "#f1c40f" },
-  { key: "state", label: "State", color: "#1abc9c" },
-];
-const CHART_WIDTH = 600;
-const CHART_HEIGHT = 300;
-
-const BRACKET_COLORS = [
-  "#2ecc71",
-  "#27ae60",
-  "#f1c40f",
-  "#e67e22",
-  "#e74c3c",
-  "#c0392b",
-  "#8e44ad",
-];
-
-const STATE_TAX_NODES = {
-  california: "ca_540_L64_ca_total_tax",
-  new_york: "ny_it201_L46_ny_total_state_tax",
-};
-
-const YEAR = 2024;
+function byId(id) {
+  return document.getElementById(id);
+}
 
 function formatCurrency(value) {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(value);
+  return CURRENCY_FORMATTER.format(Math.abs(value) < 0.005 ? 0 : value);
 }
 
 function formatPercent(value) {
-  return value.toFixed(1) + "%";
+  return `${value.toFixed(1)}%`;
 }
 
-function getFilingStatus(value) {
-  switch (value) {
-    case "single":
-      return FilingStatus.single();
-    case "married_joint":
-      return FilingStatus.married_joint();
-    case "married_separate":
-      return FilingStatus.married_separate();
-    case "head_of_household":
-      return FilingStatus.head_of_household();
-    case "qualifying_widow":
-      return FilingStatus.qualifying_widow();
-    default:
-      return FilingStatus.single();
+function createTextElement(tagName, className, text) {
+  const element = document.createElement(tagName);
+  element.className = className;
+  element.textContent = text;
+  return element;
+}
+
+function createMoneyField(name, specification) {
+  const field = document.createElement("div");
+  field.className = "input-field money-field";
+  field.dataset.inputField = name;
+
+  const inputId = `input-${name}`;
+  const descriptionId = `${inputId}-description`;
+  const label = createTextElement("label", "", specification.label);
+  label.htmlFor = inputId;
+
+  const wrapper = document.createElement("div");
+  wrapper.className = "money-input-wrap";
+  wrapper.appendChild(createTextElement("span", "money-prefix", "$"));
+
+  const input = document.createElement("input");
+  input.type = "number";
+  input.id = inputId;
+  input.name = name;
+  input.dataset.browserInput = name;
+  input.step = "100";
+  input.inputMode = "decimal";
+  input.setAttribute("aria-describedby", descriptionId);
+  if (!specification.allows_negative) input.min = "0";
+  wrapper.appendChild(input);
+
+  const description = createTextElement(
+    "p",
+    "field-description",
+    specification.description,
+  );
+  description.id = descriptionId;
+
+  field.append(label, wrapper, description);
+  return field;
+}
+
+function createChoiceField(name, specification) {
+  const field = document.createElement("div");
+  field.className = "input-field choice-field";
+  field.dataset.inputField = name;
+
+  const inputId = `input-${name}`;
+  const descriptionId = `${inputId}-description`;
+  const label = createTextElement("label", "", specification.label);
+  label.htmlFor = inputId;
+
+  const select = document.createElement("select");
+  select.id = inputId;
+  select.name = name;
+  select.dataset.browserInput = name;
+  select.setAttribute("aria-describedby", descriptionId);
+  for (const choice of specification.choices) {
+    const option = document.createElement("option");
+    option.value = choice;
+    option.textContent = choice === "Standard" ? "Automatic (larger)" : choice;
+    select.appendChild(option);
+  }
+
+  const description = createTextElement(
+    "p",
+    "field-description",
+    specification.description,
+  );
+  description.id = descriptionId;
+
+  field.append(label, select, description);
+  return field;
+}
+
+function createBooleanField(name, specification) {
+  const field = document.createElement("div");
+  field.className = "input-field boolean-field";
+  field.dataset.inputField = name;
+
+  const inputId = `input-${name}`;
+  const descriptionId = `${inputId}-description`;
+  const copy = document.createElement("div");
+  const label = createTextElement("label", "", specification.label);
+  label.htmlFor = inputId;
+  const description = createTextElement(
+    "p",
+    "field-description",
+    specification.description,
+  );
+  description.id = descriptionId;
+  copy.append(label, description);
+
+  const switchLabel = document.createElement("label");
+  switchLabel.className = "switch";
+  switchLabel.setAttribute("aria-label", specification.label);
+  const input = document.createElement("input");
+  input.type = "checkbox";
+  input.id = inputId;
+  input.name = name;
+  input.dataset.browserInput = name;
+  input.setAttribute("aria-describedby", descriptionId);
+  const track = document.createElement("span");
+  track.className = "switch-track";
+  switchLabel.append(input, track);
+
+  field.append(copy, switchLabel);
+  return field;
+}
+
+function createInputField(name) {
+  const specification = contract.inputs[name];
+  if (specification.type === "boolean") {
+    return createBooleanField(name, specification);
+  }
+  if (specification.type === "choice") {
+    return createChoiceField(name, specification);
+  }
+  return createMoneyField(name, specification);
+}
+
+function populateInterface() {
+  const yearSelect = byId("tax-year");
+  for (const year of [...contract.supported_years].reverse()) {
+    const option = document.createElement("option");
+    option.value = String(year);
+    option.textContent = String(year);
+    yearSelect.appendChild(option);
+  }
+
+  const filingStatusSelect = byId("filing-status");
+  for (const [value, label] of Object.entries(contract.filing_statuses)) {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = label;
+    filingStatusSelect.appendChild(option);
+  }
+
+  const jurisdictionSelect = byId("jurisdiction");
+  const jurisdictions = Object.entries(contract.jurisdictions).sort(
+    ([leftCode, left], [rightCode, right]) => {
+      if (leftCode === "US") return -1;
+      if (rightCode === "US") return 1;
+      return left.name.localeCompare(right.name);
+    },
+  );
+  for (const [code, specification] of jurisdictions) {
+    const option = document.createElement("option");
+    option.value = code;
+    option.textContent = specification.name;
+    jurisdictionSelect.appendChild(option);
+  }
+
+  for (const [containerId, inputNames] of Object.entries(INPUT_GROUPS)) {
+    const container = byId(containerId);
+    for (const name of inputNames)
+      container.appendChild(createInputField(name));
+  }
+
+  const limitations = byId("limitations-list");
+  for (const limitation of contract.limitations) {
+    limitations.appendChild(createTextElement("p", "", limitation.summary));
   }
 }
 
-let resolvedGraph = null;
+function renderScenario(nextScenario) {
+  byId("tax-year").value = String(nextScenario.year);
+  byId("filing-status").value = nextScenario.filingStatus;
+  byId("jurisdiction").value = nextScenario.jurisdiction;
 
-async function loadResolvedGraph() {
-  // One graph per year — federal plus every state, cross-form imports already
-  // resolved at build time. Eval is demand-driven, so a single load serves
-  // every state; switching state only re-reads different output nodes.
-  if (resolvedGraph) {
-    return resolvedGraph;
+  for (const [name, specification] of Object.entries(contract.inputs)) {
+    const input = byId(`input-${name}`);
+    if (specification.type === "boolean") {
+      input.checked = nextScenario.inputs[name];
+    } else {
+      input.value = String(nextScenario.inputs[name]);
+    }
   }
-  const url = `forms/us_tax_graph_${YEAR}.json`;
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Failed to load ${url}: ${response.status}`);
-  }
-  resolvedGraph = Graph.fromJson(await response.text());
-  return resolvedGraph;
+  updateUnsupportedInputs(nextScenario.year, nextScenario.jurisdiction);
+  updateExpandableCards(nextScenario);
 }
 
-function createRuntime() {
-  const statusValue = document.getElementById("filing-status").value;
-  const status = getFilingStatus(statusValue);
-  runtime = new Runtime(graph, status);
+function groupHasValues(nextScenario, groupName) {
+  return INPUT_GROUPS[groupName].some(
+    (name) => nextScenario.inputs[name] !== contract.inputs[name].default,
+  );
 }
 
-function getInputValues() {
+function updateExpandableCards(nextScenario) {
+  const narrowScreen = window.matchMedia("(max-width: 680px)").matches;
+  byId("other-income-card").open =
+    !narrowScreen || groupHasValues(nextScenario, "other-income-fields");
+  byId("advanced-card").open = groupHasValues(nextScenario, "advanced-fields");
+}
+
+function readScenario() {
+  const inputs = {};
+  for (const [name, specification] of Object.entries(contract.inputs)) {
+    const input = byId(`input-${name}`);
+    if (specification.type === "boolean") {
+      inputs[name] = input.checked;
+    } else if (specification.type === "choice") {
+      inputs[name] = input.value;
+    } else {
+      inputs[name] = Number.isFinite(input.valueAsNumber)
+        ? input.valueAsNumber
+        : 0;
+    }
+  }
   return {
-    wages: parseFloat(document.getElementById("wages").value) || 0,
-    interest: parseFloat(document.getElementById("interest").value) || 0,
-    dividends: parseFloat(document.getElementById("dividends").value) || 0,
-    stcg: parseFloat(document.getElementById("stcg").value) || 0,
-    ltcg: parseFloat(document.getElementById("ltcg").value) || 0,
-    iso: parseFloat(document.getElementById("iso").value) || 0,
+    year: Number(byId("tax-year").value),
+    jurisdiction: byId("jurisdiction").value,
+    filingStatus: byId("filing-status").value,
+    inputs,
   };
 }
 
-function setRuntimeInputs(values) {
-  runtime.set("us_1040_wages", values.wages);
-  runtime.set("us_1040_interest", values.interest);
-  runtime.set("us_1040_dividends", values.dividends);
-  runtime.set("us_schedule_d_short_term_capital_gains", values.stcg);
-  runtime.set("us_schedule_d_long_term_capital_gains", values.ltcg);
-  runtime.set("us_form_6251_iso_exercise_gains", values.iso);
-}
+function updateUnsupportedInputs(year, jurisdiction) {
+  document.querySelectorAll("[data-input-field]").forEach((field) => {
+    field.classList.remove("unsupported");
+    field.querySelector(".unsupported-message")?.remove();
+  });
 
-function safeEval(nodeName) {
-  try {
-    const val = runtime.eval(nodeName);
-    return isFinite(val) ? val : 0;
-  } catch (e) {
-    return 0;
-  }
-}
-
-function safeGradient(output, input) {
-  try {
-    const val = runtime.gradient(output, input);
-    return isFinite(val) ? val : 0;
-  } catch (e) {
-    return 0;
-  }
-}
-
-function getStateKey() {
-  return document.getElementById("state").value;
-}
-
-function showState() {
-  return getStateKey() !== "none";
-}
-
-function getStateTaxNode() {
-  return STATE_TAX_NODES[getStateKey()] || null;
-}
-
-function updateResults() {
-  if (!graph || !runtime) return;
-
-  const values = getInputValues();
-  const stateActive = showState();
-
-  try {
-    setRuntimeInputs(values);
-
-    const grossIncome = safeEval("us_1040_gross_income");
-    const stdDeduction = safeEval("us_1040_standard_deduction");
-    const taxableIncome = safeEval("us_1040_taxable_ordinary_income");
-    const ordinaryTax = safeEval("us_1040_ordinary_income_tax");
-    const ltcgTax = safeEval("us_1040_ltcg_tax");
-    const niit = safeEval("us_form_8960_niit");
-    const medicareTax = safeEval("us_form_8959_additional_medicare_tax");
-    const amt = safeEval("us_form_6251_amt");
-    const federalTax = safeEval("us_1040_federal_tax");
-    const stateTaxNode = getStateTaxNode();
-    const stateTax = stateTaxNode ? safeEval(stateTaxNode) : 0;
-    const totalTax = federalTax + stateTax;
-    const effectiveRate =
-      grossIncome > 0 ? (federalTax / grossIncome) * 100 : 0;
-    const marginalRate =
-      safeGradient("us_1040_federal_tax", "us_1040_wages") * 100;
-
-    document.getElementById("gross-income").textContent =
-      formatCurrency(grossIncome);
-    document.getElementById("std-deduction").textContent =
-      "-" + formatCurrency(stdDeduction);
-    document.getElementById("taxable-income").textContent =
-      formatCurrency(taxableIncome);
-    document.getElementById("ordinary-tax").textContent =
-      formatCurrency(ordinaryTax);
-    document.getElementById("ltcg-tax").textContent = formatCurrency(ltcgTax);
-
-    const ltcgRow = document.getElementById("ltcg-tax-row");
-    ltcgRow.style.display = ltcgTax > 0 ? "flex" : "none";
-
-    const niitRow = document.getElementById("niit-row");
-    niitRow.style.display = niit > 0 ? "flex" : "none";
-    document.getElementById("niit").textContent = formatCurrency(niit);
-
-    const medicareRow = document.getElementById("medicare-row");
-    medicareRow.style.display = medicareTax > 0 ? "flex" : "none";
-    document.getElementById("medicare-tax").textContent =
-      formatCurrency(medicareTax);
-
-    const federalBeforeAmt = safeEval("us_1040_federal_before_amt");
-    const tentativeMinTax = safeEval("us_form_6251_tentative_minimum_tax");
-    const amtCushion = federalBeforeAmt - tentativeMinTax;
-
-    const amtRow = document.getElementById("amt-row");
-    const amtLabel = document.getElementById("amt-label");
-    const amtValue = document.getElementById("amt");
-
-    if (amt > 0) {
-      amtRow.style.display = "flex";
-      amtRow.classList.add("in-amt");
-      amtRow.classList.remove("amt-cushion");
-      amtLabel.textContent = "AMT (paying extra)";
-      amtValue.textContent = "+" + formatCurrency(amt);
-    } else if (values.iso > 0 && amtCushion > 0) {
-      amtRow.style.display = "flex";
-      amtRow.classList.remove("in-amt");
-      amtRow.classList.add("amt-cushion");
-      amtLabel.textContent = "AMT Cushion";
-      amtValue.textContent = formatCurrency(amtCushion);
-    } else {
-      amtRow.style.display = "none";
-    }
-
-    document.getElementById("federal-tax").textContent =
-      formatCurrency(federalTax);
-
-    const stateRow = document.getElementById("state-tax-row");
-    const totalRow = document.getElementById("total-row");
-    const stateTaxLabel = document.getElementById("state-tax-label");
-    stateRow.style.display = stateActive ? "flex" : "none";
-    totalRow.style.display = stateActive ? "flex" : "none";
-    if (stateTaxLabel) {
-      const stateKey = getStateKey();
-      const stateNames = {
-        california: "California",
-        new_york: "New York",
-      };
-      stateTaxLabel.textContent =
-        (stateNames[stateKey] || "State") + " State Tax";
-    }
-    document.getElementById("state-tax").textContent = formatCurrency(stateTax);
-    document.getElementById("total-tax").textContent = formatCurrency(
-      stateActive ? totalTax : federalTax,
+  const unsupported =
+    contract.jurisdictions[jurisdiction].unsupported_inputs[String(year)];
+  for (const name of unsupported) {
+    const field = document.querySelector(`[data-input-field="${name}"]`);
+    field.classList.add("unsupported");
+    field.appendChild(
+      createTextElement(
+        "p",
+        "unsupported-message",
+        `${contract.inputs[name].label} is not supported for ${contract.jurisdictions[jurisdiction].name} in ${year}. Leave it at zero to calculate.`,
+      ),
     );
-
-    document.getElementById("effective-rate").textContent =
-      formatPercent(effectiveRate);
-    document.getElementById("marginal-rate").textContent =
-      formatPercent(marginalRate);
-
-    updateSensitivity();
-    updateBracketVisualization(taxableIncome);
-    const isStacked = document.getElementById("stacked-toggle").checked;
-    const chartTax = stateActive && isStacked ? totalTax : federalTax;
-    updateTaxCurve(values.wages, chartTax);
-  } catch (e) {
-    console.error("Evaluation error:", e);
   }
 }
 
-function updateSensitivity() {
-  const stateTaxNode = getStateTaxNode();
-
-  const federalWagesGrad = safeGradient("us_1040_federal_tax", "us_1040_wages");
-  const federalInterestGrad = safeGradient(
-    "us_1040_federal_tax",
-    "us_1040_interest",
-  );
-  const federalLtcgGrad = safeGradient(
-    "us_1040_federal_tax",
-    "us_schedule_d_long_term_capital_gains",
-  );
-
-  const stateWagesGrad = stateTaxNode
-    ? safeGradient(stateTaxNode, "us_1040_wages")
-    : 0;
-  const stateInterestGrad = stateTaxNode
-    ? safeGradient(stateTaxNode, "us_1040_interest")
-    : 0;
-  const stateLtcgGrad = stateTaxNode
-    ? safeGradient(stateTaxNode, "us_schedule_d_long_term_capital_gains")
-    : 0;
-
-  const wagesGrad = federalWagesGrad + stateWagesGrad;
-  const interestGrad = federalInterestGrad + stateInterestGrad;
-  const ltcgGrad = federalLtcgGrad + stateLtcgGrad;
-
-  document.getElementById("sens-wages").textContent =
-    "+" + formatCurrency(wagesGrad * 1000);
-  document.getElementById("sens-wages-rate").textContent = formatPercent(
-    wagesGrad * 100,
-  );
-
-  document.getElementById("sens-interest").textContent =
-    "+" + formatCurrency(interestGrad * 1000);
-  document.getElementById("sens-interest-rate").textContent = formatPercent(
-    interestGrad * 100,
-  );
-
-  document.getElementById("sens-ltcg").textContent =
-    "+" + formatCurrency(ltcgGrad * 1000);
-  document.getElementById("sens-ltcg-rate").textContent = formatPercent(
-    ltcgGrad * 100,
-  );
-}
-
-function updateBracketVisualization(taxableIncome) {
-  const bracketBar = document.getElementById("bracket-bar");
-  const bracketLegend = document.getElementById("bracket-legend");
-
-  // Read brackets from graph by evaluating at known income levels
-  const brackets = readBracketsFromGraph();
-
-  const maxIncome = Math.max(taxableIncome * 1.5, 250000);
-  let prevThreshold = 0;
-  let currentBracketIndex = -1;
-
-  bracketBar.innerHTML = "";
-  bracketLegend.innerHTML = "";
-
-  brackets.forEach((bracket, i) => {
-    const bracketEnd = Math.min(bracket.threshold, maxIncome);
-    const bracketWidth = bracketEnd - prevThreshold;
-
-    if (bracketWidth <= 0) return;
-
-    const widthPercent = (bracketWidth / maxIncome) * 100;
-    const segment = document.createElement("div");
-    segment.className = "bracket-segment";
-    segment.style.flex = widthPercent;
-    segment.textContent = bracket.rate * 100 + "%";
-
-    if (taxableIncome > prevThreshold && taxableIncome <= bracket.threshold) {
-      currentBracketIndex = i;
-      segment.classList.add("bracket-marker");
-    }
-
-    bracketBar.appendChild(segment);
-
-    const legendItem = document.createElement("div");
-    legendItem.className =
-      "legend-item" + (i === currentBracketIndex ? " current" : "");
-    legendItem.innerHTML = `
-            <span class="legend-color" style="background: ${
-              BRACKET_COLORS[i % BRACKET_COLORS.length]
-            }"></span>
-            <span>${bracket.rate * 100}%: ${formatCurrency(prevThreshold)} - ${
-              bracket.threshold === Infinity
-                ? "above"
-                : formatCurrency(bracket.threshold)
-            }</span>
-        `;
-    bracketLegend.appendChild(legendItem);
-
-    prevThreshold = bracket.threshold;
-  });
-}
-
-function readBracketsFromGraph() {
-  // Probe the marginal rate at various income levels to detect bracket boundaries.
-  // This works by evaluating the gradient at many points and detecting rate changes.
-  const probePoints = [];
-  for (let i = 0; i <= 100; i++) {
-    probePoints.push(i * 10000);
-  }
-
-  const brackets = [];
-  let lastRate = -1;
-
-  for (const income of probePoints) {
-    runtime.set("us_1040_wages", income);
-    // Zero out other inputs for bracket probing
-    runtime.set("us_1040_interest", 0);
-    runtime.set("us_1040_dividends", 0);
-    runtime.set("us_schedule_d_short_term_capital_gains", 0);
-    runtime.set("us_schedule_d_long_term_capital_gains", 0);
-    runtime.set("us_form_6251_iso_exercise_gains", 0);
-
-    const rate = safeGradient("us_1040_ordinary_income_tax", "us_1040_wages");
-    const roundedRate = Math.round(rate * 10000) / 10000;
-
-    if (roundedRate !== lastRate && roundedRate > 0) {
-      if (brackets.length > 0) {
-        brackets[brackets.length - 1].threshold = income;
+async function loadGraph(year) {
+  if (!graphCache.has(year)) {
+    const graphPromise = (async () => {
+      const path = contract.graph.path_template.replace("{year}", String(year));
+      const response = await fetch(path);
+      if (!response.ok) {
+        throw new BrowserContractError(
+          `Failed to load the ${year} tax graph (${response.status})`,
+        );
       }
-      brackets.push({ threshold: Infinity, rate: roundedRate });
-      lastRate = roundedRate;
-    }
+      return graphlib.Graph.fromJson(await response.text());
+    })();
+    graphCache.set(year, graphPromise);
   }
-
-  // Restore actual inputs
-  const values = getInputValues();
-  setRuntimeInputs(values);
-
-  if (brackets.length === 0) {
-    // Fallback: hardcoded 2024 single brackets
-    return [
-      { threshold: 11600, rate: 0.1 },
-      { threshold: 47150, rate: 0.12 },
-      { threshold: 100525, rate: 0.22 },
-      { threshold: 191950, rate: 0.24 },
-      { threshold: 243725, rate: 0.32 },
-      { threshold: 609350, rate: 0.35 },
-      { threshold: Infinity, rate: 0.37 },
-    ];
-  }
-
-  return brackets;
+  return graphCache.get(year);
 }
 
-function computeTaxCurve(overrideValues = null) {
-  const numPoints = 100;
-  const maxIncome = 500000;
-  const values = overrideValues || getInputValues();
-  const stateTaxNode = getStateTaxNode();
-
-  taxCurveData = [];
-  stackedCurveData = [];
-
-  for (let i = 0; i <= numPoints; i++) {
-    const income = (i / numPoints) * maxIncome;
-    runtime.set("us_1040_wages", income);
-    runtime.set("us_1040_interest", values.interest);
-    runtime.set("us_1040_dividends", values.dividends);
-    runtime.set("us_schedule_d_short_term_capital_gains", values.stcg);
-    runtime.set("us_schedule_d_long_term_capital_gains", values.ltcg);
-    runtime.set("us_form_6251_iso_exercise_gains", values.iso);
-
-    const tax = safeEval("us_1040_federal_tax");
-    taxCurveData.push({ income, tax });
-
-    stackedCurveData.push({
-      income,
-      ordinary: safeEval("us_1040_ordinary_income_tax"),
-      ltcg: safeEval("us_1040_ltcg_tax"),
-      amt: safeEval("us_form_6251_amt"),
-      niit: safeEval("us_form_8960_niit"),
-      medicare: safeEval("us_form_8959_additional_medicare_tax"),
-      state: stateTaxNode ? safeEval(stateTaxNode) : 0,
-    });
-  }
-
-  setRuntimeInputs(values);
+function setText(id, value) {
+  byId(id).textContent = value;
 }
 
-function updateTaxCurve(currentIncome, currentTax) {
-  const svg = document.getElementById("tax-chart");
-  const width = CHART_WIDTH - CHART_PADDING.left - CHART_PADDING.right;
-  const height = CHART_HEIGHT - CHART_PADDING.top - CHART_PADDING.bottom;
-  const isStacked = document.getElementById("stacked-toggle").checked;
-  const stateActive = showState();
+function setOptionalMoney(rowId, valueId, value) {
+  const visible = value !== null && Math.abs(value) >= 0.005;
+  byId(rowId).hidden = !visible;
+  if (visible) setText(valueId, formatCurrency(value));
+}
 
-  if (taxCurveData.length === 0) {
-    computeTaxCurve();
+function selectedJurisdiction() {
+  return contract.jurisdictions[scenario.jurisdiction];
+}
+
+function renderResults(results, elapsedMilliseconds) {
+  const jurisdiction = selectedJurisdiction();
+  const federalOnly = scenario.jurisdiction === "US";
+
+  setText("result-year", String(scenario.year));
+  setText("result-state-context", federalOnly ? "" : ` · ${jurisdiction.name}`);
+  setText("total-tax", formatCurrency(results.total_tax));
+  setText("federal-tax", formatCurrency(results.federal_total_tax));
+  setText(
+    "state-tax-label",
+    federalOnly ? "No state selected" : jurisdiction.name,
+  );
+  setText(
+    "state-tax",
+    federalOnly ? "—" : formatCurrency(results.state_total_tax),
+  );
+  setText("effective-rate", formatPercent(results.effective_tax_rate));
+  setText(
+    "federal-effective-rate",
+    formatPercent(results.federal_effective_tax_rate),
+  );
+  setText(
+    "state-effective-rate",
+    federalOnly ? "—" : formatPercent(results.state_effective_tax_rate),
+  );
+
+  setText("federal-agi", formatCurrency(results.federal_adjusted_gross_income));
+  setText(
+    "federal-taxable-income",
+    formatCurrency(results.federal_taxable_income),
+  );
+  setOptionalMoney(
+    "qbi-row",
+    "federal-qbi-deduction",
+    results.federal_qbi_deduction,
+  );
+
+  const stateAgiVisible =
+    !federalOnly && results.state_adjusted_gross_income !== null;
+  byId("state-agi-row").hidden = !stateAgiVisible;
+  if (stateAgiVisible) {
+    setText("state-agi-label", `${jurisdiction.name} adjusted gross income`);
+    setText("state-agi", formatCurrency(results.state_adjusted_gross_income));
   }
-
-  const maxIncome = 500000;
-
-  let maxTax;
-  if (isStacked && stackedCurveData.length > 0) {
-    const componentKeys = TAX_COMPONENTS.filter(
-      (c) => c.key !== "state" || stateActive,
-    ).map((c) => c.key);
-    maxTax =
-      Math.max(
-        ...stackedCurveData.map((d) =>
-          componentKeys.reduce((sum, key) => sum + (d[key] || 0), 0),
-        ),
-        currentTax,
-      ) * 1.1;
-  } else {
-    maxTax = Math.max(...taxCurveData.map((d) => d.tax), currentTax) * 1.1;
-  }
-
-  const xScale = (val) => CHART_PADDING.left + (val / maxIncome) * width;
-  const yScale = (val) => CHART_PADDING.top + height - (val / maxTax) * height;
-
-  const gridGroup = svg.querySelector(".grid");
-  gridGroup.innerHTML = "";
-
-  for (let i = 0; i <= 5; i++) {
-    const y = CHART_PADDING.top + (i / 5) * height;
-    const line = document.createElementNS("http://www.w3.org/2000/svg", "line");
-    line.setAttribute("x1", CHART_PADDING.left);
-    line.setAttribute("x2", CHART_WIDTH - CHART_PADDING.right);
-    line.setAttribute("y1", y);
-    line.setAttribute("y2", y);
-    gridGroup.appendChild(line);
-  }
-
-  for (let i = 0; i <= 5; i++) {
-    const x = CHART_PADDING.left + (i / 5) * width;
-    const line = document.createElementNS("http://www.w3.org/2000/svg", "line");
-    line.setAttribute("x1", x);
-    line.setAttribute("x2", x);
-    line.setAttribute("y1", CHART_PADDING.top);
-    line.setAttribute("y2", CHART_HEIGHT - CHART_PADDING.bottom);
-    gridGroup.appendChild(line);
-  }
-
-  const labelsGroup = svg.querySelector(".axis-labels");
-  labelsGroup.innerHTML = "";
-
-  for (let i = 0; i <= 5; i++) {
-    const income = (i / 5) * maxIncome;
-    const x = xScale(income);
-    const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
-    text.setAttribute("x", x);
-    text.setAttribute("y", CHART_HEIGHT - 18);
-    text.setAttribute("text-anchor", "middle");
-    text.textContent = "$" + income / 1000 + "K";
-    labelsGroup.appendChild(text);
-  }
-
-  const xLabel = document.createElementNS("http://www.w3.org/2000/svg", "text");
-  xLabel.setAttribute("x", CHART_PADDING.left + width / 2);
-  xLabel.setAttribute("y", CHART_HEIGHT - 2);
-  xLabel.setAttribute("text-anchor", "middle");
-  xLabel.setAttribute("font-size", "11");
-  xLabel.setAttribute("fill", "#7f8c8d");
-  xLabel.textContent = "Wages";
-  labelsGroup.appendChild(xLabel);
-
-  for (let i = 0; i <= 4; i++) {
-    const tax = ((4 - i) / 4) * maxTax;
-    const y = CHART_PADDING.top + (i / 4) * height;
-    const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
-    text.setAttribute("x", CHART_PADDING.left - 5);
-    text.setAttribute("y", y + 4);
-    text.setAttribute("text-anchor", "end");
-    text.textContent = "$" + Math.round(tax / 1000) + "K";
-    labelsGroup.appendChild(text);
-  }
-
-  const stackedGroup = svg.querySelector(".stacked-areas");
-  const simpleCurve = svg.querySelector(".tax-curve");
-  const simpleArea = svg.querySelector(".tax-area");
-  const legendDiv = document.getElementById("stacked-legend");
-
-  stackedGroup.innerHTML = "";
-
-  if (isStacked && stackedCurveData.length > 0) {
-    simpleCurve.style.display = "none";
-    simpleArea.style.display = "none";
-    legendDiv.style.display = "flex";
-
-    const activeComponents = TAX_COMPONENTS.filter(
-      (c) => c.key !== "state" || stateActive,
+  const stateTaxableVisible =
+    !federalOnly && results.state_taxable_income !== null;
+  byId("state-taxable-income-row").hidden = !stateTaxableVisible;
+  if (stateTaxableVisible) {
+    setText(
+      "state-taxable-income-label",
+      `${jurisdiction.name} taxable income`,
     );
-
-    const stacks = activeComponents.map((comp, idx) => {
-      return stackedCurveData.map((d) => {
-        const baseY = activeComponents
-          .slice(0, idx)
-          .reduce((sum, c) => sum + (d[c.key] || 0), 0);
-        const topY = baseY + (d[comp.key] || 0);
-        return { income: d.income, baseY, topY };
-      });
-    });
-
-    stacks.forEach((stack, idx) => {
-      const comp = activeComponents[idx];
-      let areaPath = `M ${xScale(0)} ${yScale(stack[0].baseY)}`;
-
-      stack.forEach((pt) => {
-        areaPath += ` L ${xScale(pt.income)} ${yScale(pt.topY)}`;
-      });
-
-      for (let i = stack.length - 1; i >= 0; i--) {
-        areaPath += ` L ${xScale(stack[i].income)} ${yScale(stack[i].baseY)}`;
-      }
-      areaPath += " Z";
-
-      const path = document.createElementNS(
-        "http://www.w3.org/2000/svg",
-        "path",
-      );
-      path.setAttribute("d", areaPath);
-      path.setAttribute("fill", comp.color);
-      stackedGroup.appendChild(path);
-    });
-
-    legendDiv.innerHTML = activeComponents
-      .map(
-        (c) =>
-          `<div class="stacked-legend-item">
-                <span class="stacked-legend-color" style="background: ${c.color}"></span>
-                <span>${c.label}</span>
-            </div>`,
-      )
-      .join("");
-  } else {
-    simpleCurve.style.display = "";
-    simpleArea.style.display = "";
-    legendDiv.style.display = "none";
-
-    let pathD = "";
-    let areaD = `M ${xScale(0)} ${yScale(0)} `;
-
-    taxCurveData.forEach((point, i) => {
-      const x = xScale(point.income);
-      const y = yScale(point.tax);
-      if (i === 0) {
-        pathD = `M ${x} ${y}`;
-        areaD += `L ${x} ${y} `;
-      } else {
-        pathD += ` L ${x} ${y}`;
-        areaD += `L ${x} ${y} `;
-      }
-    });
-
-    areaD += `L ${xScale(maxIncome)} ${yScale(0)} Z`;
-
-    simpleCurve.setAttribute("d", pathD);
-    simpleArea.setAttribute("d", areaD);
-  }
-
-  const currentX = xScale(Math.min(currentIncome, maxIncome));
-  const currentY = yScale(currentTax);
-
-  const pointGroup = svg.querySelector(".current-point");
-  const circle = pointGroup.querySelector("circle");
-  const crosshairV = pointGroup.querySelector(".crosshair-v");
-  const crosshairH = pointGroup.querySelector(".crosshair-h");
-
-  circle.setAttribute("cx", currentX);
-  circle.setAttribute("cy", currentY);
-
-  crosshairV.setAttribute("x1", currentX);
-  crosshairV.setAttribute("x2", currentX);
-  crosshairV.setAttribute("y1", CHART_PADDING.top);
-  crosshairV.setAttribute("y2", CHART_HEIGHT - CHART_PADDING.bottom);
-
-  crosshairH.setAttribute("x1", CHART_PADDING.left);
-  crosshairH.setAttribute("x2", CHART_WIDTH - CHART_PADDING.right);
-  crosshairH.setAttribute("y1", currentY);
-  crosshairH.setAttribute("y2", currentY);
-}
-
-function handleSolve() {
-  if (!graph || !runtime) return;
-
-  const targetTax =
-    parseFloat(document.getElementById("target-tax").value) || 0;
-  const values = getInputValues();
-
-  const btn = document.getElementById("solve-btn");
-  const btnText = btn.querySelector(".btn-text");
-  const btnLoading = btn.querySelector(".btn-loading");
-  const animationDiv = document.getElementById("solver-animation");
-  const resultDiv = document.getElementById("solver-result");
-
-  btn.disabled = true;
-  btnText.style.display = "none";
-  btnLoading.style.display = "inline";
-  animationDiv.style.display = "block";
-  resultDiv.style.display = "none";
-
-  runtime.set("us_1040_interest", values.interest);
-  runtime.set("us_1040_dividends", values.dividends);
-  runtime.set("us_schedule_d_short_term_capital_gains", values.stcg);
-  runtime.set("us_schedule_d_long_term_capital_gains", values.ltcg);
-  runtime.set("us_form_6251_iso_exercise_gains", values.iso);
-
-  animateSolver(targetTax, values.wages).then((result) => {
-    btn.disabled = false;
-    btnText.style.display = "inline";
-    btnLoading.style.display = "none";
-
-    if (result.success) {
-      document.getElementById("solved-wages").textContent = formatCurrency(
-        result.wages,
-      );
-      resultDiv.style.display = "flex";
-    } else {
-      document.getElementById("solved-wages").textContent =
-        "Could not converge";
-      resultDiv.style.display = "flex";
-    }
-  });
-}
-
-async function animateSolver(targetTax, initialGuess) {
-  const svg = document.getElementById("solver-chart");
-  const iterCountEl = document.getElementById("iter-count");
-  const iterErrorEl = document.getElementById("iter-error");
-
-  const minWages = 0;
-  const maxWages = Math.max(initialGuess * 3, 300000);
-  const padding = { left: 40, right: 20, top: 15, bottom: 25 };
-  const width = 400 - padding.left - padding.right;
-  const height = 200 - padding.top - padding.bottom;
-
-  const curvePoints = [];
-  for (let i = 0; i <= 50; i++) {
-    const w = (i / 50) * maxWages;
-    runtime.set("us_1040_wages", w);
-    const tax = safeEval("us_1040_federal_tax");
-    curvePoints.push({ wages: w, tax });
-  }
-
-  const maxTax = Math.max(...curvePoints.map((p) => p.tax), targetTax) * 1.1;
-
-  const xScale = (w) => padding.left + (w / maxWages) * width;
-  const yScale = (t) => padding.top + height - (t / maxTax) * height;
-
-  let curveD = "";
-  curvePoints.forEach((p, i) => {
-    const x = xScale(p.wages);
-    const y = yScale(p.tax);
-    curveD += (i === 0 ? "M" : "L") + ` ${x} ${y} `;
-  });
-
-  svg.querySelector(".solver-curve").setAttribute("d", curveD);
-
-  const targetLine = svg.querySelector(".target-line");
-  targetLine.setAttribute("x1", padding.left);
-  targetLine.setAttribute("x2", 400 - padding.right);
-  targetLine.setAttribute("y1", yScale(targetTax));
-  targetLine.setAttribute("y2", yScale(targetTax));
-
-  svg.querySelector(".iteration-points").innerHTML = "";
-
-  const iterations = [];
-  let currentWages = initialGuess;
-  const maxIter = 20;
-  const tolerance = 1;
-
-  for (let iter = 0; iter < maxIter; iter++) {
-    runtime.set("us_1040_wages", currentWages);
-    const tax = safeEval("us_1040_federal_tax");
-    const gradient = safeGradient("us_1040_federal_tax", "us_1040_wages");
-    const error = tax - targetTax;
-
-    iterations.push({
-      wages: currentWages,
-      tax,
-      gradient,
-      error,
-    });
-
-    if (Math.abs(error) < tolerance || gradient === 0) {
-      break;
-    }
-
-    currentWages = currentWages - error / gradient;
-    currentWages = Math.max(0, Math.min(currentWages, maxWages * 2));
-  }
-
-  for (let i = 0; i < iterations.length; i++) {
-    const iter = iterations[i];
-
-    await new Promise((r) => setTimeout(r, 300));
-
-    const x = xScale(iter.wages);
-    const y = yScale(iter.tax);
-
-    const pointsGroup = svg.querySelector(".iteration-points");
-    const circle = document.createElementNS(
-      "http://www.w3.org/2000/svg",
-      "circle",
+    setText(
+      "state-taxable-income",
+      formatCurrency(results.state_taxable_income),
     );
-    circle.setAttribute("cx", x);
-    circle.setAttribute("cy", y);
-    circle.setAttribute("r", 4);
-    pointsGroup.appendChild(circle);
-
-    const currentCircle = svg.querySelector(".current-iter");
-    currentCircle.setAttribute("cx", x);
-    currentCircle.setAttribute("cy", y);
-
-    if (iter.gradient !== 0 && i < iterations.length - 1) {
-      const tangentX1 = Math.max(xScale(iter.wages - 20000), padding.left);
-      const tangentX2 = Math.min(
-        xScale(iter.wages + 20000),
-        400 - padding.right,
-      );
-      const tangentY1 =
-        y -
-        (tangentX1 - x) *
-          ((-iter.gradient * (maxWages / width)) / (maxTax / height));
-      const tangentY2 =
-        y -
-        (tangentX2 - x) *
-          ((-iter.gradient * (maxWages / width)) / (maxTax / height));
-
-      const tangentLine = svg.querySelector(".tangent-line");
-      tangentLine.setAttribute("x1", tangentX1);
-      tangentLine.setAttribute("y1", tangentY1);
-      tangentLine.setAttribute("x2", tangentX2);
-      tangentLine.setAttribute("y2", tangentY2);
-    }
-
-    iterCountEl.textContent = i + 1;
-    iterErrorEl.textContent = formatCurrency(Math.abs(iter.error));
   }
 
-  const finalIter = iterations[iterations.length - 1];
-  return {
-    success: Math.abs(finalIter.error) < 100,
-    wages: finalIter.wages,
-  };
+  setText("federal-income-tax", formatCurrency(results.federal_income_tax));
+  setOptionalMoney("se-tax-row", "federal-se-tax", results.federal_se_tax);
+  setOptionalMoney("niit-row", "federal-niit", results.federal_niit);
+  setOptionalMoney(
+    "medicare-tax-row",
+    "federal-medicare-tax",
+    results.federal_additional_medicare_tax,
+  );
+  setOptionalMoney("amt-row", "federal-amt", results.federal_amt);
+
+  byId("calculation-status").classList.remove("calculating");
+  setText(
+    "calculation-status",
+    `Calculated locally · ${Math.max(1, Math.round(elapsedMilliseconds))} ms`,
+  );
+  byId("error-banner").hidden = true;
+  byId("results-heading").closest(".results-hero").classList.remove("is-stale");
+  byId("results-heading")
+    .closest(".results-hero")
+    .setAttribute("aria-busy", "false");
 }
 
-function syncSliders() {
-  const sliderPairs = [
-    ["wages-slider", "wages"],
-    ["interest-slider", "interest"],
-    ["dividends-slider", "dividends"],
-    ["stcg-slider", "stcg"],
-    ["ltcg-slider", "ltcg"],
-    ["iso-slider", "iso"],
-  ];
+function clearResults() {
+  for (const id of [
+    "total-tax",
+    "federal-tax",
+    "state-tax",
+    "effective-rate",
+    "federal-effective-rate",
+    "state-effective-rate",
+    "federal-agi",
+    "federal-taxable-income",
+    "federal-income-tax",
+  ]) {
+    setText(id, "—");
+  }
+  document.querySelectorAll(".optional-result").forEach((row) => {
+    row.hidden = true;
+  });
+  const hero = byId("results-heading").closest(".results-hero");
+  hero.classList.add("is-stale");
+  hero.setAttribute("aria-busy", "false");
+}
 
-  sliderPairs.forEach(([sliderId, inputId]) => {
-    const slider = document.getElementById(sliderId);
-    const input = document.getElementById(inputId);
-    const invalidatesCurve = inputId !== "wages";
+function showError(error) {
+  clearResults();
+  byId("error-message").textContent = error.message;
+  byId("error-banner").hidden = false;
+  byId("calculation-status").classList.remove("calculating");
+  setText("calculation-status", "No result calculated");
+}
 
-    slider.addEventListener("input", () => {
-      input.value = slider.value;
-      if (invalidatesCurve) {
-        taxCurveData = [];
-        computeTaxCurve(getInputValues());
-      }
-      updateResults();
-    });
+function updateAddressBar() {
+  const fragment = serializeScenario(contract, scenario);
+  const url = `${window.location.pathname}#${fragment}`;
+  window.history.replaceState(null, "", url);
+}
 
-    input.addEventListener("input", () => {
-      slider.value = Math.min(input.value, slider.max);
-      if (invalidatesCurve) {
-        taxCurveData = [];
-        computeTaxCurve(getInputValues());
-      }
-      updateResults();
-    });
+function scenarioLocation() {
+  return window.location.hash || window.location.search;
+}
+
+async function calculate() {
+  const sequence = ++calculationSequence;
+  scenario = readScenario();
+  updateUnsupportedInputs(scenario.year, scenario.jurisdiction);
+  byId("calculation-status").classList.add("calculating");
+  setText("calculation-status", "Calculating locally…");
+  byId("results-heading")
+    .closest(".results-hero")
+    .setAttribute("aria-busy", "true");
+
+  try {
+    const graph = await loadGraph(scenario.year);
+    const startedAt = performance.now();
+    const results = calculateScenario(graphlib, graph, contract, scenario);
+    if (sequence !== calculationSequence) return;
+    renderResults(results, performance.now() - startedAt);
+    updateAddressBar();
+  } catch (error) {
+    if (sequence !== calculationSequence) return;
+    showError(
+      error instanceof Error ? error : new Error("Unknown calculation error"),
+    );
+  }
+}
+
+function scheduleCalculation() {
+  const sequence = ++calculationSequence;
+  window.requestAnimationFrame(() => {
+    if (sequence === calculationSequence) calculate();
   });
 }
 
-function setupCollapsibles() {
-  document.querySelectorAll(".collapsible").forEach((section) => {
-    const header = section.querySelector(".collapsible-header");
-    header.addEventListener("click", () => {
-      section.classList.toggle("open");
-    });
-  });
+function showToast(message) {
+  const toast = byId("toast");
+  window.clearTimeout(toastTimer);
+  toast.textContent = message;
+  toast.classList.add("visible");
+  toastTimer = window.setTimeout(() => toast.classList.remove("visible"), 2200);
 }
 
-function showError(message) {
-  const loading = document.getElementById("loading");
-  loading.textContent = "";
+async function copyShareLink() {
+  const url = window.location.href;
+  try {
+    await navigator.clipboard.writeText(url);
+  } catch {
+    const textarea = document.createElement("textarea");
+    textarea.value = url;
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand("copy");
+    textarea.remove();
+  }
+  showToast("Scenario link copied");
+}
 
-  const errorP = document.createElement("p");
-  errorP.style.color = "#e74c3c";
-  errorP.textContent = "Failed to load: " + message;
+function bindEvents() {
+  const form = byId("calculator-form");
+  form.addEventListener("input", scheduleCalculation);
+  form.addEventListener("change", scheduleCalculation);
 
-  const helpP = document.createElement("p");
-  helpP.textContent =
-    "Calculator initialization stopped; no tax result was calculated.";
+  for (const id of ["tax-year", "filing-status", "jurisdiction"]) {
+    byId(id).addEventListener("change", scheduleCalculation);
+  }
 
-  loading.appendChild(errorP);
-  loading.appendChild(helpP);
+  byId("share-scenario").addEventListener("click", copyShareLink);
+  byId("reset-scenario").addEventListener("click", () => {
+    scenario = createDefaultScenario(contract);
+    renderScenario(scenario);
+    scheduleCalculation();
+    showToast("Scenario reset");
+  });
+  byId("dismiss-error").addEventListener("click", () => {
+    byId("error-banner").hidden = true;
+  });
+  window.addEventListener("popstate", () => {
+    try {
+      scenario = parseScenario(contract, scenarioLocation());
+      renderScenario(scenario);
+      scheduleCalculation();
+    } catch (error) {
+      showError(error);
+    }
+  });
 }
 
 async function main() {
+  let invalidShareLink = null;
   try {
     await init();
-
-    document.getElementById("loading").querySelector("p").textContent =
-      "Loading tax forms...";
-
-    const stateKey = getStateKey();
-    graph = await loadResolvedGraph();
-
-    createRuntime();
-    syncSliders();
-    setupCollapsibles();
-    computeTaxCurve();
-    updateResults();
-
-    document.getElementById("filing-status").addEventListener("change", () => {
-      createRuntime();
-      taxCurveData = [];
-      computeTaxCurve();
-      updateResults();
-    });
-
-    document.getElementById("state").addEventListener("change", async () => {
-      const newState = getStateKey();
-      document.getElementById("loading").style.display = "flex";
-      document.getElementById("loading").querySelector("p").textContent =
-        "Switching state...";
-      try {
-        graph = await loadResolvedGraph();
-        createRuntime();
-        taxCurveData = [];
-        computeTaxCurve();
-        updateResults();
-      } catch (e) {
-        console.error("Failed to load state:", e);
-        showError(e.message);
-      }
-      document.getElementById("loading").style.display = "none";
-    });
-
-    document
-      .getElementById("stacked-toggle")
-      .addEventListener("change", updateResults);
-
-    document.getElementById("solve-btn").addEventListener("click", handleSolve);
-    document.getElementById("target-tax").addEventListener("keypress", (e) => {
-      if (e.key === "Enter") handleSolve();
-    });
-
-    document.getElementById("loading").style.display = "none";
-  } catch (e) {
-    console.error("Initialization error:", e);
-    showError(e.message);
+    contract = await loadBrowserContract();
+    populateInterface();
+    try {
+      scenario = parseScenario(contract, scenarioLocation());
+    } catch (error) {
+      invalidShareLink = error;
+      scenario = createDefaultScenario(contract);
+    }
+    renderScenario(scenario);
+    bindEvents();
+    await calculate();
+    if (invalidShareLink) {
+      showToast(`Invalid share link ignored: ${invalidShareLink.message}`);
+    }
+  } catch (error) {
+    showError(
+      error instanceof Error ? error : new Error("Initialization failed"),
+    );
+  } finally {
+    byId("loading").classList.add("is-hidden");
   }
 }
 

--- a/crates/tenforty-graph/demo/calculator.js
+++ b/crates/tenforty-graph/demo/calculator.js
@@ -1,0 +1,139 @@
+import { BrowserContractError, BrowserTaxRuntime } from "./browser_contract.js";
+
+export const INPUT_GROUPS = {
+  "income-fields": [
+    "w2_income",
+    "taxable_interest",
+    "ordinary_dividends",
+    "qualified_dividends",
+  ],
+  "other-income-fields": [
+    "short_term_capital_gains",
+    "long_term_capital_gains",
+    "self_employment_income",
+    "rental_income",
+    "schedule_1_income",
+  ],
+  "deduction-fields": ["standard_or_itemized", "itemized_deductions"],
+  "advanced-fields": [
+    "incentive_stock_option_gains",
+    "qbi_w2_wages",
+    "qbi_ubia",
+    "qbi_is_sstb",
+  ],
+};
+
+function defaultInputs(contract) {
+  return Object.fromEntries(
+    Object.entries(contract.inputs).map(([name, specification]) => [
+      name,
+      specification.default,
+    ]),
+  );
+}
+
+export function createDefaultScenario(contract) {
+  const inputs = defaultInputs(contract);
+  inputs.w2_income = 75000;
+  return {
+    year: Math.max(...contract.supported_years),
+    jurisdiction: "US",
+    filingStatus: "single",
+    inputs,
+  };
+}
+
+export function scenarioFromParityCase(contract, testCase) {
+  return {
+    year: testCase.year,
+    jurisdiction: testCase.jurisdiction,
+    filingStatus: testCase.filing_status,
+    inputs: { ...defaultInputs(contract), ...testCase.inputs },
+  };
+}
+
+function parseBoolean(name, value) {
+  if (value === "true" || value === "1") return true;
+  if (value === "false" || value === "0") return false;
+  throw new BrowserContractError(`${name} must be true or false`);
+}
+
+function parseInput(name, specification, value) {
+  if (specification.type === "boolean") return parseBoolean(name, value);
+  if (specification.type === "choice") {
+    if (!specification.choices.includes(value)) {
+      throw new BrowserContractError(
+        `${name} must be one of: ${specification.choices.join(", ")}`,
+      );
+    }
+    return value;
+  }
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    throw new BrowserContractError(`${name} must be a finite number`);
+  }
+  return number;
+}
+
+export function parseScenario(contract, search, fallbackScenario = null) {
+  const fallback = fallbackScenario ?? createDefaultScenario(contract);
+  const parameters =
+    search instanceof URLSearchParams
+      ? search
+      : new URLSearchParams(String(search).replace(/^[?#]/, ""));
+  const year = Number(parameters.get("year") ?? fallback.year);
+  const jurisdiction = parameters.get("jurisdiction") ?? fallback.jurisdiction;
+  const filingStatus = parameters.get("filing_status") ?? fallback.filingStatus;
+
+  if (!contract.supported_years.includes(year)) {
+    throw new BrowserContractError(`Unsupported tax year: ${year}`);
+  }
+  if (!Object.hasOwn(contract.jurisdictions, jurisdiction)) {
+    throw new BrowserContractError(`Unsupported jurisdiction: ${jurisdiction}`);
+  }
+  if (!Object.hasOwn(contract.filing_statuses, filingStatus)) {
+    throw new BrowserContractError(
+      `Unsupported filing status: ${filingStatus}`,
+    );
+  }
+
+  const inputs = { ...defaultInputs(contract), ...fallback.inputs };
+  for (const [name, specification] of Object.entries(contract.inputs)) {
+    if (parameters.has(name)) {
+      inputs[name] = parseInput(name, specification, parameters.get(name));
+    }
+  }
+
+  return { year, jurisdiction, filingStatus, inputs };
+}
+
+function encodedInputValue(specification, value) {
+  if (specification.type === "boolean") return value ? "true" : "false";
+  return String(value);
+}
+
+export function serializeScenario(contract, scenario) {
+  const parameters = new URLSearchParams();
+  const defaults = createDefaultScenario(contract).inputs;
+  parameters.set("year", String(scenario.year));
+  parameters.set("jurisdiction", scenario.jurisdiction);
+  parameters.set("filing_status", scenario.filingStatus);
+
+  for (const [name, specification] of Object.entries(contract.inputs)) {
+    const value = scenario.inputs[name];
+    if (value !== defaults[name]) {
+      parameters.set(name, encodedInputValue(specification, value));
+    }
+  }
+  return parameters.toString();
+}
+
+export function calculateScenario(graphlib, graph, contract, scenario) {
+  const calculator = new BrowserTaxRuntime(graphlib, graph, contract, {
+    year: scenario.year,
+    jurisdiction: scenario.jurisdiction,
+    filingStatus: scenario.filingStatus,
+  });
+  calculator.setInputs(scenario.inputs);
+  return calculator.evaluate();
+}

--- a/crates/tenforty-graph/demo/index.html
+++ b/crates/tenforty-graph/demo/index.html
@@ -3,454 +3,271 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tax Calculator Demo - tenforty-graph</title>
+    <meta
+      name="description"
+      content="Estimate federal and state income taxes privately in your browser with tenforty."
+    />
+    <title>US income tax calculator · tenforty</title>
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <div class="container">
-      <header>
-        <h1>Tax Calculator Demo</h1>
-        <p class="subtitle">Powered by tenforty-graph WebAssembly</p>
-      </header>
+    <a class="skip-link" href="#calculator">Skip to calculator</a>
 
-      <main>
-        <div class="col-inputs">
-          <section class="card">
-            <h2>Filing Status & State</h2>
-            <div class="two-col">
-              <div class="input-group">
-                <label for="filing-status">Filing Status</label>
-                <select id="filing-status">
-                  <option value="single">Single</option>
-                  <option value="married_joint">Married Filing Jointly</option>
-                  <option value="married_separate">
-                    Married Filing Separately
-                  </option>
-                  <option value="head_of_household">Head of Household</option>
-                  <option value="qualifying_widow">Qualifying Widow(er)</option>
-                </select>
-              </div>
-              <div class="input-group">
-                <label for="state">State</label>
-                <select id="state">
-                  <option value="none">Federal Only</option>
-                  <option value="california">California</option>
-                  <option value="new_york">New York</option>
-                </select>
-              </div>
-            </div>
-          </section>
+    <header class="site-header">
+      <a class="brand" href="./" aria-label="tenforty calculator home">
+        <span class="brand-mark" aria-hidden="true">1040</span>
+        <span>tenforty</span>
+      </a>
+      <div class="header-actions">
+        <span class="privacy-note">
+          <span class="privacy-dot" aria-hidden="true"></span>
+          Runs locally in your browser
+        </span>
+        <a class="github-link" href="https://github.com/mmacpherson/tenforty"
+          >Source on GitHub</a
+        >
+      </div>
+    </header>
 
-          <section class="card">
-            <h2>Earned Income</h2>
-            <div class="slider-group">
-              <label for="wages">Wages & Salary</label>
-              <div class="slider-row">
-                <input
-                  type="range"
-                  id="wages-slider"
-                  min="0"
-                  max="500000"
-                  step="1000"
-                  value="75000"
-                />
-                <div class="input-wrapper compact">
-                  <span class="prefix">$</span>
-                  <input
-                    type="number"
-                    id="wages"
-                    value="75000"
-                    min="0"
-                    step="1000"
-                  />
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section class="card">
-            <h2>Investment Income</h2>
-            <div class="slider-group">
-              <label for="interest">Interest Income</label>
-              <div class="slider-row">
-                <input
-                  type="range"
-                  id="interest-slider"
-                  min="0"
-                  max="50000"
-                  step="100"
-                  value="500"
-                />
-                <div class="input-wrapper compact">
-                  <span class="prefix">$</span>
-                  <input
-                    type="number"
-                    id="interest"
-                    value="500"
-                    min="0"
-                    step="100"
-                  />
-                </div>
-              </div>
-            </div>
-            <div class="slider-group">
-              <label for="dividends">Dividends</label>
-              <div class="slider-row">
-                <input
-                  type="range"
-                  id="dividends-slider"
-                  min="0"
-                  max="50000"
-                  step="100"
-                  value="1000"
-                />
-                <div class="input-wrapper compact">
-                  <span class="prefix">$</span>
-                  <input
-                    type="number"
-                    id="dividends"
-                    value="1000"
-                    min="0"
-                    step="100"
-                  />
-                </div>
-              </div>
-            </div>
-            <div class="slider-group">
-              <label for="stcg">Short-Term Capital Gains</label>
-              <div class="slider-row">
-                <input
-                  type="range"
-                  id="stcg-slider"
-                  min="0"
-                  max="100000"
-                  step="500"
-                  value="0"
-                />
-                <div class="input-wrapper compact">
-                  <span class="prefix">$</span>
-                  <input type="number" id="stcg" value="0" min="0" step="500" />
-                </div>
-              </div>
-            </div>
-            <div class="slider-group">
-              <label for="ltcg">Long-Term Capital Gains</label>
-              <div class="slider-row">
-                <input
-                  type="range"
-                  id="ltcg-slider"
-                  min="0"
-                  max="200000"
-                  step="1000"
-                  value="0"
-                />
-                <div class="input-wrapper compact">
-                  <span class="prefix">$</span>
-                  <input
-                    type="number"
-                    id="ltcg"
-                    value="0"
-                    min="0"
-                    step="1000"
-                  />
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section class="card collapsible" id="amt-section">
-            <h2 class="collapsible-header">
-              <span>AMT (Stock Options)</span>
-              <span class="toggle-icon">+</span>
-            </h2>
-            <div class="collapsible-content">
-              <p class="description">
-                ISO exercise spread triggers Alternative Minimum Tax
-              </p>
-              <div class="slider-group">
-                <label for="iso">ISO Exercise Gains</label>
-                <div class="slider-row">
-                  <input
-                    type="range"
-                    id="iso-slider"
-                    min="0"
-                    max="500000"
-                    step="5000"
-                    value="0"
-                  />
-                  <div class="input-wrapper compact">
-                    <span class="prefix">$</span>
-                    <input
-                      type="number"
-                      id="iso"
-                      value="0"
-                      min="0"
-                      step="5000"
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-          </section>
-        </div>
-
-        <div class="col-results">
-          <section class="card tax-breakdown">
-            <h2>Tax Breakdown</h2>
-            <div class="breakdown-table">
-              <div class="breakdown-row">
-                <span class="label">Gross Income</span>
-                <span class="value" id="gross-income">$0</span>
-              </div>
-              <div class="breakdown-row deduction">
-                <span class="label">- Standard Deduction</span>
-                <span class="value" id="std-deduction">-$0</span>
-              </div>
-              <div class="breakdown-row subtotal">
-                <span class="label">= Taxable Income</span>
-                <span class="value" id="taxable-income">$0</span>
-              </div>
-              <div class="breakdown-divider"></div>
-              <div class="breakdown-row">
-                <span class="label">Ordinary Income Tax</span>
-                <span class="value" id="ordinary-tax">$0</span>
-              </div>
-              <div class="breakdown-row" id="ltcg-tax-row">
-                <span class="label">Capital Gains Tax</span>
-                <span class="value" id="ltcg-tax">$0</span>
-              </div>
-              <div class="breakdown-row" id="niit-row" style="display: none">
-                <span class="label">Net Investment Income Tax (3.8%)</span>
-                <span class="value" id="niit">$0</span>
-              </div>
-              <div
-                class="breakdown-row"
-                id="medicare-row"
-                style="display: none"
-              >
-                <span class="label">Additional Medicare Tax (0.9%)</span>
-                <span class="value" id="medicare-tax">$0</span>
-              </div>
-              <div
-                class="breakdown-row amt-indicator"
-                id="amt-row"
-                style="display: none"
-              >
-                <span class="label" id="amt-label"
-                  >Alternative Minimum Tax</span
-                >
-                <span class="value" id="amt">$0</span>
-              </div>
-              <div class="breakdown-divider"></div>
-              <div class="breakdown-row total federal">
-                <span class="label">Federal Tax</span>
-                <span class="value" id="federal-tax">$0</span>
-              </div>
-              <div
-                class="breakdown-row"
-                id="state-tax-row"
-                style="display: none"
-              >
-                <span class="label" id="state-tax-label">State Tax</span>
-                <span class="value" id="state-tax">$0</span>
-              </div>
-              <div
-                class="breakdown-row total combined"
-                id="total-row"
-                style="display: none"
-              >
-                <span class="label">Total Tax</span>
-                <span class="value" id="total-tax">$0</span>
-              </div>
-            </div>
-            <div class="rate-display">
-              <div class="rate-item">
-                <span class="rate-value" id="effective-rate">0%</span>
-                <span class="rate-label">Effective Rate</span>
-              </div>
-              <div class="rate-item">
-                <span class="rate-value" id="marginal-rate">0%</span>
-                <span class="rate-label">Marginal Rate</span>
-              </div>
-            </div>
-          </section>
-
-          <section class="card visualization">
-            <div class="chart-header">
-              <h2>Tax Curve</h2>
-              <label class="toggle-label">
-                <input type="checkbox" id="stacked-toggle" />
-                <span>Show breakdown</span>
-              </label>
-            </div>
-            <div class="chart-container">
-              <svg
-                id="tax-chart"
-                viewBox="0 0 600 300"
-                preserveAspectRatio="xMidYMid meet"
-              >
-                <defs>
-                  <linearGradient
-                    id="curveGradient"
-                    x1="0%"
-                    y1="0%"
-                    x2="0%"
-                    y2="100%"
-                  >
-                    <stop
-                      offset="0%"
-                      style="stop-color: #667eea; stop-opacity: 0.3"
-                    />
-                    <stop
-                      offset="100%"
-                      style="stop-color: #667eea; stop-opacity: 0.05"
-                    />
-                  </linearGradient>
-                </defs>
-                <g class="grid"></g>
-                <g class="axis-labels"></g>
-                <g class="stacked-areas"></g>
-                <path class="tax-area" fill="url(#curveGradient)"></path>
-                <path
-                  class="tax-curve"
-                  fill="none"
-                  stroke="#667eea"
-                  stroke-width="2"
-                ></path>
-                <g class="current-point">
-                  <line
-                    class="crosshair-v"
-                    stroke="#e74c3c"
-                    stroke-dasharray="4,4"
-                  ></line>
-                  <line
-                    class="crosshair-h"
-                    stroke="#e74c3c"
-                    stroke-dasharray="4,4"
-                  ></line>
-                  <circle r="6" fill="#e74c3c"></circle>
-                </g>
-              </svg>
-              <div
-                class="stacked-legend"
-                id="stacked-legend"
-                style="display: none"
-              ></div>
-              <div class="chart-tooltip" id="chart-tooltip"></div>
-            </div>
-          </section>
-
-          <section class="card bracket-viz">
-            <h2>Bracket Breakdown</h2>
-            <div class="bracket-bar" id="bracket-bar"></div>
-            <div class="bracket-legend" id="bracket-legend"></div>
-          </section>
-
-          <section class="card sensitivity">
-            <h2>Gradient Sensitivity</h2>
-            <p class="description">
-              Tax impact of +$1,000 in each income type (autodiff)
-            </p>
-            <div class="sensitivity-grid" id="sensitivity-grid">
-              <div class="sensitivity-item">
-                <span class="sens-label">Wages</span>
-                <span class="sens-value" id="sens-wages">+$0</span>
-                <span class="sens-rate" id="sens-wages-rate">0%</span>
-              </div>
-              <div class="sensitivity-item">
-                <span class="sens-label">Interest</span>
-                <span class="sens-value" id="sens-interest">+$0</span>
-                <span class="sens-rate" id="sens-interest-rate">0%</span>
-              </div>
-              <div class="sensitivity-item">
-                <span class="sens-label">LTCG</span>
-                <span class="sens-value" id="sens-ltcg">+$0</span>
-                <span class="sens-rate" id="sens-ltcg-rate">0%</span>
-              </div>
-            </div>
-          </section>
-
-          <section class="card solver">
-            <h2>Inverse Solver</h2>
-            <p class="description">
-              What wages would result in a specific tax amount?
-            </p>
-            <div class="input-group">
-              <label for="target-tax">Target Federal Tax</label>
-              <div class="input-wrapper">
-                <span class="prefix">$</span>
-                <input
-                  type="number"
-                  id="target-tax"
-                  value="10000"
-                  min="0"
-                  step="1000"
-                />
-              </div>
-            </div>
-            <button id="solve-btn">
-              <span class="btn-text">Calculate Required Wages</span>
-              <span class="btn-loading" style="display: none">Solving...</span>
-            </button>
-            <div
-              class="solver-animation"
-              id="solver-animation"
-              style="display: none"
-            >
-              <svg
-                id="solver-chart"
-                viewBox="0 0 400 200"
-                preserveAspectRatio="xMidYMid meet"
-              >
-                <path
-                  class="solver-curve"
-                  fill="none"
-                  stroke="#3498db"
-                  stroke-width="2"
-                ></path>
-                <line
-                  class="target-line"
-                  stroke="#27ae60"
-                  stroke-width="2"
-                  stroke-dasharray="6,3"
-                ></line>
-                <g class="iteration-points"></g>
-                <line
-                  class="tangent-line"
-                  stroke="#e74c3c"
-                  stroke-width="1.5"
-                ></line>
-                <circle class="current-iter" r="5" fill="#e74c3c"></circle>
-              </svg>
-              <div class="solver-stats">
-                <span>Iteration: <strong id="iter-count">0</strong></span>
-                <span>Error: <strong id="iter-error">$0</strong></span>
-              </div>
-            </div>
-            <div class="result-row" id="solver-result" style="display: none">
-              <span class="label">Required Wages</span>
-              <span class="value" id="solved-wages">$0</span>
-            </div>
-          </section>
-        </div>
-      </main>
-
-      <footer>
-        <p>
-          2024 Tax Year | Graph-based computation with autodiff | Powered by
-          <a
-            href="https://github.com/mmacpherson/tenforty"
-            style="color: #7f8c8d"
-            >tenforty</a
-          >
+    <main id="calculator">
+      <section class="intro" aria-labelledby="page-title">
+        <p class="eyebrow">Federal + all 50 states + DC</p>
+        <h1 id="page-title">See the tax picture,<br />as you change it.</h1>
+        <p class="intro-copy">
+          A fast, open-source estimate of modeled personal income taxes. Change
+          any number and the graph recalculates instantly—without sending your
+          financial information anywhere.
         </p>
-      </footer>
+      </section>
+
+      <section class="scenario-bar" aria-labelledby="scenario-heading">
+        <div class="scenario-heading-wrap">
+          <p class="section-number">01</p>
+          <div>
+            <h2 id="scenario-heading">Your filing scenario</h2>
+            <p>Choose the return you want to model.</p>
+          </div>
+        </div>
+        <div class="scenario-controls">
+          <div class="control">
+            <label for="tax-year">Tax year</label>
+            <select id="tax-year" name="year"></select>
+          </div>
+          <div class="control control-wide">
+            <label for="filing-status">Filing status</label>
+            <select id="filing-status" name="filing_status"></select>
+          </div>
+          <div class="control control-wide">
+            <label for="jurisdiction">State</label>
+            <select id="jurisdiction" name="jurisdiction"></select>
+          </div>
+        </div>
+      </section>
+
+      <div id="error-banner" class="error-banner" role="alert" hidden>
+        <div>
+          <strong>We couldn’t calculate this scenario.</strong>
+          <p id="error-message"></p>
+        </div>
+        <button id="dismiss-error" type="button" aria-label="Dismiss error">
+          ×
+        </button>
+      </div>
+
+      <form id="calculator-form" class="calculator-grid" novalidate>
+        <section class="input-card" aria-labelledby="income-heading">
+          <div class="card-heading">
+            <p class="section-number">02</p>
+            <div>
+              <h2 id="income-heading">Income</h2>
+              <p>Start with the amounts that make up most returns.</p>
+            </div>
+          </div>
+          <div id="income-fields" class="field-grid"></div>
+        </section>
+
+        <details id="other-income-card" class="input-card expandable-card" open>
+          <summary>
+            <span>
+              <span class="summary-title">Investments &amp; other income</span>
+              <span class="summary-description"
+                >Capital gains, rentals, and business income</span
+              >
+            </span>
+            <span class="summary-icon" aria-hidden="true"></span>
+          </summary>
+          <div id="other-income-fields" class="field-grid details-fields"></div>
+        </details>
+
+        <section class="input-card" aria-labelledby="deductions-heading">
+          <div class="card-heading compact-heading">
+            <div>
+              <h2 id="deductions-heading">Deductions</h2>
+              <p>Use the larger deduction automatically, or force itemizing.</p>
+            </div>
+          </div>
+          <div id="deduction-fields" class="field-grid"></div>
+        </section>
+
+        <details id="advanced-card" class="input-card expandable-card">
+          <summary>
+            <span>
+              <span class="summary-title">Advanced tax inputs</span>
+              <span class="summary-description"
+                >ISO exercise spread and qualified-business limits</span
+              >
+            </span>
+            <span class="summary-icon" aria-hidden="true"></span>
+          </summary>
+          <div id="advanced-fields" class="field-grid details-fields"></div>
+        </details>
+        <aside class="results-column" aria-labelledby="results-heading">
+          <section class="results-hero" aria-live="polite" aria-busy="true">
+            <div class="result-kicker">
+              <span id="result-year">2025</span> estimated total tax
+              <span id="result-state-context"></span>
+            </div>
+            <h2 id="results-heading" class="sr-only">Estimated tax results</h2>
+            <p id="total-tax" class="total-tax">—</p>
+            <div class="hero-breakdown">
+              <div>
+                <span>Federal</span>
+                <strong id="federal-tax">—</strong>
+              </div>
+              <div>
+                <span id="state-tax-label">State</span>
+                <strong id="state-tax">—</strong>
+              </div>
+            </div>
+            <div class="effective-rate-row">
+              <div>
+                <strong id="effective-rate">—</strong>
+                <span>Combined effective rate</span>
+              </div>
+              <div>
+                <strong id="federal-effective-rate">—</strong>
+                <span>Federal</span>
+              </div>
+              <div>
+                <strong id="state-effective-rate">—</strong>
+                <span>State</span>
+              </div>
+            </div>
+          </section>
+
+          <section class="result-details" aria-labelledby="detail-heading">
+            <div class="result-details-heading">
+              <div>
+                <p class="section-number">03</p>
+                <h2 id="detail-heading">How it adds up</h2>
+              </div>
+              <span id="calculation-status" class="calculation-status"
+                >Loading calculator…</span
+              >
+            </div>
+
+            <div class="result-group">
+              <h3>Income after deductions</h3>
+              <div class="result-row">
+                <span>Federal adjusted gross income</span>
+                <strong id="federal-agi">—</strong>
+              </div>
+              <div class="result-row">
+                <span>Federal taxable income</span>
+                <strong id="federal-taxable-income">—</strong>
+              </div>
+              <div class="result-row optional-result" id="qbi-row" hidden>
+                <span>Qualified-business deduction</span>
+                <strong id="federal-qbi-deduction">—</strong>
+              </div>
+              <div class="result-row optional-result" id="state-agi-row" hidden>
+                <span id="state-agi-label">State adjusted gross income</span>
+                <strong id="state-agi">—</strong>
+              </div>
+              <div
+                class="result-row optional-result"
+                id="state-taxable-income-row"
+                hidden
+              >
+                <span id="state-taxable-income-label"
+                  >State taxable income</span
+                >
+                <strong id="state-taxable-income">—</strong>
+              </div>
+            </div>
+
+            <div class="result-group">
+              <h3>Federal tax components</h3>
+              <div class="result-row">
+                <span>Income tax <small>includes AMT</small></span>
+                <strong id="federal-income-tax">—</strong>
+              </div>
+              <div class="result-row optional-result" id="se-tax-row" hidden>
+                <span>Self-employment tax</span>
+                <strong id="federal-se-tax">—</strong>
+              </div>
+              <div class="result-row optional-result" id="niit-row" hidden>
+                <span>Net investment income tax</span>
+                <strong id="federal-niit">—</strong>
+              </div>
+              <div
+                class="result-row optional-result"
+                id="medicare-tax-row"
+                hidden
+              >
+                <span>Additional Medicare tax</span>
+                <strong id="federal-medicare-tax">—</strong>
+              </div>
+              <div class="result-row informational" id="amt-row" hidden>
+                <span>Of income tax: alternative minimum tax</span>
+                <strong id="federal-amt">—</strong>
+              </div>
+            </div>
+
+            <div class="result-actions">
+              <button id="share-scenario" class="button primary" type="button">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path
+                    d="M8.7 13.9 15.3 10M8.7 10.1l6.6 3.8M6 14.5a3 3 0 1 1 0-6 3 3 0 0 1 0 6Zm12 4a3 3 0 1 1 0-6 3 3 0 0 1 0 6Zm0-7a3 3 0 1 1 0-6 3 3 0 0 1 0 6Z"
+                  />
+                </svg>
+                Copy share link
+              </button>
+              <button
+                id="reset-scenario"
+                class="button secondary"
+                type="button"
+              >
+                Reset
+              </button>
+            </div>
+          </section>
+
+          <details class="scope-note">
+            <summary>What this estimate includes</summary>
+            <div id="limitations-list"></div>
+          </details>
+        </aside>
+      </form>
+    </main>
+
+    <footer class="site-footer">
+      <div>
+        <strong>tenforty</strong>
+        <span>Open-source tax computation for exploration and planning.</span>
+      </div>
+      <p>
+        Estimates modeled income-tax liability before payments and refundable
+        credits. Not tax-return filing advice.
+      </p>
+    </footer>
+
+    <div id="loading" class="loading" role="status">
+      <div class="loading-mark" aria-hidden="true">1040</div>
+      <p>Loading the tax graph…</p>
     </div>
 
-    <div id="loading" class="loading">
-      <div class="spinner"></div>
-      <p>Loading WebAssembly module...</p>
-    </div>
+    <div id="toast" class="toast" role="status" aria-live="polite"></div>
 
     <script type="module" src="app.js"></script>
   </body>

--- a/crates/tenforty-graph/demo/style.css
+++ b/crates/tenforty-graph/demo/style.css
@@ -1,751 +1,1024 @@
+:root {
+  color-scheme: light;
+  --ink: #17241f;
+  --ink-soft: #52615b;
+  --paper: #f3f2ec;
+  --surface: #fffefa;
+  --line: #d9ddd6;
+  --line-strong: #b8c0b9;
+  --green: #164f3e;
+  --green-bright: #3bd49a;
+  --green-pale: #dff4e9;
+  --yellow: #f5d35f;
+  --red: #a53d32;
+  --red-pale: #fbe8e4;
+  --shadow: 0 18px 55px rgb(23 36 31 / 8%);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  font-synthesis: none;
+}
+
 * {
   box-sizing: border-box;
-  margin: 0;
-  padding: 0;
+}
+
+html {
+  scroll-behavior: smooth;
 }
 
 body {
-  font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
-    sans-serif;
-  background: #f5f7fa;
-  color: #2c3e50;
-  line-height: 1.6;
+  margin: 0;
+  background:
+    radial-gradient(circle at 90% 3%, rgb(59 212 154 / 10%), transparent 26rem),
+    var(--paper);
+  color: var(--ink);
+  line-height: 1.5;
 }
 
-.container {
-  max-width: 1400px;
+button,
+input,
+select {
+  color: inherit;
+  font: inherit;
+}
+
+button,
+select {
+  cursor: pointer;
+}
+
+a {
+  color: inherit;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+.skip-link {
+  position: fixed;
+  z-index: 100;
+  top: 0.75rem;
+  left: 0.75rem;
+  padding: 0.7rem 1rem;
+  transform: translateY(-150%);
+  border-radius: 0.25rem;
+  background: var(--ink);
+  color: white;
+}
+
+.skip-link:focus {
+  transform: none;
+}
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 1280px;
   margin: 0 auto;
-  padding: 20px;
+  padding: 1.35rem 2rem;
+  border-bottom: 1px solid rgb(23 36 31 / 12%);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.7rem;
+  color: var(--ink);
+  font-size: 1.15rem;
+  font-weight: 780;
+  letter-spacing: -0.025em;
+  text-decoration: none;
+}
+
+.brand-mark {
+  display: grid;
+  width: 2.5rem;
+  height: 2.5rem;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--green);
+  color: white;
+  font-size: 0.7rem;
+  font-weight: 850;
+  letter-spacing: -0.03em;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  font-size: 0.82rem;
+}
+
+.privacy-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--ink-soft);
+}
+
+.privacy-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: #22a875;
+  box-shadow: 0 0 0 0.22rem rgb(34 168 117 / 14%);
+}
+
+.github-link {
+  font-weight: 700;
+  text-underline-offset: 0.2rem;
 }
 
 main {
-  display: grid;
-  grid-template-columns: 380px 1fr;
-  gap: 30px;
-  align-items: start;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 4.5rem 2rem 6rem;
 }
 
-.col-inputs,
-.col-results {
+.intro {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) minmax(18rem, 0.7fr);
+  align-items: end;
+  gap: 4rem;
+  margin-bottom: 3.6rem;
+}
+
+.eyebrow,
+.section-number {
+  margin: 0 0 0.7rem;
+  color: var(--green);
+  font-size: 0.72rem;
+  font-weight: 820;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.intro h1 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(3rem, 6.7vw, 6.1rem);
+  font-weight: 500;
+  letter-spacing: -0.06em;
+  line-height: 0.93;
+}
+
+.intro-copy {
+  max-width: 34rem;
+  margin: 0 0 0.45rem;
+  color: var(--ink-soft);
+  font-size: 1.04rem;
+  line-height: 1.72;
+}
+
+.scenario-bar {
+  display: grid;
+  grid-template-columns: 0.72fr 1.28fr;
+  gap: 2rem;
+  align-items: end;
+  padding: 1.65rem;
+  border: 1px solid var(--line);
+  background: rgb(255 254 250 / 78%);
+  box-shadow: 0 8px 30px rgb(23 36 31 / 4%);
+}
+
+.scenario-heading-wrap,
+.card-heading {
   display: flex;
-  flex-direction: column;
-  gap: 20px;
+  align-items: flex-start;
+  gap: 1rem;
 }
 
-.col-inputs .card,
-.col-results .card {
-  margin-bottom: 0;
+.scenario-heading-wrap .section-number,
+.card-heading .section-number {
+  min-width: 1.8rem;
+  padding-top: 0.25rem;
 }
 
-@media (max-width: 900px) {
-  main {
-    grid-template-columns: 1fr;
-  }
+.scenario-heading-wrap h2,
+.card-heading h2,
+.result-details h2 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 1.45rem;
+  font-weight: 500;
+  letter-spacing: -0.025em;
 }
 
-header {
-  text-align: center;
-  margin-bottom: 30px;
+.scenario-heading-wrap p:not(.section-number),
+.card-heading p:not(.section-number) {
+  margin: 0.2rem 0 0;
+  color: var(--ink-soft);
+  font-size: 0.84rem;
 }
 
-header h1 {
-  font-size: 1.8rem;
-  color: #2c3e50;
-  margin-bottom: 5px;
-}
-
-.subtitle {
-  color: #7f8c8d;
-  font-size: 0.9rem;
-}
-
-.card {
-  background: white;
-  border-radius: 12px;
-  padding: 20px;
-  margin-bottom: 20px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-}
-
-.card h2 {
-  font-size: 1.1rem;
-  color: #34495e;
-  margin-bottom: 15px;
-  padding-bottom: 10px;
-  border-bottom: 1px solid #ecf0f1;
-}
-
-.two-col {
+.scenario-controls {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 15px;
+  grid-template-columns: 0.62fr 1.22fr 1.16fr;
+  gap: 0.85rem;
 }
 
-@media (max-width: 500px) {
-  .two-col {
-    grid-template-columns: 1fr;
-  }
+.control label,
+.money-field label,
+.choice-field label {
+  display: block;
+  margin-bottom: 0.42rem;
+  color: var(--ink-soft);
+  font-size: 0.75rem;
+  font-weight: 720;
+}
+
+select,
+input[type="number"] {
+  width: 100%;
+  min-height: 3rem;
+  border: 1px solid var(--line-strong);
+  border-radius: 0;
+  background-color: var(--surface);
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease;
 }
 
 select {
-  width: 100%;
-  padding: 12px;
-  border: 1px solid #dce4ec;
-  border-radius: 8px;
-  font-size: 1rem;
-  background: white;
-  cursor: pointer;
-}
-
-select:focus {
-  outline: none;
-  border-color: #3498db;
-  box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.1);
-}
-
-.input-group {
-  margin-bottom: 15px;
-}
-
-.input-group:last-child {
-  margin-bottom: 0;
-}
-
-.input-group label {
-  display: block;
-  font-size: 0.85rem;
-  color: #7f8c8d;
-  margin-bottom: 5px;
-}
-
-.input-wrapper {
-  position: relative;
-  display: flex;
-  align-items: center;
-}
-
-.prefix {
-  position: absolute;
-  left: 12px;
-  color: #7f8c8d;
-  font-weight: 500;
+  padding: 0.65rem 2.1rem 0.65rem 0.8rem;
 }
 
 input[type="number"] {
-  width: 100%;
-  padding: 12px 12px 12px 28px;
-  border: 1px solid #dce4ec;
-  border-radius: 8px;
-  font-size: 1rem;
-}
-
-input[type="number"]:focus {
-  outline: none;
-  border-color: #3498db;
-  box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.1);
-}
-
-input[type="number"]::-webkit-inner-spin-button,
-input[type="number"]::-webkit-outer-spin-button {
-  opacity: 1;
-}
-
-.slider-group {
-  margin-bottom: 12px;
-}
-
-.slider-group:last-child {
-  margin-bottom: 0;
-}
-
-.col-inputs .slider-group {
-  margin-bottom: 10px;
-}
-
-.slider-group label {
-  display: block;
-  font-size: 0.85rem;
-  color: #7f8c8d;
-  margin-bottom: 8px;
-}
-
-.slider-row {
-  display: flex;
-  align-items: center;
-  gap: 15px;
-}
-
-input[type="range"] {
-  flex: 1;
-  height: 6px;
-  -webkit-appearance: none;
-  appearance: none;
-  background: #ecf0f1;
-  border-radius: 3px;
-  cursor: pointer;
-}
-
-input[type="range"]::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 18px;
-  height: 18px;
-  background: #3498db;
-  border-radius: 50%;
-  cursor: pointer;
-  transition: transform 0.1s;
-}
-
-input[type="range"]::-webkit-slider-thumb:hover {
-  transform: scale(1.1);
-}
-
-input[type="range"]::-moz-range-thumb {
-  width: 18px;
-  height: 18px;
-  background: #3498db;
-  border: none;
-  border-radius: 50%;
-  cursor: pointer;
-}
-
-.input-wrapper.compact {
-  width: 120px;
-  flex-shrink: 0;
-}
-
-.input-wrapper.compact input[type="number"] {
-  padding: 8px 8px 8px 24px;
-  font-size: 0.9rem;
-}
-
-.input-wrapper.compact .prefix {
-  left: 8px;
-}
-
-.collapsible .collapsible-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  cursor: pointer;
-  margin-bottom: 0;
-  padding-bottom: 0;
-  border-bottom: none;
-}
-
-.collapsible .toggle-icon {
-  font-size: 1.2rem;
-  color: #7f8c8d;
-  transition: transform 0.2s;
-}
-
-.collapsible.open .toggle-icon {
-  transform: rotate(45deg);
-}
-
-.collapsible .collapsible-content {
-  display: none;
-  padding-top: 15px;
-  border-top: 1px solid #ecf0f1;
-  margin-top: 15px;
-}
-
-.collapsible.open .collapsible-content {
-  display: block;
-}
-
-.description {
-  font-size: 0.85rem;
-  color: #7f8c8d;
-  margin-bottom: 15px;
-}
-
-.tax-breakdown {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
-}
-
-.tax-breakdown h2 {
-  color: rgba(255, 255, 255, 0.9);
-  border-bottom-color: rgba(255, 255, 255, 0.2);
-}
-
-.breakdown-table {
-  font-size: 0.95rem;
-}
-
-.breakdown-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 8px 0;
-}
-
-.breakdown-row .label {
-  opacity: 0.9;
-}
-
-.breakdown-row .value {
-  font-weight: 500;
+  padding: 0.65rem 0.8rem 0.65rem 1.75rem;
   font-variant-numeric: tabular-nums;
 }
 
-.breakdown-row.deduction {
-  color: rgba(255, 255, 255, 0.75);
+select:hover,
+input[type="number"]:hover {
+  border-color: #7d8981;
 }
 
-.breakdown-row.subtotal {
-  font-weight: 600;
-  border-top: 1px solid rgba(255, 255, 255, 0.2);
-  padding-top: 10px;
-  margin-top: 5px;
+select:focus-visible,
+input:focus-visible,
+button:focus-visible,
+summary:focus-visible,
+a:focus-visible {
+  outline: 3px solid rgb(59 212 154 / 45%);
+  outline-offset: 2px;
 }
 
-.breakdown-divider {
-  height: 1px;
-  background: rgba(255, 255, 255, 0.2);
-  margin: 12px 0;
-}
-
-.breakdown-row.total {
-  font-size: 1.1rem;
-  font-weight: 600;
-}
-
-.breakdown-row.total.federal {
-  padding-top: 5px;
-}
-
-.breakdown-row.total.combined {
-  font-size: 1.2rem;
-  padding-top: 10px;
-  border-top: 1px solid rgba(255, 255, 255, 0.3);
-  margin-top: 5px;
-}
-
-.breakdown-row.amt-indicator.in-amt {
-  background: rgba(231, 76, 60, 0.3);
-  margin: 4px -10px;
-  padding: 8px 10px;
-  border-radius: 6px;
-}
-
-.breakdown-row.amt-indicator.in-amt .value {
-  color: #ffcccc;
-  font-weight: 600;
-}
-
-.breakdown-row.amt-indicator.amt-cushion {
-  opacity: 0.7;
-}
-
-.breakdown-row.amt-indicator.amt-cushion .value {
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.rate-display {
+.error-banner {
   display: flex;
-  gap: 30px;
-  margin-top: 20px;
-  padding-top: 15px;
-  border-top: 1px solid rgba(255, 255, 255, 0.2);
-}
-
-.rate-item {
-  display: flex;
-  flex-direction: column;
-}
-
-.rate-value {
-  font-size: 1.5rem;
-  font-weight: 700;
-}
-
-.rate-label {
-  font-size: 0.8rem;
-  opacity: 0.8;
-}
-
-.visualization {
-  padding-bottom: 15px;
-}
-
-.chart-header {
-  display: flex;
+  align-items: flex-start;
   justify-content: space-between;
-  align-items: center;
-  margin-bottom: 15px;
-  padding-bottom: 10px;
-  border-bottom: 1px solid #ecf0f1;
+  gap: 1rem;
+  margin-top: 1rem;
+  padding: 1rem 1.15rem;
+  border: 1px solid #d8a29a;
+  background: var(--red-pale);
+  color: #702921;
 }
 
-.chart-header h2 {
-  margin-bottom: 0;
-  padding-bottom: 0;
-  border-bottom: none;
+.error-banner p {
+  margin: 0.2rem 0 0;
+  font-size: 0.86rem;
 }
 
-.toggle-label {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 0.85rem;
-  color: #7f8c8d;
-  cursor: pointer;
+.error-banner button {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font-size: 1.4rem;
+  line-height: 1;
 }
 
-.toggle-label input[type="checkbox"] {
-  width: 16px;
-  height: 16px;
-  cursor: pointer;
+.calculator-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(22rem, 0.72fr);
+  gap: 1.3rem;
+  align-items: start;
+  margin-top: 1.3rem;
 }
 
-.stacked-legend {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 16px;
-  margin-top: 12px;
-  padding-top: 12px;
-  border-top: 1px solid #ecf0f1;
-  font-size: 0.8rem;
+.input-card,
+.result-details,
+.scope-note {
+  border: 1px solid var(--line);
+  background: var(--surface);
 }
 
-.stacked-legend-item {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  color: #5a6a7a;
+.input-card {
+  grid-column: 1;
+  padding: 1.7rem;
 }
 
-.stacked-legend-color {
-  width: 12px;
-  height: 12px;
-  border-radius: 2px;
+.card-heading {
+  padding-bottom: 1.35rem;
+  border-bottom: 1px solid var(--line);
 }
 
-.stacked-areas path {
-  opacity: 0.85;
+.compact-heading {
+  display: block;
 }
 
-.chart-container {
+.field-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.15rem 1rem;
+  padding-top: 1.35rem;
+}
+
+.input-field {
+  min-width: 0;
+}
+
+.input-field.full-width {
+  grid-column: 1 / -1;
+}
+
+.money-input-wrap {
   position: relative;
-  width: 100%;
-  aspect-ratio: 2 / 1;
 }
 
-#tax-chart {
-  width: 100%;
-  height: 100%;
-}
-
-.chart-tooltip {
+.money-prefix {
   position: absolute;
-  background: rgba(44, 62, 80, 0.95);
-  color: white;
-  padding: 8px 12px;
-  border-radius: 6px;
-  font-size: 0.85rem;
-  pointer-events: none;
+  z-index: 1;
+  top: 50%;
+  left: 0.8rem;
+  transform: translateY(-50%);
+  color: #758079;
+  font-size: 0.9rem;
+}
+
+.field-description {
+  min-height: 2.5em;
+  margin: 0.38rem 0 0;
+  color: #748078;
+  font-size: 0.7rem;
+  line-height: 1.35;
+}
+
+.input-field.unsupported {
+  padding: 0.7rem;
+  border: 1px solid #dfb169;
+  background: #fff8e9;
+}
+
+.unsupported-message {
+  margin: 0.45rem 0 0;
+  color: #7a5318;
+  font-size: 0.72rem;
+  font-weight: 650;
+}
+
+.boolean-field {
+  display: flex;
+  grid-column: 1 / -1;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--line);
+}
+
+.boolean-field label {
+  font-size: 0.82rem;
+  font-weight: 730;
+}
+
+.boolean-field .field-description {
+  min-height: 0;
+  margin-top: 0.2rem;
+}
+
+.switch {
+  position: relative;
+  width: 2.8rem;
+  height: 1.55rem;
+  flex: 0 0 auto;
+}
+
+.switch input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
   opacity: 0;
-  transition: opacity 0.15s;
-  z-index: 10;
+}
+
+.switch-track {
+  position: absolute;
+  inset: 0;
+  border-radius: 2rem;
+  background: #c7cec9;
+  transition: background 150ms ease;
+}
+
+.switch-track::after {
+  position: absolute;
+  top: 0.2rem;
+  left: 0.2rem;
+  width: 1.15rem;
+  height: 1.15rem;
+  border-radius: 50%;
+  background: white;
+  box-shadow: 0 1px 4px rgb(0 0 0 / 20%);
+  content: "";
+  transition: transform 150ms ease;
+}
+
+.switch input:checked + .switch-track {
+  background: var(--green);
+}
+
+.switch input:checked + .switch-track::after {
+  transform: translateX(1.25rem);
+}
+
+.switch input:focus-visible + .switch-track {
+  outline: 3px solid rgb(59 212 154 / 45%);
+  outline-offset: 2px;
+}
+
+.expandable-card {
+  padding: 0;
+}
+
+.expandable-card summary,
+.scope-note summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.35rem 1.7rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.expandable-card summary::-webkit-details-marker,
+.scope-note summary::-webkit-details-marker {
+  display: none;
+}
+
+.summary-title {
+  display: block;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 1.1rem;
+}
+
+.summary-description {
+  display: block;
+  margin-top: 0.15rem;
+  color: var(--ink-soft);
+  font-size: 0.75rem;
+}
+
+.summary-icon {
+  position: relative;
+  width: 1.1rem;
+  height: 1.1rem;
+  flex: 0 0 auto;
+}
+
+.summary-icon::before,
+.summary-icon::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0.75rem;
+  height: 1px;
+  background: var(--ink);
+  content: "";
+  transition: transform 150ms ease;
+}
+
+.summary-icon::before {
+  transform: translate(-50%, -50%);
+}
+
+.summary-icon::after {
+  transform: translate(-50%, -50%) rotate(90deg);
+}
+
+.expandable-card[open] .summary-icon::after {
+  transform: translate(-50%, -50%) rotate(0deg);
+}
+
+.details-fields {
+  margin: 0 1.7rem;
+  padding: 1.35rem 0 1.7rem;
+  border-top: 1px solid var(--line);
+}
+
+.results-column {
+  position: sticky;
+  top: 1rem;
+  display: grid;
+  grid-column: 2;
+  grid-row: 1 / span 4;
+  gap: 1rem;
+}
+
+.results-hero {
+  position: relative;
+  overflow: hidden;
+  padding: 2rem;
+  background: var(--green);
+  color: white;
+  box-shadow: var(--shadow);
+}
+
+.results-hero::after {
+  position: absolute;
+  top: -7rem;
+  right: -7rem;
+  width: 15rem;
+  height: 15rem;
+  border: 1px solid rgb(255 255 255 / 17%);
+  border-radius: 50%;
+  box-shadow:
+    0 0 0 2.5rem rgb(255 255 255 / 3%),
+    0 0 0 5rem rgb(255 255 255 / 2%);
+  content: "";
+}
+
+.result-kicker {
+  position: relative;
+  z-index: 1;
+  color: rgb(255 255 255 / 68%);
+  font-size: 0.73rem;
+  font-weight: 760;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.total-tax {
+  position: relative;
+  z-index: 1;
+  margin: 0.25rem 0 1.3rem;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(3.1rem, 5vw, 4.6rem);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.055em;
+  line-height: 1;
+}
+
+.hero-breakdown {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  padding: 1rem 0;
+  border-top: 1px solid rgb(255 255 255 / 18%);
+  border-bottom: 1px solid rgb(255 255 255 / 18%);
+}
+
+.hero-breakdown div,
+.effective-rate-row div {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.hero-breakdown span,
+.effective-rate-row span {
+  color: rgb(255 255 255 / 62%);
+  font-size: 0.69rem;
+}
+
+.hero-breakdown strong {
+  font-size: 1.04rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.effective-rate-row {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 1.45fr 1fr 1fr;
+  gap: 0.7rem;
+  padding-top: 1.1rem;
+}
+
+.effective-rate-row strong {
+  font-size: 1.15rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.results-hero.is-stale {
+  opacity: 0.72;
+}
+
+.result-details {
+  padding: 1.5rem;
+}
+
+.result-details-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 1.2rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.result-details-heading .section-number {
+  margin-bottom: 0.25rem;
+}
+
+.calculation-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: 0.15rem;
+  color: var(--ink-soft);
+  font-size: 0.67rem;
+  font-weight: 680;
   white-space: nowrap;
 }
 
-.chart-tooltip.visible {
-  opacity: 1;
+.calculation-status::before {
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: 50%;
+  background: #22a875;
+  content: "";
 }
 
-.grid line {
-  stroke: #ecf0f1;
-  stroke-width: 1;
+.calculation-status.calculating::before {
+  animation: pulse 0.8s infinite alternate;
+  background: var(--yellow);
 }
 
-.axis-labels text {
-  fill: #7f8c8d;
-  font-size: 10px;
+.result-group {
+  padding: 1.15rem 0 0.55rem;
+  border-bottom: 1px solid var(--line);
 }
 
-.current-point {
-  transition: transform 0.1s;
+.result-group h3 {
+  margin: 0 0 0.55rem;
+  color: var(--ink-soft);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
 }
 
-.bracket-viz {
-  padding-bottom: 15px;
-}
-
-.bracket-bar {
+.result-row {
   display: flex;
-  height: 30px;
-  border-radius: 4px;
-  overflow: hidden;
-  margin-bottom: 15px;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.48rem 0;
+  font-size: 0.79rem;
 }
 
-.bracket-segment {
-  display: flex;
+.result-row span {
+  color: var(--ink-soft);
+}
+
+.result-row small {
+  display: block;
+  color: #89928c;
+  font-size: 0.62rem;
+}
+
+.result-row strong {
+  flex: 0 0 auto;
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.result-row.informational {
+  margin-top: 0.25rem;
+  padding: 0.55rem 0.65rem;
+  background: var(--green-pale);
+}
+
+.result-actions {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.7rem;
+  padding-top: 1.25rem;
+}
+
+.button {
+  min-height: 2.85rem;
+  padding: 0.65rem 1rem;
+  border: 1px solid var(--ink);
+  font-size: 0.76rem;
+  font-weight: 760;
+}
+
+.button.primary {
+  display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 0.5rem;
+  background: var(--ink);
   color: white;
-  font-size: 0.7rem;
-  font-weight: 600;
-  min-width: 25px;
-  transition: flex 0.3s ease;
 }
 
-.bracket-segment:nth-child(1) {
-  background: #2ecc71;
-}
-.bracket-segment:nth-child(2) {
-  background: #27ae60;
-}
-.bracket-segment:nth-child(3) {
-  background: #f1c40f;
-}
-.bracket-segment:nth-child(4) {
-  background: #e67e22;
-}
-.bracket-segment:nth-child(5) {
-  background: #e74c3c;
-}
-.bracket-segment:nth-child(6) {
-  background: #c0392b;
-}
-.bracket-segment:nth-child(7) {
-  background: #8e44ad;
+.button.primary:hover {
+  background: var(--green);
 }
 
-.bracket-marker {
-  position: relative;
+.button.secondary {
+  background: transparent;
 }
 
-.bracket-marker::after {
-  content: "";
-  position: absolute;
-  top: -8px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 0;
-  height: 0;
-  border-left: 6px solid transparent;
-  border-right: 6px solid transparent;
-  border-top: 8px solid #2c3e50;
+.button.secondary:hover {
+  background: var(--paper);
 }
 
-.bracket-legend {
+.button svg {
+  width: 1rem;
+  height: 1rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
+.scope-note {
+  background: transparent;
+}
+
+.scope-note summary {
+  padding: 1rem 1.2rem;
+  font-size: 0.76rem;
+  font-weight: 740;
+}
+
+.scope-note summary::after {
+  content: "+";
+  font-size: 1.15rem;
+  font-weight: 400;
+}
+
+.scope-note[open] summary::after {
+  content: "−";
+}
+
+#limitations-list {
+  padding: 0 1.2rem 1rem;
+}
+
+#limitations-list p {
+  margin: 0.6rem 0;
+  color: var(--ink-soft);
+  font-size: 0.71rem;
+}
+
+.site-footer {
   display: flex;
-  flex-wrap: wrap;
-  gap: 8px 15px;
-  font-size: 0.8rem;
-  color: #7f8c8d;
+  justify-content: space-between;
+  gap: 2rem;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 1.7rem 2rem 2.5rem;
+  border-top: 1px solid rgb(23 36 31 / 12%);
+  color: var(--ink-soft);
+  font-size: 0.72rem;
 }
 
-.legend-item {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-}
-
-.legend-color {
-  width: 12px;
-  height: 12px;
-  border-radius: 2px;
-}
-
-.legend-item.current {
-  font-weight: 600;
-  color: #2c3e50;
-}
-
-.sensitivity {
-  background: #fafbfc;
-}
-
-.sensitivity-grid {
+.site-footer div {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 15px;
+  gap: 0.15rem;
 }
 
-@media (max-width: 500px) {
-  .sensitivity-grid {
-    grid-template-columns: 1fr;
-  }
+.site-footer strong {
+  color: var(--ink);
 }
 
-.sensitivity-item {
-  background: white;
-  padding: 15px;
-  border-radius: 8px;
-  text-align: center;
-  border: 1px solid #ecf0f1;
-}
-
-.sens-label {
-  display: block;
-  font-size: 0.8rem;
-  color: #7f8c8d;
-  margin-bottom: 8px;
-}
-
-.sens-value {
-  display: block;
-  font-size: 1.2rem;
-  font-weight: 600;
-  color: #e74c3c;
-}
-
-.sens-rate {
-  display: block;
-  font-size: 0.85rem;
-  color: #7f8c8d;
-  margin-top: 4px;
-}
-
-.solver .description {
-  font-size: 0.85rem;
-  color: #7f8c8d;
-  margin-bottom: 15px;
-}
-
-button {
-  width: 100%;
-  padding: 12px;
-  background: #3498db;
-  color: white;
-  border: none;
-  border-radius: 8px;
-  font-size: 1rem;
-  font-weight: 500;
-  cursor: pointer;
-  margin-top: 15px;
-  transition: background 0.2s;
-}
-
-button:hover {
-  background: #2980b9;
-}
-
-button:active {
-  transform: scale(0.98);
-}
-
-button:disabled {
-  background: #bdc3c7;
-  cursor: not-allowed;
-}
-
-.solver .result-row {
-  margin-top: 15px;
-  padding: 15px;
-  background: #e8f4fd;
-  border-radius: 8px;
-}
-
-.solver .label {
-  color: #2c3e50;
-}
-
-.solver .value {
-  color: #2980b9;
-  font-size: 1.3rem;
-  font-weight: 600;
-}
-
-.solver-animation {
-  margin-top: 15px;
-  padding: 15px;
-  background: #fafbfc;
-  border-radius: 8px;
-  border: 1px solid #ecf0f1;
-}
-
-#solver-chart {
-  width: 100%;
-  height: 150px;
-}
-
-.solver-stats {
-  display: flex;
-  justify-content: space-around;
-  margin-top: 10px;
-  font-size: 0.9rem;
-  color: #7f8c8d;
-}
-
-.solver-stats strong {
-  color: #2c3e50;
-}
-
-.iteration-points circle {
-  fill: rgba(52, 152, 219, 0.3);
-  stroke: #3498db;
-  stroke-width: 1;
-}
-
-footer {
-  text-align: center;
-  padding: 20px;
-  color: #95a5a6;
-  font-size: 0.85rem;
+.site-footer p {
+  max-width: 30rem;
+  margin: 0;
+  text-align: right;
 }
 
 .loading {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(255, 255, 255, 0.95);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
+  z-index: 50;
+  inset: 0;
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  gap: 1rem;
+  background: var(--paper);
+  transition:
+    opacity 180ms ease,
+    visibility 180ms ease;
 }
 
-.spinner {
-  width: 40px;
-  height: 40px;
-  border: 3px solid #ecf0f1;
-  border-top-color: #3498db;
+.loading.is-hidden {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.loading-mark {
+  display: grid;
+  width: 4rem;
+  height: 4rem;
+  place-items: center;
   border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-  margin-bottom: 15px;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
+  background: var(--green);
+  color: white;
+  font-size: 0.85rem;
+  font-weight: 850;
+  animation: breathe 1s infinite alternate ease-in-out;
 }
 
 .loading p {
-  color: #7f8c8d;
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.8rem;
 }
 
-code {
-  background: #f5f7fa;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-family: "SF Mono", Monaco, "Courier New", monospace;
+.toast {
+  position: fixed;
+  z-index: 60;
+  right: 1.2rem;
+  bottom: 1.2rem;
+  padding: 0.8rem 1rem;
+  transform: translateY(1rem);
+  background: var(--ink);
+  color: white;
+  font-size: 0.76rem;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 150ms ease,
+    transform 150ms ease;
 }
 
-@media (max-width: 400px) {
-  .container {
-    padding: 10px;
+.toast.visible {
+  transform: none;
+  opacity: 1;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes breathe {
+  to {
+    transform: scale(1.06);
+  }
+}
+
+@keyframes pulse {
+  to {
+    opacity: 0.35;
+  }
+}
+
+@media (max-width: 980px) {
+  .intro {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
   }
 
-  .card {
-    padding: 15px;
+  .scenario-bar {
+    grid-template-columns: 1fr;
   }
 
-  .rate-display {
-    gap: 15px;
+  .calculator-grid {
+    grid-template-columns: 1fr;
   }
 
-  .rate-value {
-    font-size: 1.2rem;
+  .results-column {
+    position: static;
+    grid-column: 1;
+    grid-row: auto;
+  }
+}
+
+@media (max-width: 680px) {
+  .site-header {
+    padding: 1rem;
+  }
+
+  .privacy-note {
+    display: none;
+  }
+
+  .header-actions {
+    gap: 0.7rem;
+  }
+
+  main {
+    padding: 3rem 1rem 4rem;
+  }
+
+  .intro {
+    margin-bottom: 2.4rem;
+  }
+
+  .intro h1 {
+    font-size: clamp(3rem, 15vw, 4.5rem);
+  }
+
+  .scenario-bar,
+  .input-card,
+  .results-hero,
+  .result-details {
+    padding: 1.25rem;
+  }
+
+  .scenario-controls,
+  .field-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .calculator-grid > :first-child {
+    order: 1;
+  }
+
+  .results-column {
+    order: 2;
+  }
+
+  .calculator-grid > .input-card:not(:first-child) {
+    order: 3;
+  }
+
+  .input-field.full-width {
+    grid-column: auto;
+  }
+
+  .details-fields {
+    margin: 0 1.25rem;
+    padding-bottom: 1.25rem;
+  }
+
+  .expandable-card summary {
+    padding: 1.15rem 1.25rem;
+  }
+
+  .field-description {
+    min-height: 0;
+  }
+
+  .effective-rate-row {
+    grid-template-columns: 1.35fr 1fr 1fr;
+  }
+
+  .result-details-heading {
+    display: block;
+  }
+
+  .calculation-status {
+    margin-top: 0.6rem;
+  }
+
+  .site-footer {
+    display: grid;
+    padding: 1.4rem 1rem 2rem;
+  }
+
+  .site-footer p {
+    text-align: left;
+  }
+}
+
+@media (max-width: 390px) {
+  .hero-breakdown,
+  .effective-rate-row {
+    grid-template-columns: 1fr;
+  }
+
+  .effective-rate-row div {
+    grid-template-columns: auto 1fr;
+    align-items: baseline;
+    gap: 0.5rem;
+  }
+
+  .result-actions {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
 }

--- a/docs/browser-calculator-contract.md
+++ b/docs/browser-calculator-contract.md
@@ -77,5 +77,8 @@ uv run pytest tests/browser_contract_test.py
 node scripts/smoke_wasm_demo.mjs target/pages
 ```
 
-The current demo UI does not consume the contract yet. Rebinding the calculator
-and adding a browser-level integration test are the scope of `tenforty-ox4.4.3`.
+The calculator renders its supported fields and dimensions from this contract.
+Its DOM layer passes a public scenario to the same calculation boundary exercised
+by the Pages smoke test; that test also round-trips every pinned scenario through
+the share-link encoding before comparing its WASM result with Python. Share links
+put scenario data after the URL fragment marker so it remains client-side.

--- a/scripts/smoke_wasm_demo.mjs
+++ b/scripts/smoke_wasm_demo.mjs
@@ -8,12 +8,32 @@ const siteDirectory = path.resolve(process.argv[2] ?? "target/pages");
 const modulePath = path.join(siteDirectory, "pkg", "graphlib.js");
 const wasmPath = path.join(siteDirectory, "pkg", "graphlib_bg.wasm");
 const contractModulePath = path.join(siteDirectory, "browser_contract.js");
+const calculatorModulePath = path.join(siteDirectory, "calculator.js");
 const contractPath = path.join(siteDirectory, "browser_contract.json");
 const graphlib = await import(pathToFileURL(modulePath));
-const { BrowserContractError, BrowserTaxRuntime, validateBrowserContract } =
+const { BrowserContractError, validateBrowserContract } =
   await import(pathToFileURL(contractModulePath));
+const {
+  INPUT_GROUPS,
+  calculateScenario,
+  parseScenario,
+  scenarioFromParityCase,
+  serializeScenario,
+} = await import(pathToFileURL(calculatorModulePath));
 await graphlib.default({ module_or_path: await readFile(wasmPath) });
 const contract = JSON.parse(await readFile(contractPath, "utf8"));
+const visibleInputs = Object.values(INPUT_GROUPS).flat();
+
+assert.deepEqual(
+  new Set(visibleInputs),
+  new Set(Object.keys(contract.inputs)),
+  "calculator must expose every contracted browser input",
+);
+assert.equal(
+  visibleInputs.length,
+  new Set(visibleInputs).size,
+  "calculator must expose each browser input exactly once",
+);
 
 const graphs = new Map();
 
@@ -32,18 +52,22 @@ for (const year of contract.supported_years) {
 }
 
 for (const testCase of contract.parity_cases) {
-  const calculator = new BrowserTaxRuntime(
+  const scenario = scenarioFromParityCase(contract, testCase);
+  const sharedScenario = parseScenario(
+    contract,
+    `#${serializeScenario(contract, scenario)}`,
+  );
+  assert.deepEqual(
+    sharedScenario,
+    scenario,
+    `${testCase.id}: share URL changed the scenario`,
+  );
+  const actual = calculateScenario(
     graphlib,
     graphs.get(testCase.year),
     contract,
-    {
-      year: testCase.year,
-      jurisdiction: testCase.jurisdiction,
-      filingStatus: testCase.filing_status,
-    },
+    sharedScenario,
   );
-  calculator.setInputs(testCase.inputs);
-  const actual = calculator.evaluate();
 
   for (const [name, expected] of Object.entries(testCase.expected)) {
     assert.ok(

--- a/tests/browser_contract_test.py
+++ b/tests/browser_contract_test.py
@@ -15,6 +15,8 @@ from tenforty.models import OTSFilingStatus, OTSState, TaxReturnInput
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACT_PATH = ROOT / "crates/tenforty-graph/demo/browser_contract.json"
 CONTRACT = json.loads(CONTRACT_PATH.read_text())
+APP_PATH = ROOT / "crates/tenforty-graph/demo/app.js"
+CALCULATOR_PATH = ROOT / "crates/tenforty-graph/demo/calculator.js"
 
 FILING_STATUSES = {
     "single": OTSFilingStatus.SINGLE,
@@ -61,6 +63,18 @@ def test_browser_contract_exposes_known_limitations():
     assert CONTRACT["jurisdictions"]["LA"]["unsupported_inputs"]["2024"] == [
         "itemized_deductions"
     ]
+
+
+def test_browser_ui_uses_the_public_calculation_boundary():
+    """The DOM layer must not regress to form-node bindings or silent zeros."""
+    app_source = APP_PATH.read_text()
+    calculator_source = CALCULATOR_PATH.read_text()
+
+    assert not re.search(r"\bus_[a-z0-9_]+", app_source)
+    assert not re.search(r"\bus_[a-z0-9_]+", calculator_source)
+    assert "BrowserTaxRuntime" in calculator_source
+    assert "safeEval" not in app_source
+    assert "safeGradient" not in app_source
 
 
 @pytest.mark.parametrize("case", CONTRACT["parity_cases"], ids=lambda case: case["id"])


### PR DESCRIPTION
## Summary

- replace the obsolete graph-node demo with a responsive, contract-driven calculator
- expose both supported tax years, federal-only plus all 50 states and DC, every contracted public input, and live federal/state/total results
- show AGI, taxable income, QBI, income tax, self-employment tax, NIIT, Additional Medicare Tax, AMT, and effective-rate detail without silently substituting missing values
- serialize reproducible scenarios in URL fragments so financial inputs remain client-side
- exercise the exact browser calculation and share-link boundary against the pinned Python parity corpus in the Pages smoke test

The calculator intentionally leaves gradients, scenario charts, and the inverse solver to the follow-up autodiff and sweep beads (`tenforty-ox4.4.4` and `tenforty-ox4.4.5`).

## Validation

- `uv run pytest tests/ -q --tb=line` — 1133 passed, 13 skipped, 26 xfailed
- release `make wasm` build
- staged browser smoke — 7 URL-round-tripped parity cases across 2 years and 52 jurisdictions
- repository hooks on every changed file
- manual Chromium inspection at 1440px and 390px widths
- manual Louisiana 2024 unsupported-itemized-input failure check

Tracks `tenforty-ox4.4.3`.