### PR TITLE
feat(wasm): make autodiff the calculator centerpiece

### DIFF
--- a/crates/tenforty-graph/demo/README.md
+++ b/crates/tenforty-graph/demo/README.md
@@ -11,6 +11,12 @@ concepts from that contract rather than graph-node names. Share links serialize
 the same public scenario passed to the calculator boundary in the URL fragment,
 which browsers do not send to the hosting server.
 
+The primary view is analytical rather than a filing interview: it places the
+current return on a live federal/state/combined tax curve, draws the exact local
+tangent, and decomposes selected next-dollar sensitivities from a grouped
+autodiff vector. Effective rates remain separate from these local effects, and
+qualified-dividend sensitivity is labeled as a reclassification.
+
 Build and serve it locally with:
 
 ```console

--- a/crates/tenforty-graph/demo/app.js
+++ b/crates/tenforty-graph/demo/app.js
@@ -4,11 +4,14 @@ import {
   loadBrowserContract,
 } from "./browser_contract.js";
 import {
+  CURVE_INPUTS,
   INPUT_GROUPS,
-  calculateScenario,
+  SENSITIVITY_INPUTS,
+  analyzeScenario,
   createDefaultScenario,
   parseScenario,
   serializeScenario,
+  sweepScenario,
 } from "./calculator.js";
 
 const CURRENCY_FORMATTER = new Intl.NumberFormat("en-US", {
@@ -21,6 +24,7 @@ let contract;
 let scenario;
 let calculationSequence = 0;
 let toastTimer;
+let selectedCurveInput = "w2_income";
 const graphCache = new Map();
 
 function byId(id) {
@@ -33,6 +37,20 @@ function formatCurrency(value) {
 
 function formatPercent(value) {
   return `${value.toFixed(1)}%`;
+}
+
+function formatCents(value) {
+  const cents = value * 100;
+  const sign = cents < -0.0005 ? "−" : "";
+  return `${sign}${Math.abs(cents).toFixed(1)}¢`;
+}
+
+function formatAxisCurrency(value) {
+  if (Math.abs(value) >= 1000) {
+    const thousands = value / 1000;
+    return `$${thousands >= 100 ? thousands.toFixed(0) : thousands.toFixed(1)}k`;
+  }
+  return `$${Math.round(value)}`;
 }
 
 function createTextElement(tagName, className, text) {
@@ -195,10 +213,228 @@ function populateInterface() {
       container.appendChild(createInputField(name));
   }
 
+  const curveInput = byId("curve-input");
+  for (const name of CURVE_INPUTS) {
+    const option = document.createElement("option");
+    option.value = name;
+    option.textContent = SENSITIVITY_INPUTS[name].shortLabel;
+    curveInput.appendChild(option);
+  }
+  curveInput.value = selectedCurveInput;
+
   const limitations = byId("limitations-list");
   for (const limitation of contract.limitations) {
     limitations.appendChild(createTextElement("p", "", limitation.summary));
   }
+}
+
+function svgElement(name, attributes = {}) {
+  const element = document.createElementNS("http://www.w3.org/2000/svg", name);
+  for (const [attribute, value] of Object.entries(attributes)) {
+    element.setAttribute(attribute, String(value));
+  }
+  return element;
+}
+
+function curvePath(points, valueName, xScale, yScale) {
+  return points
+    .map(
+      (point, index) =>
+        `${index === 0 ? "M" : "L"}${xScale(point.input).toFixed(2)},${yScale(point[valueName]).toFixed(2)}`,
+    )
+    .join(" ");
+}
+
+function renderCurve(points, results, gradient, inputName) {
+  const width = 680;
+  const height = 320;
+  const margin = { top: 22, right: 18, bottom: 40, left: 58 };
+  const innerWidth = width - margin.left - margin.right;
+  const innerHeight = height - margin.top - margin.bottom;
+  const minimumInput = points[0].input;
+  const maximumInput = points.at(-1).input;
+  const maximumTax = Math.max(
+    1,
+    ...points.flatMap((point) => [point.total, point.federal, point.state]),
+  );
+  const paddedMaximumTax = maximumTax * 1.08;
+  const xScale = (value) =>
+    margin.left +
+    ((value - minimumInput) / (maximumInput - minimumInput)) * innerWidth;
+  const yScale = (value) =>
+    margin.top + innerHeight - (value / paddedMaximumTax) * innerHeight;
+
+  byId("curve-total").setAttribute(
+    "d",
+    curvePath(points, "total", xScale, yScale),
+  );
+  byId("curve-federal").setAttribute(
+    "d",
+    curvePath(points, "federal", xScale, yScale),
+  );
+  byId("curve-state").setAttribute(
+    "d",
+    curvePath(points, "state", xScale, yScale),
+  );
+
+  const grid = byId("curve-grid");
+  const labels = byId("curve-labels");
+  grid.replaceChildren();
+  labels.replaceChildren();
+  for (let index = 0; index <= 4; index += 1) {
+    const taxValue = (paddedMaximumTax * index) / 4;
+    const y = yScale(taxValue);
+    grid.appendChild(
+      svgElement("line", {
+        x1: margin.left,
+        x2: width - margin.right,
+        y1: y,
+        y2: y,
+      }),
+    );
+    const label = svgElement("text", {
+      x: margin.left - 9,
+      y: y + 4,
+      "text-anchor": "end",
+    });
+    label.textContent = formatAxisCurrency(taxValue);
+    labels.appendChild(label);
+  }
+  for (let index = 0; index <= 4; index += 1) {
+    const inputValue =
+      minimumInput + ((maximumInput - minimumInput) * index) / 4;
+    const label = svgElement("text", {
+      x: xScale(inputValue),
+      y: height - 12,
+      "text-anchor": index === 0 ? "start" : index === 4 ? "end" : "middle",
+    });
+    label.textContent = formatAxisCurrency(inputValue);
+    labels.appendChild(label);
+  }
+
+  const currentInput = scenario.inputs[inputName];
+  const currentTax = results.total_tax;
+  const currentX = xScale(currentInput);
+  const currentY = yScale(currentTax);
+  const currentPoint = byId("curve-current");
+  currentPoint.setAttribute("cx", currentX);
+  currentPoint.setAttribute("cy", currentY);
+  const guide = byId("curve-guide");
+  guide.setAttribute("x1", currentX);
+  guide.setAttribute("x2", currentX);
+  guide.setAttribute("y1", currentY);
+  guide.setAttribute("y2", margin.top + innerHeight);
+
+  const tangentRadius = (maximumInput - minimumInput) * 0.075;
+  const tangentStart = Math.max(minimumInput, currentInput - tangentRadius);
+  const tangentEnd = Math.min(maximumInput, currentInput + tangentRadius);
+  const tangent = byId("curve-tangent");
+  tangent.setAttribute("x1", xScale(tangentStart));
+  tangent.setAttribute("x2", xScale(tangentEnd));
+  tangent.setAttribute(
+    "y1",
+    yScale(currentTax + gradient.total * (tangentStart - currentInput)),
+  );
+  tangent.setAttribute(
+    "y2",
+    yScale(currentTax + gradient.total * (tangentEnd - currentInput)),
+  );
+
+  const shortLabel = SENSITIVITY_INPUTS[inputName].shortLabel.toLowerCase();
+  setText("curve-title", `as ${shortLabel} changes`);
+  setText(
+    "curve-summary",
+    `Modeled total tax as ${shortLabel} ranges from ${formatCurrency(minimumInput)} to ${formatCurrency(maximumInput)}. This return is at ${formatCurrency(currentInput)} with ${formatCurrency(currentTax)} of modeled total tax and a local slope of ${formatCents(gradient.total)} per dollar.`,
+  );
+}
+
+function sensitivityNames(gradients) {
+  const unsupported = new Set(
+    selectedJurisdiction().unsupported_inputs[String(scenario.year)],
+  );
+  const active = Object.keys(gradients).filter(
+    (name) =>
+      SENSITIVITY_INPUTS[name] &&
+      !unsupported.has(name) &&
+      Math.abs(scenario.inputs[name]) >= 0.005,
+  );
+  const staples = [
+    "w2_income",
+    "taxable_interest",
+    "long_term_capital_gains",
+    "qualified_dividends",
+    "ordinary_dividends",
+    "itemized_deductions",
+    "incentive_stock_option_gains",
+  ];
+  return [...new Set([...active, ...staples])]
+    .filter(
+      (name) =>
+        gradients[name] &&
+        !unsupported.has(name) &&
+        (name !== "qualified_dividends" ||
+          scenario.inputs.ordinary_dividends >
+            scenario.inputs.qualified_dividends),
+    )
+    .slice(0, 6);
+}
+
+function renderSensitivities(gradients) {
+  const list = byId("sensitivity-list");
+  list.replaceChildren();
+  for (const name of sensitivityNames(gradients)) {
+    const metadata = SENSITIVITY_INPUTS[name];
+    const element = document.createElement(
+      metadata.curveMaximum ? "button" : "div",
+    );
+    element.className = "sensitivity-item";
+    if (metadata.curveMaximum) {
+      element.type = "button";
+      element.dataset.curveInput = name;
+      element.setAttribute(
+        "aria-label",
+        `Plot ${metadata.shortLabel}: ${formatCents(gradients[name].total)} of tax per dollar`,
+      );
+    }
+    element.append(
+      createTextElement("span", "sensitivity-action", metadata.action),
+      createTextElement(
+        "strong",
+        gradients[name].total < 0 ? "negative" : "",
+        formatCents(gradients[name].total),
+      ),
+      createTextElement(
+        "small",
+        "",
+        `${formatCents(gradients[name].federal)} federal · ${formatCents(gradients[name].state)} state`,
+      ),
+    );
+    list.appendChild(element);
+  }
+}
+
+function renderAnalysis(analysis, curvePoints, inputName) {
+  const metadata = SENSITIVITY_INPUTS[inputName];
+  const gradient = analysis.gradients[inputName];
+  const jurisdiction = selectedJurisdiction();
+  setText("analysis-action", metadata.action);
+  setText("next-dollar-cents", (gradient.total * 100).toFixed(1));
+  setText("next-dollar-federal", formatCents(gradient.federal));
+  setText(
+    "next-dollar-state-label",
+    scenario.jurisdiction === "US" ? "No state selected" : jurisdiction.name,
+  );
+  setText("next-dollar-state", formatCents(gradient.state));
+  setText("next-dollar-total", formatPercent(gradient.total * 100));
+  setText(
+    "derivative-interpretation",
+    metadata.reclassification
+      ? "This reclassifies an existing ordinary-dividend dollar; it is not the cost of earning another dollar."
+      : "This is the composed right-hand effect at the current return—not your effective rate.",
+  );
+  renderCurve(curvePoints, analysis.results, gradient, inputName);
+  renderSensitivities(analysis.gradients);
+  byId("analysis-lab").setAttribute("aria-busy", "false");
 }
 
 function renderScenario(nextScenario) {
@@ -405,6 +641,11 @@ function clearResults() {
   const hero = byId("results-heading").closest(".results-hero");
   hero.classList.add("is-stale");
   hero.setAttribute("aria-busy", "false");
+  byId("analysis-lab").setAttribute("aria-busy", "false");
+  setText("next-dollar-cents", "—");
+  setText("next-dollar-federal", "—");
+  setText("next-dollar-state", "—");
+  setText("next-dollar-total", "—");
 }
 
 function showError(error) {
@@ -434,13 +675,22 @@ async function calculate() {
   byId("results-heading")
     .closest(".results-hero")
     .setAttribute("aria-busy", "true");
+  byId("analysis-lab").setAttribute("aria-busy", "true");
 
   try {
     const graph = await loadGraph(scenario.year);
     const startedAt = performance.now();
-    const results = calculateScenario(graphlib, graph, contract, scenario);
+    const analysis = analyzeScenario(graphlib, graph, contract, scenario);
+    const curvePoints = sweepScenario(
+      graphlib,
+      graph,
+      contract,
+      scenario,
+      selectedCurveInput,
+    );
     if (sequence !== calculationSequence) return;
-    renderResults(results, performance.now() - startedAt);
+    renderResults(analysis.results, performance.now() - startedAt);
+    renderAnalysis(analysis, curvePoints, selectedCurveInput);
     updateAddressBar();
   } catch (error) {
     if (sequence !== calculationSequence) return;
@@ -490,6 +740,18 @@ function bindEvents() {
   for (const id of ["tax-year", "filing-status", "jurisdiction"]) {
     byId(id).addEventListener("change", scheduleCalculation);
   }
+
+  byId("curve-input").addEventListener("change", (event) => {
+    selectedCurveInput = event.target.value;
+    scheduleCalculation();
+  });
+  byId("sensitivity-list").addEventListener("click", (event) => {
+    const button = event.target.closest("[data-curve-input]");
+    if (!button) return;
+    selectedCurveInput = button.dataset.curveInput;
+    byId("curve-input").value = selectedCurveInput;
+    scheduleCalculation();
+  });
 
   byId("share-scenario").addEventListener("click", copyShareLink);
   byId("reset-scenario").addEventListener("click", () => {

--- a/crates/tenforty-graph/demo/app.js
+++ b/crates/tenforty-graph/demo/app.js
@@ -176,6 +176,12 @@ function createInputField(name) {
 }
 
 function populateInterface() {
+  const calculatorForm = byId("calculator-form");
+  calculatorForm.insertBefore(
+    byId("analysis-lab"),
+    calculatorForm.querySelector(".results-column"),
+  );
+
   const yearSelect = byId("tax-year");
   for (const year of [...contract.supported_years].reverse()) {
     const option = document.createElement("option");
@@ -742,6 +748,7 @@ function bindEvents() {
   }
 
   byId("curve-input").addEventListener("change", (event) => {
+    event.stopPropagation();
     selectedCurveInput = event.target.value;
     scheduleCalculation();
   });

--- a/crates/tenforty-graph/demo/browser_contract.js
+++ b/crates/tenforty-graph/demo/browser_contract.js
@@ -98,6 +98,30 @@ function evaluateNode(runtime, node, context) {
   return value;
 }
 
+function evaluateGradientVector(runtime, outputs, inputGroups, context) {
+  const inputNodes = inputGroups.flat();
+  const groupLengths = inputGroups.map((nodes) => nodes.length);
+  let values;
+  try {
+    values = Array.from(
+      runtime.gradientVector(outputs, inputNodes, groupLengths),
+    );
+  } catch (error) {
+    throw new BrowserContractError(
+      `Browser contract gradient failed (${context}): ${error}`,
+    );
+  }
+  if (
+    values.length !== inputGroups.length ||
+    values.some((value) => !Number.isFinite(value))
+  ) {
+    throw new BrowserContractError(
+      `Browser contract gradient is invalid (${context})`,
+    );
+  }
+  return values;
+}
+
 function calculateDerivedOutput(specification, values) {
   if (specification.formula === "subtract") {
     return specification.values.reduce(
@@ -214,6 +238,7 @@ export class BrowserTaxRuntime {
 
   setInputs(suppliedInputs) {
     const values = normalizeInputs(this.contract, suppliedInputs);
+    this.values = values;
     const unsupported = this.jurisdictionSpec.unsupported_inputs[this.yearKey];
     for (const name of unsupported) {
       if (values[name] !== 0 && values[name] !== false) {
@@ -261,6 +286,56 @@ export class BrowserTaxRuntime {
         setNode(this.runtime, node, value, `derived ${name}`);
       }
     }
+  }
+
+  gradientVectors() {
+    if (!this.values) {
+      throw new BrowserContractError(
+        "Set browser inputs before requesting gradients",
+      );
+    }
+    const inputNames = Object.entries(this.contract.inputs)
+      .filter(([, specification]) => specification.type === "money")
+      .map(([name]) => name);
+    const stateInputNodes = this.jurisdictionSpec.input_nodes[this.yearKey];
+    const derivedWageNodes =
+      this.values.self_employment_income !== 0 &&
+      this.filingStatus !== "married_joint"
+        ? this.contract.derived_inputs.schedule_se_ss_wages.federal_nodes
+        : [];
+    const inputGroups = inputNames.map((name) => [
+      ...this.contract.inputs[name].federal_nodes,
+      ...(stateInputNodes[name] ?? []),
+      ...(name === "w2_income" ? derivedWageNodes : []),
+    ]);
+    const federalOutput = this.contract.outputs.federal_total_tax.node;
+    const stateOutput =
+      this.jurisdictionSpec.output_nodes[this.yearKey].state_total_tax;
+    const federalValues = evaluateGradientVector(
+      this.runtime,
+      [federalOutput],
+      inputGroups,
+      "federal total tax",
+    );
+    const stateValues = stateOutput
+      ? evaluateGradientVector(
+          this.runtime,
+          [stateOutput],
+          inputGroups,
+          `${this.jurisdiction} total tax`,
+        )
+      : federalValues.map(() => 0);
+
+    return Object.fromEntries(
+      inputNames.map((name, index) => [
+        name,
+        {
+          federal: federalValues[index],
+          state: stateValues[index],
+          total: federalValues[index] + stateValues[index],
+        },
+      ]),
+    );
   }
 
   evaluate() {

--- a/crates/tenforty-graph/demo/browser_contract.json
+++ b/crates/tenforty-graph/demo/browser_contract.json
@@ -1744,5 +1744,106 @@
         "total_tax": 16094
       }
     }
+  ],
+  "gradient_cases": [
+    {
+      "id": "ordinary-bracket",
+      "year": 2024,
+      "jurisdiction": "US",
+      "filing_status": "single",
+      "inputs": {
+        "w2_income": 100000
+      },
+      "expected": {
+        "w2_income": {
+          "federal": 0.22,
+          "state": 0.0,
+          "total": 0.22
+        }
+      }
+    },
+    {
+      "id": "capital-gain-stacking",
+      "year": 2024,
+      "jurisdiction": "US",
+      "filing_status": "single",
+      "inputs": {
+        "w2_income": 30000,
+        "long_term_capital_gains": 50000
+      },
+      "expected": {
+        "w2_income": {
+          "federal": 0.27,
+          "state": 0.0,
+          "total": 0.27
+        },
+        "long_term_capital_gains": {
+          "federal": 0.15,
+          "state": 0.0,
+          "total": 0.15
+        }
+      }
+    },
+    {
+      "id": "alternative-minimum-tax",
+      "year": 2025,
+      "jurisdiction": "US",
+      "filing_status": "single",
+      "inputs": {
+        "w2_income": 200000,
+        "incentive_stock_option_gains": 300000
+      },
+      "expected": {
+        "w2_income": {
+          "federal": 0.289,
+          "state": 0.0,
+          "total": 0.289
+        },
+        "incentive_stock_option_gains": {
+          "federal": 0.28,
+          "state": 0.0,
+          "total": 0.28
+        }
+      }
+    },
+    {
+      "id": "medicare-and-niit",
+      "year": 2024,
+      "jurisdiction": "US",
+      "filing_status": "single",
+      "inputs": {
+        "w2_income": 250000,
+        "taxable_interest": 50000
+      },
+      "expected": {
+        "w2_income": {
+          "federal": 0.359,
+          "state": 0.0,
+          "total": 0.359
+        },
+        "taxable_interest": {
+          "federal": 0.388,
+          "state": 0.0,
+          "total": 0.388
+        }
+      }
+    },
+    {
+      "id": "new-hampshire-interest",
+      "year": 2024,
+      "jurisdiction": "NH",
+      "filing_status": "single",
+      "inputs": {
+        "w2_income": 150000,
+        "taxable_interest": 50000
+      },
+      "expected": {
+        "taxable_interest": {
+          "federal": 0.278,
+          "state": 0.03,
+          "total": 0.308
+        }
+      }
+    }
   ]
 }

--- a/crates/tenforty-graph/demo/calculator.js
+++ b/crates/tenforty-graph/demo/calculator.js
@@ -23,6 +23,74 @@ export const INPUT_GROUPS = {
   ],
 };
 
+export const SENSITIVITY_INPUTS = {
+  w2_income: {
+    action: "Earn $1 more in wages",
+    shortLabel: "Wages",
+    curveMaximum: 200000,
+  },
+  taxable_interest: {
+    action: "Earn $1 more of taxable interest",
+    shortLabel: "Interest",
+    curveMaximum: 100000,
+  },
+  ordinary_dividends: {
+    action: "Receive $1 more of ordinary dividends",
+    shortLabel: "Ordinary dividends",
+  },
+  qualified_dividends: {
+    action: "Reclassify $1 of ordinary dividends as qualified",
+    shortLabel: "Qualified share",
+    reclassification: true,
+  },
+  short_term_capital_gains: {
+    action: "Realize $1 more of short-term gain",
+    shortLabel: "Short-term gain",
+  },
+  long_term_capital_gains: {
+    action: "Realize $1 more of long-term gain",
+    shortLabel: "Long-term gain",
+    curveMaximum: 150000,
+  },
+  self_employment_income: {
+    action: "Earn $1 more from self-employment",
+    shortLabel: "Self-employment",
+    curveMaximum: 200000,
+  },
+  rental_income: {
+    action: "Earn $1 more of rental income",
+    shortLabel: "Rental income",
+  },
+  schedule_1_income: {
+    action: "Earn $1 more of other income",
+    shortLabel: "Other income",
+  },
+  itemized_deductions: {
+    action: "Claim $1 more of itemized deductions",
+    shortLabel: "Itemized deductions",
+  },
+  incentive_stock_option_gains: {
+    action: "Exercise $1 more of ISO spread",
+    shortLabel: "ISO spread",
+    curveMaximum: 200000,
+  },
+  qbi_w2_wages: {
+    action: "Add $1 of qualified-business W-2 wages",
+    shortLabel: "QBI wages",
+  },
+  qbi_ubia: {
+    action: "Add $1 of qualified-property UBIA",
+    shortLabel: "QBI property",
+  },
+};
+
+export const CURVE_INPUTS = [
+  "w2_income",
+  "long_term_capital_gains",
+  "self_employment_income",
+  "incentive_stock_option_gains",
+];
+
 function defaultInputs(contract) {
   return Object.fromEntries(
     Object.entries(contract.inputs).map(([name, specification]) => [
@@ -136,4 +204,53 @@ export function calculateScenario(graphlib, graph, contract, scenario) {
   });
   calculator.setInputs(scenario.inputs);
   return calculator.evaluate();
+}
+
+export function analyzeScenario(graphlib, graph, contract, scenario) {
+  const calculator = new BrowserTaxRuntime(graphlib, graph, contract, {
+    year: scenario.year,
+    jurisdiction: scenario.jurisdiction,
+    filingStatus: scenario.filingStatus,
+  });
+  calculator.setInputs(scenario.inputs);
+  return {
+    results: calculator.evaluate(),
+    gradients: calculator.gradientVectors(),
+  };
+}
+
+export function sweepScenario(
+  graphlib,
+  graph,
+  contract,
+  scenario,
+  inputName,
+  pointCount = 57,
+) {
+  const metadata = SENSITIVITY_INPUTS[inputName];
+  if (!metadata?.curveMaximum) {
+    throw new BrowserContractError(
+      `${inputName} is not available as a browser tax-curve axis`,
+    );
+  }
+  const current = scenario.inputs[inputName];
+  const minimum = Math.min(0, current * 1.35);
+  const maximum = Math.max(metadata.curveMaximum, current * 1.35);
+  const calculator = new BrowserTaxRuntime(graphlib, graph, contract, {
+    year: scenario.year,
+    jurisdiction: scenario.jurisdiction,
+    filingStatus: scenario.filingStatus,
+  });
+
+  return Array.from({ length: pointCount }, (_, index) => {
+    const value = minimum + ((maximum - minimum) * index) / (pointCount - 1);
+    calculator.setInputs({ ...scenario.inputs, [inputName]: value });
+    const results = calculator.evaluate();
+    return {
+      input: value,
+      federal: results.federal_total_tax,
+      state: results.state_total_tax,
+      total: results.total_tax,
+    };
+  });
 }

--- a/crates/tenforty-graph/demo/index.html
+++ b/crates/tenforty-graph/demo/index.html
@@ -31,12 +31,14 @@
 
     <main id="calculator">
       <section class="intro" aria-labelledby="page-title">
-        <p class="eyebrow">Federal + all 50 states + DC</p>
-        <h1 id="page-title">See the tax picture,<br />as you change it.</h1>
+        <p class="eyebrow">
+          Federal + all 50 states + DC · exact local effects
+        </p>
+        <h1 id="page-title">See what the<br />next dollar does.</h1>
         <p class="intro-copy">
-          A fast, open-source estimate of modeled personal income taxes. Change
-          any number and the graph recalculates instantly—without sending your
-          financial information anywhere.
+          Most calculators give you one total. tenforty also shows the local
+          shape of the tax system: where your return sits, how the curve
+          changes, and what one more dollar does next.
         </p>
       </section>
 
@@ -74,10 +76,109 @@
         </button>
       </div>
 
+      <section
+        id="analysis-lab"
+        class="analysis-lab"
+        aria-labelledby="analysis-heading"
+        aria-busy="true"
+      >
+        <div class="analysis-copy">
+          <p class="analysis-eyebrow">02 · Local tax geometry</p>
+          <div class="analysis-title-row">
+            <div>
+              <h2 id="analysis-heading">What the next dollar costs</h2>
+              <p id="analysis-action">Earn $1 more in wages</p>
+            </div>
+            <label class="curve-control" for="curve-input">
+              Change the question
+              <select id="curve-input"></select>
+            </label>
+          </div>
+
+          <div class="next-dollar-readout" aria-live="polite">
+            <div class="next-dollar-number">
+              <strong id="next-dollar-cents">—</strong><span>¢</span>
+            </div>
+            <p>of the next $1 goes to modeled income tax</p>
+          </div>
+          <div class="rate-parts">
+            <div>
+              <span>Federal effect</span>
+              <strong id="next-dollar-federal">—</strong>
+            </div>
+            <div>
+              <span id="next-dollar-state-label">State effect</span>
+              <strong id="next-dollar-state">—</strong>
+            </div>
+            <div>
+              <span>Combined local slope</span>
+              <strong id="next-dollar-total">—</strong>
+            </div>
+          </div>
+          <p id="derivative-interpretation" class="derivative-interpretation">
+            This is a local, right-hand derivative—not your effective rate.
+          </p>
+        </div>
+
+        <div class="curve-panel">
+          <div class="curve-heading">
+            <div>
+              <span>Modeled total tax</span>
+              <strong id="curve-title">as wages change</strong>
+            </div>
+            <div class="curve-legend" aria-hidden="true">
+              <span class="legend-total">Total</span>
+              <span class="legend-federal">Federal</span>
+              <span class="legend-state">State</span>
+            </div>
+          </div>
+          <svg
+            id="tax-curve"
+            class="tax-curve"
+            viewBox="0 0 680 320"
+            role="img"
+            aria-labelledby="curve-title curve-summary"
+          >
+            <g id="curve-grid"></g>
+            <path id="curve-state" class="curve-line state-line"></path>
+            <path id="curve-federal" class="curve-line federal-line"></path>
+            <path id="curve-total" class="curve-line total-line"></path>
+            <line id="curve-tangent" class="curve-tangent"></line>
+            <line id="curve-guide" class="curve-guide"></line>
+            <circle id="curve-current" class="curve-current" r="6"></circle>
+            <g id="curve-labels"></g>
+          </svg>
+          <p id="curve-summary" class="sr-only"></p>
+          <p class="curve-caption">
+            The dot is your return. The short gold line is the exact local
+            slope; the full curve comes from evaluating nearby scenarios.
+          </p>
+        </div>
+
+        <div class="sensitivity-panel">
+          <div>
+            <p class="analysis-eyebrow">Selected sensitivities</p>
+            <h3>Several questions, one gradient vector</h3>
+          </div>
+          <div id="sensitivity-list" class="sensitivity-list"></div>
+        </div>
+
+        <details class="derivative-note">
+          <summary>What “next dollar” means here</summary>
+          <p>
+            This is the composed effect of one public input across every federal
+            and state graph node it writes. At an exact threshold, tenforty
+            shows the effect immediately to the right. Qualified dividends are a
+            reclassification of ordinary dividends, so their sensitivity can be
+            negative without implying that earning income creates a subsidy.
+          </p>
+        </details>
+      </section>
+
       <form id="calculator-form" class="calculator-grid" novalidate>
         <section class="input-card" aria-labelledby="income-heading">
           <div class="card-heading">
-            <p class="section-number">02</p>
+            <p class="section-number">03</p>
             <div>
               <h2 id="income-heading">Income</h2>
               <p>Start with the amounts that make up most returns.</p>
@@ -158,7 +259,7 @@
           <section class="result-details" aria-labelledby="detail-heading">
             <div class="result-details-heading">
               <div>
-                <p class="section-number">03</p>
+                <p class="section-number">04</p>
                 <h2 id="detail-heading">How it adds up</h2>
               </div>
               <span id="calculation-status" class="calculation-status"

--- a/crates/tenforty-graph/demo/index.html
+++ b/crates/tenforty-graph/demo/index.html
@@ -83,7 +83,7 @@
         aria-busy="true"
       >
         <div class="analysis-copy">
-          <p class="analysis-eyebrow">02 · Local tax geometry</p>
+          <p class="analysis-eyebrow">03 · Local tax geometry</p>
           <div class="analysis-title-row">
             <div>
               <h2 id="analysis-heading">What the next dollar costs</h2>
@@ -176,9 +176,13 @@
       </section>
 
       <form id="calculator-form" class="calculator-grid" novalidate>
-        <section class="input-card" aria-labelledby="income-heading">
+        <section
+          id="income-card"
+          class="input-card"
+          aria-labelledby="income-heading"
+        >
           <div class="card-heading">
-            <p class="section-number">03</p>
+            <p class="section-number">02</p>
             <div>
               <h2 id="income-heading">Income</h2>
               <p>Start with the amounts that make up most returns.</p>
@@ -200,7 +204,11 @@
           <div id="other-income-fields" class="field-grid details-fields"></div>
         </details>
 
-        <section class="input-card" aria-labelledby="deductions-heading">
+        <section
+          id="deductions-card"
+          class="input-card"
+          aria-labelledby="deductions-heading"
+        >
           <div class="card-heading compact-heading">
             <div>
               <h2 id="deductions-heading">Deductions</h2>

--- a/crates/tenforty-graph/demo/style.css
+++ b/crates/tenforty-graph/demo/style.css
@@ -143,6 +143,9 @@ a {
 }
 
 main {
+  display: grid;
+  grid-template-columns: minmax(20rem, 0.62fr) minmax(0, 1.38fr);
+  gap: 1.3rem;
   max-width: 1280px;
   margin: 0 auto;
   padding: 4.5rem 2rem 6rem;
@@ -150,6 +153,8 @@ main {
 
 .intro {
   display: grid;
+  grid-column: 1 / -1;
+  grid-row: 1;
   grid-template-columns: minmax(0, 1.3fr) minmax(18rem, 0.7fr);
   grid-template-areas:
     "eyebrow copy"
@@ -194,6 +199,8 @@ main {
 
 .scenario-bar {
   display: grid;
+  grid-column: 1 / -1;
+  grid-row: 2;
   grid-template-columns: 0.72fr 1.28fr;
   gap: 2rem;
   align-items: end;
@@ -296,6 +303,12 @@ a:focus-visible {
   color: #702921;
 }
 
+main > .error-banner {
+  grid-column: 1 / -1;
+  grid-row: 3;
+  margin-top: 0;
+}
+
 .error-banner p {
   margin: 0.2rem 0 0;
   font-size: 0.86rem;
@@ -313,7 +326,12 @@ a:focus-visible {
   display: grid;
   grid-template-columns: minmax(18rem, 0.68fr) minmax(26rem, 1.32fr);
   gap: 0;
-  margin-top: 1.3rem;
+  position: sticky;
+  top: 1rem;
+  grid-column: 2;
+  grid-row: 4 / span 4;
+  align-self: start;
+  margin-top: 0;
   overflow: hidden;
   background: var(--analysis);
   color: white;
@@ -659,11 +677,7 @@ button.sensitivity-item:hover {
 }
 
 .calculator-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(22rem, 0.72fr);
-  gap: 1.3rem;
-  align-items: start;
-  margin-top: 1.3rem;
+  display: contents;
 }
 
 .input-card,
@@ -676,6 +690,22 @@ button.sensitivity-item:hover {
 .input-card {
   grid-column: 1;
   padding: 1.7rem;
+}
+
+#income-card {
+  grid-row: 4;
+}
+
+#other-income-card {
+  grid-row: 5;
+}
+
+#deductions-card {
+  grid-row: 6;
+}
+
+#advanced-card {
+  grid-row: 7;
 }
 
 .card-heading {
@@ -876,12 +906,16 @@ button.sensitivity-item:hover {
 }
 
 .results-column {
-  position: sticky;
-  top: 1rem;
+  position: static;
   display: grid;
-  grid-column: 2;
-  grid-row: 1 / span 4;
+  grid-column: 1 / -1;
+  grid-row: 8;
+  grid-template-columns: minmax(20rem, 0.62fr) minmax(0, 1.38fr);
   gap: 1rem;
+}
+
+.results-column .scope-note {
+  grid-column: 1 / -1;
 }
 
 .results-hero {
@@ -1249,6 +1283,10 @@ button.sensitivity-item:hover {
 }
 
 @media (max-width: 980px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+
   .intro {
     grid-template-columns: 1fr;
     grid-template-areas:
@@ -1263,6 +1301,9 @@ button.sensitivity-item:hover {
   }
 
   .analysis-lab {
+    position: static;
+    grid-column: 1;
+    grid-row: 8;
     grid-template-columns: 1fr;
   }
 
@@ -1271,14 +1312,11 @@ button.sensitivity-item:hover {
     border-bottom: 1px solid var(--analysis-line);
   }
 
-  .calculator-grid {
-    grid-template-columns: 1fr;
-  }
-
   .results-column {
     position: static;
     grid-column: 1;
-    grid-row: auto;
+    grid-row: 9;
+    grid-template-columns: 1fr;
   }
 }
 
@@ -1352,18 +1390,6 @@ button.sensitivity-item:hover {
   .scenario-controls,
   .field-grid {
     grid-template-columns: 1fr;
-  }
-
-  .calculator-grid > :first-child {
-    order: 1;
-  }
-
-  .results-column {
-    order: 2;
-  }
-
-  .calculator-grid > .input-card:not(:first-child) {
-    order: 3;
   }
 
   .input-field.full-width {

--- a/crates/tenforty-graph/demo/style.css
+++ b/crates/tenforty-graph/demo/style.css
@@ -12,6 +12,10 @@
   --yellow: #f5d35f;
   --red: #a53d32;
   --red-pale: #fbe8e4;
+  --analysis: #102b27;
+  --analysis-soft: #b9cec5;
+  --analysis-line: rgb(230 247 239 / 15%);
+  --coral: #ff876f;
   --shadow: 0 18px 55px rgb(23 36 31 / 8%);
   font-family:
     Inter,
@@ -147,9 +151,16 @@ main {
 .intro {
   display: grid;
   grid-template-columns: minmax(0, 1.3fr) minmax(18rem, 0.7fr);
+  grid-template-areas:
+    "eyebrow copy"
+    "title copy";
   align-items: end;
   gap: 4rem;
   margin-bottom: 3.6rem;
+}
+
+.intro .eyebrow {
+  grid-area: eyebrow;
 }
 
 .eyebrow,
@@ -163,6 +174,7 @@ main {
 }
 
 .intro h1 {
+  grid-area: title;
   margin: 0;
   font-family: Georgia, "Times New Roman", serif;
   font-size: clamp(3rem, 6.7vw, 6.1rem);
@@ -172,6 +184,7 @@ main {
 }
 
 .intro-copy {
+  grid-area: copy;
   max-width: 34rem;
   margin: 0 0 0.45rem;
   color: var(--ink-soft);
@@ -294,6 +307,355 @@ a:focus-visible {
   color: inherit;
   font-size: 1.4rem;
   line-height: 1;
+}
+
+.analysis-lab {
+  display: grid;
+  grid-template-columns: minmax(18rem, 0.68fr) minmax(26rem, 1.32fr);
+  gap: 0;
+  margin-top: 1.3rem;
+  overflow: hidden;
+  background: var(--analysis);
+  color: white;
+  box-shadow: 0 24px 65px rgb(16 43 39 / 18%);
+}
+
+.analysis-lab[aria-busy="true"] {
+  opacity: 0.78;
+}
+
+.analysis-copy {
+  padding: 2rem;
+  border-right: 1px solid var(--analysis-line);
+}
+
+.analysis-eyebrow {
+  margin: 0 0 0.65rem;
+  color: var(--green-bright);
+  font-size: 0.67rem;
+  font-weight: 820;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.analysis-title-row {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.analysis-title-row h2 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(1.7rem, 2.6vw, 2.35rem);
+  font-weight: 500;
+  letter-spacing: -0.035em;
+  line-height: 1.05;
+}
+
+.analysis-title-row p {
+  margin: 0.35rem 0 0;
+  color: var(--analysis-soft);
+  font-size: 0.8rem;
+}
+
+.curve-control {
+  display: grid;
+  gap: 0.35rem;
+  max-width: 18rem;
+  color: var(--analysis-soft);
+  font-size: 0.66rem;
+  font-weight: 720;
+}
+
+.curve-control select {
+  min-height: 2.55rem;
+  border-color: rgb(255 255 255 / 25%);
+  background: rgb(255 255 255 / 8%);
+  color: white;
+}
+
+.curve-control select option {
+  color: var(--ink);
+}
+
+.next-dollar-readout {
+  margin: 2.1rem 0 1.4rem;
+}
+
+.next-dollar-number {
+  display: flex;
+  align-items: flex-start;
+  color: var(--green-bright);
+  font-family: Georgia, "Times New Roman", serif;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.075em;
+  line-height: 0.8;
+}
+
+.next-dollar-number strong {
+  font-size: clamp(4.6rem, 7vw, 7rem);
+  font-weight: 500;
+}
+
+.next-dollar-number span {
+  margin: 0.3rem 0 0 0.25rem;
+  font-size: 2rem;
+}
+
+.next-dollar-readout p {
+  max-width: 16rem;
+  margin: 0.75rem 0 0;
+  color: var(--analysis-soft);
+  font-size: 0.79rem;
+}
+
+.rate-parts {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.7rem;
+  padding: 1rem 0;
+  border-top: 1px solid var(--analysis-line);
+  border-bottom: 1px solid var(--analysis-line);
+}
+
+.rate-parts div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.rate-parts span {
+  color: var(--analysis-soft);
+  font-size: 0.59rem;
+  line-height: 1.25;
+}
+
+.rate-parts strong {
+  font-size: 0.92rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.derivative-interpretation {
+  margin: 1rem 0 0;
+  color: var(--analysis-soft);
+  font-size: 0.68rem;
+  line-height: 1.55;
+}
+
+.curve-panel {
+  min-width: 0;
+  padding: 1.65rem 1.65rem 1.2rem;
+  background:
+    radial-gradient(
+      circle at 78% 12%,
+      rgb(59 212 154 / 12%),
+      transparent 16rem
+    ),
+    #14342f;
+}
+
+.curve-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.curve-heading > div:first-child {
+  display: grid;
+}
+
+.curve-heading span,
+.curve-caption {
+  color: var(--analysis-soft);
+  font-size: 0.65rem;
+}
+
+.curve-heading strong {
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 1.1rem;
+  font-weight: 500;
+}
+
+.curve-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+}
+
+.curve-legend span::before {
+  display: inline-block;
+  width: 0.85rem;
+  height: 0.15rem;
+  margin-right: 0.35rem;
+  vertical-align: middle;
+  background: currentcolor;
+  content: "";
+}
+
+.legend-total {
+  color: var(--green-bright) !important;
+}
+
+.legend-federal {
+  color: #f8f1d4 !important;
+}
+
+.legend-state {
+  color: var(--coral) !important;
+}
+
+.tax-curve {
+  display: block;
+  width: 100%;
+  height: auto;
+  min-height: 18rem;
+  overflow: visible;
+}
+
+#curve-grid line {
+  stroke: var(--analysis-line);
+  stroke-width: 1;
+}
+
+#curve-labels text {
+  fill: var(--analysis-soft);
+  font-family: inherit;
+  font-size: 10px;
+}
+
+.curve-line {
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.total-line {
+  stroke: var(--green-bright);
+  stroke-width: 3.5;
+}
+
+.federal-line {
+  stroke: #f8f1d4;
+  stroke-width: 1.6;
+  opacity: 0.8;
+}
+
+.state-line {
+  stroke: var(--coral);
+  stroke-width: 1.6;
+  opacity: 0.85;
+}
+
+.curve-guide {
+  stroke: rgb(255 255 255 / 28%);
+  stroke-dasharray: 4 4;
+}
+
+.curve-tangent {
+  stroke: var(--yellow);
+  stroke-linecap: round;
+  stroke-width: 4;
+}
+
+.curve-current {
+  fill: var(--yellow);
+  stroke: var(--analysis);
+  stroke-width: 3;
+}
+
+.curve-caption {
+  max-width: 34rem;
+  margin: -0.15rem 0 0;
+  line-height: 1.5;
+}
+
+.sensitivity-panel {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: minmax(12rem, 0.42fr) minmax(0, 1.58fr);
+  gap: 1.5rem;
+  align-items: center;
+  padding: 1.35rem 1.65rem;
+  border-top: 1px solid var(--analysis-line);
+}
+
+.sensitivity-panel h3 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 1.15rem;
+  font-weight: 500;
+}
+
+.sensitivity-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.55rem;
+}
+
+.sensitivity-item {
+  display: grid;
+  min-width: 0;
+  min-height: 5.6rem;
+  align-content: start;
+  padding: 0.7rem;
+  border: 1px solid var(--analysis-line);
+  background: rgb(255 255 255 / 3%);
+  color: white;
+  text-align: left;
+}
+
+button.sensitivity-item:hover {
+  border-color: var(--green-bright);
+  background: rgb(59 212 154 / 8%);
+}
+
+.sensitivity-item span {
+  min-height: 2.5em;
+  overflow: hidden;
+  color: var(--analysis-soft);
+  font-size: 0.61rem;
+  line-height: 1.25;
+}
+
+.sensitivity-item strong {
+  margin-top: 0.25rem;
+  color: var(--green-bright);
+  font-size: 1rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.sensitivity-item strong.negative {
+  color: var(--coral);
+}
+
+.sensitivity-item small {
+  overflow: hidden;
+  color: rgb(185 206 197 / 70%);
+  font-size: 0.52rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.derivative-note {
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--analysis-line);
+}
+
+.derivative-note summary {
+  padding: 0.85rem 1.65rem;
+  color: var(--analysis-soft);
+  cursor: pointer;
+  font-size: 0.66rem;
+  font-weight: 700;
+}
+
+.derivative-note p {
+  max-width: 58rem;
+  margin: 0;
+  padding: 0 1.65rem 1.2rem;
+  color: var(--analysis-soft);
+  font-size: 0.68rem;
+  line-height: 1.6;
 }
 
 .calculator-grid {
@@ -889,11 +1251,24 @@ a:focus-visible {
 @media (max-width: 980px) {
   .intro {
     grid-template-columns: 1fr;
+    grid-template-areas:
+      "eyebrow"
+      "title"
+      "copy";
     gap: 1.5rem;
   }
 
   .scenario-bar {
     grid-template-columns: 1fr;
+  }
+
+  .analysis-lab {
+    grid-template-columns: 1fr;
+  }
+
+  .analysis-copy {
+    border-right: 0;
+    border-bottom: 1px solid var(--analysis-line);
   }
 
   .calculator-grid {
@@ -937,6 +1312,41 @@ a:focus-visible {
   .results-hero,
   .result-details {
     padding: 1.25rem;
+  }
+
+  .analysis-copy,
+  .curve-panel {
+    padding: 1.25rem;
+  }
+
+  .rate-parts {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .rate-parts div:last-child {
+    grid-column: 1 / -1;
+  }
+
+  .curve-heading,
+  .sensitivity-panel {
+    display: grid;
+  }
+
+  .curve-legend {
+    margin-top: 0.5rem;
+  }
+
+  .tax-curve {
+    min-height: 13rem;
+  }
+
+  .sensitivity-panel {
+    grid-template-columns: 1fr;
+    padding: 1.2rem;
+  }
+
+  .sensitivity-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .scenario-controls,

--- a/crates/tenforty-graph/src/wasm.rs
+++ b/crates/tenforty-graph/src/wasm.rs
@@ -157,6 +157,66 @@ impl Runtime {
         })
     }
 
+    /// Grouped total derivatives of the sum of `outputs`.
+    ///
+    /// `input_nodes` contains every graph node written by the public inputs,
+    /// flattened group by group. `group_lengths` restores those public-input
+    /// groups without requiring nested-array conversion at the WASM boundary.
+    #[wasm_bindgen(js_name = gradientVector)]
+    pub fn gradient_vector(
+        &mut self,
+        outputs: Vec<String>,
+        input_nodes: Vec<String>,
+        group_lengths: Vec<u32>,
+    ) -> Result<Vec<f64>, JsError> {
+        self.inner.with_runtime_mut(|rt| {
+            if outputs.is_empty() {
+                return Err(JsError::new("At least one output node is required"));
+            }
+            let output_ids = outputs
+                .iter()
+                .map(|name| {
+                    rt.graph()
+                        .node_id_by_name(name)
+                        .ok_or_else(|| JsError::new(&format!("Node not found: {}", name)))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            let expected_nodes: usize = group_lengths.iter().map(|length| *length as usize).sum();
+            if expected_nodes != input_nodes.len() {
+                return Err(JsError::new(&format!(
+                    "Input group lengths describe {} nodes, received {}",
+                    expected_nodes,
+                    input_nodes.len()
+                )));
+            }
+
+            let mut offset = 0;
+            let input_ids = group_lengths
+                .iter()
+                .map(|length| {
+                    let end = offset + *length as usize;
+                    let names = &input_nodes[offset..end];
+                    offset = end;
+                    if names.is_empty() {
+                        return Err(JsError::new("Input groups cannot be empty"));
+                    }
+                    names
+                        .iter()
+                        .map(|name| {
+                            rt.graph()
+                                .node_id_by_name(name)
+                                .ok_or_else(|| JsError::new(&format!("Node not found: {}", name)))
+                        })
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            autodiff::gradient_sums_outputs(rt, &output_ids, &input_ids)
+                .map_err(|e| JsError::new(&format!("{}", e)))
+        })
+    }
+
     pub fn solve(
         &mut self,
         output: &str,

--- a/docs/browser-calculator-contract.md
+++ b/docs/browser-calculator-contract.md
@@ -35,7 +35,11 @@ outputs have named formulas:
 A next-dollar rate means the composed right-hand derivative of a public output
 with respect to every graph node written by one public input. That includes
 federal fan-out, state-side nodes, and active derived inputs. A single accidental
-node-to-node partial is not a public marginal rate.
+node-to-node partial is not a public marginal rate. The WASM boundary returns a
+grouped gradient vector: smooth public inputs share one reverse traversal per
+output, while active thresholds retain the graph runtime's right-hand convention.
+The calculator derives combined effects by adding the federal and selected-state
+vectors entry by entry.
 
 ## Failure and accuracy contract
 
@@ -47,10 +51,12 @@ does not define is `null`; a modeled no-income-tax result is numeric zero.
 The executable contract has two halves:
 
 1. Python tests regenerate the manifest and compare its pinned federal and state
-   scenarios with `GraphBackend`.
+   values and gradient regions with `GraphBackend`.
 2. The Pages smoke test loads the same manifest through the public WASM API,
    validates every declared node for both years and every jurisdiction, and runs
-   the same pinned scenarios. A deliberately stale node must raise.
+   the same pinned values and gradient vectors. The gradient pins cover an
+   ordinary bracket, capital-gain stacking, AMT, Additional Medicare Tax and
+   NIIT, and a state-side income node. A deliberately stale node must raise.
 
 This makes the checked-in scenario values a bridge between Python and the browser
 rather than deriving either side's expected result from the other at test time.

--- a/scripts/generate_browser_contract.py
+++ b/scripts/generate_browser_contract.py
@@ -365,6 +365,79 @@ PARITY_CASES = [
     },
 ]
 
+GRADIENT_CASES = [
+    {
+        "id": "ordinary-bracket",
+        "year": 2024,
+        "jurisdiction": "US",
+        "filing_status": "single",
+        "inputs": {"w2_income": 100000},
+        "expected": {"w2_income": {"federal": 0.22, "state": 0.0, "total": 0.22}},
+    },
+    {
+        "id": "capital-gain-stacking",
+        "year": 2024,
+        "jurisdiction": "US",
+        "filing_status": "single",
+        "inputs": {"w2_income": 30000, "long_term_capital_gains": 50000},
+        "expected": {
+            "w2_income": {"federal": 0.27, "state": 0.0, "total": 0.27},
+            "long_term_capital_gains": {
+                "federal": 0.15,
+                "state": 0.0,
+                "total": 0.15,
+            },
+        },
+    },
+    {
+        "id": "alternative-minimum-tax",
+        "year": 2025,
+        "jurisdiction": "US",
+        "filing_status": "single",
+        "inputs": {
+            "w2_income": 200000,
+            "incentive_stock_option_gains": 300000,
+        },
+        "expected": {
+            "w2_income": {"federal": 0.289, "state": 0.0, "total": 0.289},
+            "incentive_stock_option_gains": {
+                "federal": 0.28,
+                "state": 0.0,
+                "total": 0.28,
+            },
+        },
+    },
+    {
+        "id": "medicare-and-niit",
+        "year": 2024,
+        "jurisdiction": "US",
+        "filing_status": "single",
+        "inputs": {"w2_income": 250000, "taxable_interest": 50000},
+        "expected": {
+            "w2_income": {"federal": 0.359, "state": 0.0, "total": 0.359},
+            "taxable_interest": {
+                "federal": 0.388,
+                "state": 0.0,
+                "total": 0.388,
+            },
+        },
+    },
+    {
+        "id": "new-hampshire-interest",
+        "year": 2024,
+        "jurisdiction": "NH",
+        "filing_status": "single",
+        "inputs": {"w2_income": 150000, "taxable_interest": 50000},
+        "expected": {
+            "taxable_interest": {
+                "federal": 0.278,
+                "state": 0.03,
+                "total": 0.308,
+            }
+        },
+    },
+]
+
 
 def _graph_inventory(year: int) -> tuple[set[str], set[str], dict[str, object]]:
     graph_path = ROOT / f"src/tenforty/forms/us_tax_graph_{year}.json"
@@ -581,6 +654,7 @@ def build_contract() -> dict[str, object]:
             },
         ],
         "parity_cases": PARITY_CASES,
+        "gradient_cases": GRADIENT_CASES,
     }
 
 

--- a/scripts/smoke_wasm_demo.mjs
+++ b/scripts/smoke_wasm_demo.mjs
@@ -15,10 +15,13 @@ const { BrowserContractError, validateBrowserContract } =
   await import(pathToFileURL(contractModulePath));
 const {
   INPUT_GROUPS,
+  SENSITIVITY_INPUTS,
+  analyzeScenario,
   calculateScenario,
   parseScenario,
   scenarioFromParityCase,
   serializeScenario,
+  sweepScenario,
 } = await import(pathToFileURL(calculatorModulePath));
 await graphlib.default({ module_or_path: await readFile(wasmPath) });
 const contract = JSON.parse(await readFile(contractPath, "utf8"));
@@ -33,6 +36,16 @@ assert.equal(
   visibleInputs.length,
   new Set(visibleInputs).size,
   "calculator must expose each browser input exactly once",
+);
+assert.equal(
+  SENSITIVITY_INPUTS.qualified_dividends.reclassification,
+  true,
+  "qualified-dividend sensitivity must be labeled as a reclassification",
+);
+assert.match(
+  SENSITIVITY_INPUTS.qualified_dividends.action,
+  /^Reclassify /,
+  "qualified-dividend copy must not describe a new dollar of income",
 );
 
 const graphs = new Map();
@@ -77,6 +90,46 @@ for (const testCase of contract.parity_cases) {
   }
 }
 
+for (const testCase of contract.gradient_cases) {
+  const scenario = scenarioFromParityCase(contract, testCase);
+  const analysis = analyzeScenario(
+    graphlib,
+    graphs.get(testCase.year),
+    contract,
+    scenario,
+  );
+  for (const [inputName, expectedParts] of Object.entries(testCase.expected)) {
+    for (const [part, expected] of Object.entries(expectedParts)) {
+      const actual = analysis.gradients[inputName][part];
+      assert.ok(
+        Math.abs(actual - expected) <= 1e-6,
+        `${testCase.id}/${inputName}/${part}: expected ${expected}, received ${actual}`,
+      );
+    }
+  }
+}
+
+const ordinaryScenario = scenarioFromParityCase(
+  contract,
+  contract.gradient_cases.find(({ id }) => id === "ordinary-bracket"),
+);
+const ordinaryCurve = sweepScenario(
+  graphlib,
+  graphs.get(ordinaryScenario.year),
+  contract,
+  ordinaryScenario,
+  "w2_income",
+);
+assert.equal(ordinaryCurve.length, 57);
+assert.equal(ordinaryCurve[0].input, 0);
+assert.equal(ordinaryCurve.at(-1).input, 200000);
+assert.ok(
+  ordinaryCurve.every(
+    (point, index) => index === 0 || point.total >= ordinaryCurve[index - 1].total,
+  ),
+  "ordinary wage curve must remain monotone",
+);
+
 const staleContract = structuredClone(contract);
 staleContract.inputs.w2_income.federal_nodes = ["us_1040_wages"];
 assert.throws(
@@ -89,5 +142,5 @@ assert.throws(
 );
 
 console.log(
-  `WASM browser contract passed: ${contract.parity_cases.length} parity cases across ${contract.supported_years.length} tax years and ${Object.keys(contract.jurisdictions).length} jurisdictions`,
+  `WASM browser contract passed: ${contract.parity_cases.length} value cases, ${contract.gradient_cases.length} gradient regions, ${contract.supported_years.length} tax years, and ${Object.keys(contract.jurisdictions).length} jurisdictions`,
 );

--- a/tests/browser_contract_test.py
+++ b/tests/browser_contract_test.py
@@ -17,6 +17,7 @@ CONTRACT_PATH = ROOT / "crates/tenforty-graph/demo/browser_contract.json"
 CONTRACT = json.loads(CONTRACT_PATH.read_text())
 APP_PATH = ROOT / "crates/tenforty-graph/demo/app.js"
 CALCULATOR_PATH = ROOT / "crates/tenforty-graph/demo/calculator.js"
+BROWSER_BOUNDARY_PATH = ROOT / "crates/tenforty-graph/demo/browser_contract.js"
 
 FILING_STATUSES = {
     "single": OTSFilingStatus.SINGLE,
@@ -69,10 +70,13 @@ def test_browser_ui_uses_the_public_calculation_boundary():
     """The DOM layer must not regress to form-node bindings or silent zeros."""
     app_source = APP_PATH.read_text()
     calculator_source = CALCULATOR_PATH.read_text()
+    browser_boundary_source = BROWSER_BOUNDARY_PATH.read_text()
 
     assert not re.search(r"\bus_[a-z0-9_]+", app_source)
     assert not re.search(r"\bus_[a-z0-9_]+", calculator_source)
     assert "BrowserTaxRuntime" in calculator_source
+    assert "gradientVector(" in browser_boundary_source
+    assert "Reclassify $1 of ordinary dividends as qualified" in calculator_source
     assert "safeEval" not in app_source
     assert "safeGradient" not in app_source
 
@@ -95,3 +99,35 @@ def test_browser_parity_cases_match_python_graph_backend(case):
 
     for name, expected in case["expected"].items():
         assert getattr(result, name) == pytest.approx(expected, abs=1e-6)
+
+
+@pytest.mark.parametrize(
+    "case", CONTRACT["gradient_cases"], ids=lambda case: case["id"]
+)
+def test_browser_gradient_regions_match_python_graph_backend(case):
+    """Pinned vectors cover the browser's consequential derivative regions."""
+    state = (
+        OTSState.NONE
+        if case["jurisdiction"] == "US"
+        else OTSState(case["jurisdiction"])
+    )
+    tax_input = TaxReturnInput(
+        year=case["year"],
+        state=state,
+        filing_status=FILING_STATUSES[case["filing_status"]],
+        **case["inputs"],
+    )
+    backend = GraphBackend()
+    vectors = {
+        "federal": backend.gradients(tax_input, "federal_total_tax"),
+        "total": backend.gradients(tax_input, "total_tax"),
+    }
+    vectors["state"] = (
+        backend.gradients(tax_input, "state_total_tax")
+        if state != OTSState.NONE
+        else {name: 0.0 for name in vectors["federal"]}
+    )
+
+    for input_name, expected_parts in case["expected"].items():
+        for part, expected in expected_parts.items():
+            assert vectors[part][input_name] == pytest.approx(expected, abs=1e-6)


### PR DESCRIPTION
## Summary

- arrange the app as a causal workbench: return inputs beside the sticky analysis on desktop and before it on mobile, with the conventional breakdown after both
- make the analytical view—not the filing result—the browser app's visual center
- expose grouped public-input gradient vectors through WASM, preserving federal/state fan-out and active derived inputs
- show the current return on a live federal/state/combined tax curve with its exact local tangent
- decompose next-dollar effects and selected sensitivities without conflating them with effective rates
- label qualified-dividend effects as reclassification and explain the right-hand convention at thresholds
- pin ordinary brackets, capital-gain stacking, AMT/ISO, Medicare/NIIT, and a state-side gradient region in both Python and the staged browser artifact

## Stacking

This is intentionally a second take stacked on #348. That PR supplies the dependable all-state calculator, public browser contract, share URLs, and honest failure behavior. This PR keeps that substrate and changes the product's identity. It should be retargeted to `main` after #348 lands.

Tracks `tenforty-ox4.4.4`.

## Validation

- `cargo test --manifest-path crates/tenforty-graph/Cargo.toml --lib` — 35 passed
- `make wasm`
- `node scripts/smoke_wasm_demo.mjs target/pages-dev` — 7 value cases, 5 gradient regions, 2 years, 52 jurisdictions
- `uv run pytest tests/browser_contract_test.py tests/gradient_vector_test.py -q` — 26 passed
- `uv run pytest tests/ -q --tb=line` — 1,138 passed, 13 skipped, 26 xfailed
- pre-commit hooks — passed
- inspected at 1440px and 390px; local preview remains available through `make wasm-serve`
